### PR TITLE
chore: sync SDLC templates sdlc-v1.22.0 from DevAudit

### DIFF
--- a/scripts/upload-evidence.sh
+++ b/scripts/upload-evidence.sh
@@ -126,18 +126,28 @@ if [ ${#FILES[@]} -eq 0 ]; then
 fi
 
 # --- Upload each file via /api/evidence/upload ---
+#
+# Retry-on-429 / 5xx: consumer CI workflows fire 8-12 sequential uploads per
+# requirement (test-scope, test-plan, implementation-plan, security-summary,
+# test-execution-summary, ai-prompts, ai-use-note, uat-checklist, gates/*.json).
+# That cadence trips DevAudit's per-IP rate limiter, marking otherwise-green
+# CI runs as failed. Retry transiently with exponential backoff (1s → 16s),
+# honouring Retry-After if the portal supplies it. Auth/validation errors
+# (4xx other than 429) still fail fast — they won't fix themselves.
+#
+# Issue: devaudit#263.
 SUCCEEDED=0
 FAILED=0
 TOTAL_SIZE=0
 UPLOAD_URL="${META_COMPLY_BASE_URL}/api/evidence/upload"
+MAX_ATTEMPTS=${UPLOAD_MAX_ATTEMPTS:-5}
+INITIAL_BACKOFF_SECONDS=${UPLOAD_INITIAL_BACKOFF_SECONDS:-1}
 
 for FILE in "${FILES[@]}"; do
   FILENAME=$(basename "$FILE")
   FILE_SIZE=$(stat -c%s "$FILE" 2>/dev/null || stat -f%z "$FILE")
   echo -n "Uploading ${FILENAME}... "
-  RESP_BODY_FILE=$(mktemp)
   CURL_ARGS=(
-    -s -o "$RESP_BODY_FILE" -w "%{http_code}"
     -X POST "$UPLOAD_URL"
     -H "Authorization: Bearer ${META_COMPLY_API_KEY}"
     -F "file=@${FILE}"
@@ -153,14 +163,52 @@ for FILE in "${FILES[@]}"; do
   [ -n "$BRANCH" ] && CURL_ARGS+=(-F "releaseBranch=${BRANCH}")
   [ -n "$ENVIRONMENT" ] && CURL_ARGS+=(-F "environment=${ENVIRONMENT}")
   [ -n "$EVIDENCE_CATEGORY" ] && CURL_ARGS+=(-F "evidenceCategory=${EVIDENCE_CATEGORY}")
-  HTTP_CODE=$(curl "${CURL_ARGS[@]}")
+
+  ATTEMPT=1
+  BACKOFF=$INITIAL_BACKOFF_SECONDS
+  HTTP_CODE=0
+  RESP_BODY_FILE=""
+  while [ "$ATTEMPT" -le "$MAX_ATTEMPTS" ]; do
+    [ -n "$RESP_BODY_FILE" ] && rm -f "$RESP_BODY_FILE"
+    RESP_BODY_FILE=$(mktemp)
+    RESP_HEADERS_FILE=$(mktemp)
+    HTTP_CODE=$(curl -s -o "$RESP_BODY_FILE" -D "$RESP_HEADERS_FILE" -w "%{http_code}" "${CURL_ARGS[@]}")
+    if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
+      rm -f "$RESP_HEADERS_FILE"
+      break
+    fi
+    # Decide whether the failure is retriable (429 or 5xx).
+    if [ "$HTTP_CODE" = "429" ] || { [ "$HTTP_CODE" -ge 500 ] && [ "$HTTP_CODE" -lt 600 ]; }; then
+      if [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]; then
+        # Honour Retry-After (seconds) if the portal supplied it; otherwise back off.
+        WAIT_SECONDS=$BACKOFF
+        RETRY_AFTER=$(grep -i '^retry-after:' "$RESP_HEADERS_FILE" 2>/dev/null | head -1 | sed 's/^[Rr]etry-[Aa]fter:[[:space:]]*//' | tr -d '\r')
+        if [[ "$RETRY_AFTER" =~ ^[0-9]+$ ]] && [ "$RETRY_AFTER" -gt 0 ]; then
+          WAIT_SECONDS=$RETRY_AFTER
+        fi
+        echo -n "(HTTP ${HTTP_CODE}, retry in ${WAIT_SECONDS}s) "
+        rm -f "$RESP_HEADERS_FILE"
+        sleep "$WAIT_SECONDS"
+        ATTEMPT=$((ATTEMPT + 1))
+        BACKOFF=$((BACKOFF * 2))
+        continue
+      fi
+    fi
+    rm -f "$RESP_HEADERS_FILE"
+    break
+  done
+
   if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
     rm -f "$RESP_BODY_FILE"
-    echo "OK (${FILE_SIZE} bytes)"
+    if [ "$ATTEMPT" -gt 1 ]; then
+      echo "OK (${FILE_SIZE} bytes, attempt ${ATTEMPT}/${MAX_ATTEMPTS})"
+    else
+      echo "OK (${FILE_SIZE} bytes)"
+    fi
     SUCCEEDED=$((SUCCEEDED + 1))
     TOTAL_SIZE=$((TOTAL_SIZE + FILE_SIZE))
   else
-    echo "FAILED (HTTP ${HTTP_CODE})"
+    echo "FAILED (HTTP ${HTTP_CODE} after ${ATTEMPT} attempt(s))"
     echo "  Response: $(head -c 500 "$RESP_BODY_FILE")"
     rm -f "$RESP_BODY_FILE"
     FAILED=$((FAILED + 1))


### PR DESCRIPTION
## Summary

Sync from upstream **DevAudit** at tag `sdlc-v1.22.0`.

Two changes since v1.21.0:

| Change | Where | Why |
| --- | --- | --- |
| **Upload retry-with-backoff** | `scripts/upload-evidence.sh` | Closes devaudit#263. Retry on HTTP 429 / 5xx with exponential backoff (1s → 16s, max 5 attempts). Honours `Retry-After` if portal sends it. Fail fast on other 4xx. **This is the fix for the sustained 429 failures on REQ-035 / REQ-036 evidence uploads.** |
| Documentation refresh | `SDLC/*.md`, `INSTRUCTIONS.md` | Doc rebrand sweep + META-ATS pause copy carried forward. |

14 files changed, +477/-520.

## What this PR fixes

The CI Upload-Evidence step has been failing on every push to develop since REQ-035 — D1 in `compliance/evidence/REQ-036/test-execution-summary.md` documents three concrete runs that hit sustained HTTP 429s. With this sync, the next push should:

- Retry transparently on 429 (you'll see `(HTTP 429, retry in Ns)` mid-line in the log).
- Honour the portal's `Retry-After` header when present.
- Fail only if 5 attempts with 31s of cumulative backoff aren't enough (which would indicate a real outage, not throttling).

Tunable via env vars `UPLOAD_MAX_ATTEMPTS` (default 5) and `UPLOAD_INITIAL_BACKOFF_SECONDS` (default 1) if you want to dial it differently per workflow.

## Test plan

- [ ] CI green on this PR
- [ ] Push a small change to `develop` post-merge — Upload Evidence should land cleanly without manual `gh run rerun` intervention
- [ ] If a 429 does occur, the log line shows `(HTTP 429, retry in Xs)` and the upload eventually succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)