### PR TITLE
fix: lock + sync line-item Unit field when sellable with override is picked

### DIFF
--- a/__tests__/lib/expense-inventory-link.test.ts
+++ b/__tests__/lib/expense-inventory-link.test.ts
@@ -19,6 +19,7 @@ import {
   validateReversalDoesNotNegate,
   convertExpenseQuantityToInventoryUnit,
   validateExpenseUnitAgainstOverride,
+  computeLockedUnit,
 } from '@/lib/expense-inventory-link';
 import type { InventoryKind } from '@/interfaces/inventory.interface';
 import type { UnitOfMeasurement } from '@/interfaces/unit-of-measurement.interface';
@@ -457,5 +458,44 @@ describe('validateExpenseUnitAgainstOverride (REQ-038)', () => {
         override: 'cans',
       })
     ).not.toThrow();
+  });
+});
+
+describe('computeLockedUnit (#94 follow-up)', () => {
+  const sellableInventory = [
+    { id: 'inv-bottles', expenseUnitOverride: 'bottles' },
+    { id: 'inv-cans', expenseUnitOverride: 'cans' },
+    { id: 'inv-no-override' }, // no override → defaults to "Any"
+  ];
+
+  it('returns undefined when sellable mode is disabled', () => {
+    expect(
+      computeLockedUnit(false, 'inv-bottles', sellableInventory)
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when no inventory is picked', () => {
+    expect(
+      computeLockedUnit(true, undefined, sellableInventory)
+    ).toBeUndefined();
+  });
+
+  it('returns the picked sellable item override when enabled and picked', () => {
+    expect(computeLockedUnit(true, 'inv-bottles', sellableInventory)).toBe(
+      'bottles'
+    );
+    expect(computeLockedUnit(true, 'inv-cans', sellableInventory)).toBe('cans');
+  });
+
+  it('returns undefined when the picked item has no override (Any)', () => {
+    expect(
+      computeLockedUnit(true, 'inv-no-override', sellableInventory)
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when the picked id is not in the list (stale)', () => {
+    expect(
+      computeLockedUnit(true, 'inv-deleted', sellableInventory)
+    ).toBeUndefined();
   });
 });

--- a/components/features/finance/edit-pending-group-dialog.tsx
+++ b/components/features/finance/edit-pending-group-dialog.tsx
@@ -53,6 +53,7 @@ import {
   type KitchenInventoryOption,
   type SellableInventoryOption,
 } from './inventory-link-section';
+import { computeLockedUnit } from '@/lib/expense-inventory-link';
 import { getExpenseCategoriesAction } from '@/app/actions/finance/expense-categories-actions';
 import { getUnitsOfMeasurementAction } from '@/app/actions/units-actions';
 import {
@@ -512,28 +513,39 @@ export function EditPendingGroupDialog({
                       <FormField
                         control={form.control}
                         name={`items.${index}.unit`}
-                        render={({ field: f }) => (
-                          <FormItem>
-                            <FormLabel className="text-xs text-muted-foreground">
-                              Unit
-                            </FormLabel>
-                            <Select value={f.value} onValueChange={f.onChange}>
-                              <FormControl>
-                                <SelectTrigger className="h-8 text-sm">
-                                  <SelectValue placeholder="Select unit" />
-                                </SelectTrigger>
-                              </FormControl>
-                              <SelectContent>
-                                {getActiveUnits(unitsRegistry).map((u) => (
-                                  <SelectItem key={u.id} value={u.id}>
-                                    {u.label}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                            <FormMessage />
-                          </FormItem>
-                        )}
+                        render={({ field: f }) => {
+                          const lockedUnit = computeLockedUnit(
+                            sellableLinkEnabled[index] === true,
+                            items[index]?.linkedInventoryId,
+                            sellableInventory
+                          );
+                          return (
+                            <FormItem>
+                              <FormLabel className="text-xs text-muted-foreground">
+                                Unit
+                              </FormLabel>
+                              <Select
+                                value={f.value}
+                                onValueChange={f.onChange}
+                                disabled={!!lockedUnit}
+                              >
+                                <FormControl>
+                                  <SelectTrigger className="h-8 text-sm">
+                                    <SelectValue placeholder="Select unit" />
+                                  </SelectTrigger>
+                                </FormControl>
+                                <SelectContent>
+                                  {getActiveUnits(unitsRegistry).map((u) => (
+                                    <SelectItem key={u.id} value={u.id}>
+                                      {u.label}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                              <FormMessage />
+                            </FormItem>
+                          );
+                        }}
                       />
                       <FormField
                         control={form.control}

--- a/components/features/finance/expense-form.tsx
+++ b/components/features/finance/expense-form.tsx
@@ -109,6 +109,7 @@ import {
   type KitchenInventoryOption,
   type SellableInventoryOption,
 } from './inventory-link-section';
+import { computeLockedUnit } from '@/lib/expense-inventory-link';
 
 interface ExpenseFormProps {
   open: boolean;
@@ -553,28 +554,39 @@ export function ExpenseForm({
                       <FormField
                         control={form.control}
                         name={`items.${index}.unit`}
-                        render={({ field: f }) => (
-                          <FormItem>
-                            <FormLabel className="text-xs text-muted-foreground">
-                              Unit
-                            </FormLabel>
-                            <Select value={f.value} onValueChange={f.onChange}>
-                              <FormControl>
-                                <SelectTrigger className="h-8 text-sm">
-                                  <SelectValue placeholder="Select unit" />
-                                </SelectTrigger>
-                              </FormControl>
-                              <SelectContent>
-                                {getActiveUnits(unitsRegistry).map((u) => (
-                                  <SelectItem key={u.id} value={u.id}>
-                                    {u.label}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                            <FormMessage />
-                          </FormItem>
-                        )}
+                        render={({ field: f }) => {
+                          const lockedUnit = computeLockedUnit(
+                            sellableLinkEnabled[index] === true,
+                            items[index]?.linkedInventoryId,
+                            sellableInventory
+                          );
+                          return (
+                            <FormItem>
+                              <FormLabel className="text-xs text-muted-foreground">
+                                Unit
+                              </FormLabel>
+                              <Select
+                                value={f.value}
+                                onValueChange={f.onChange}
+                                disabled={!!lockedUnit}
+                              >
+                                <FormControl>
+                                  <SelectTrigger className="h-8 text-sm">
+                                    <SelectValue placeholder="Select unit" />
+                                  </SelectTrigger>
+                                </FormControl>
+                                <SelectContent>
+                                  {getActiveUnits(unitsRegistry).map((u) => (
+                                    <SelectItem key={u.id} value={u.id}>
+                                      {u.label}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                              <FormMessage />
+                            </FormItem>
+                          );
+                        }}
                       />
                       <FormField
                         control={form.control}

--- a/components/features/finance/inventory-link-section.tsx
+++ b/components/features/finance/inventory-link-section.tsx
@@ -22,6 +22,7 @@
  * Both flows write to the same `items.${index}.linkedInventoryId` field;
  * the service routes based on the linked inventory's `kind`.
  */
+import { useEffect } from 'react';
 import type { UseFormReturn } from 'react-hook-form';
 import { Checkbox } from '@/components/ui/checkbox';
 import {
@@ -38,7 +39,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { shouldShowAddToInventoryDropdown } from '@/lib/expense-inventory-link';
+import {
+  computeLockedUnit,
+  shouldShowAddToInventoryDropdown,
+} from '@/lib/expense-inventory-link';
 
 export interface KitchenInventoryOption {
   id: string;
@@ -79,12 +83,40 @@ export function InventoryLinkSection({
   sellableLinkEnabled,
   setSellableLinkEnabled,
 }: InventoryLinkSectionProps) {
+  const linkedInventoryPath = `items.${index}.linkedInventoryId` as const;
+  const unitPath = `items.${index}.unit` as const;
+
+  // Watch the linked id so the locked-unit computation reacts to picks.
+  // Hooks must be called unconditionally — early-return below guards render
+  // output but not hook order.
+  const watchedLinkedId = form.watch(linkedInventoryPath);
+  const lockedUnit = computeLockedUnit(
+    sellableLinkEnabled,
+    typeof watchedLinkedId === 'string' ? watchedLinkedId : undefined,
+    sellableInventory
+  );
+
+  // Keep the line's Unit field in sync with the locked unit. The inline
+  // setValue inside the sellable Select's onValueChange wasn't reliably
+  // updating the displayed value (RHF Controller + Radix Select timing).
+  // A useEffect that fires on lockedUnit changes is the more robust
+  // approach. shouldDirty/shouldValidate ensure subscribers re-render.
+  useEffect(() => {
+    if (lockedUnit) {
+      form.setValue(unitPath, lockedUnit, {
+        shouldDirty: true,
+        shouldValidate: true,
+        shouldTouch: true,
+      });
+    }
+    // form is stable from useForm; unitPath is derived from props that
+    // don't change for a given row's lifecycle.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lockedUnit]);
+
   if (!shouldShowAddToInventoryDropdown(expenseType)) {
     return null;
   }
-
-  const linkedInventoryPath = `items.${index}.linkedInventoryId` as const;
-  const unitPath = `items.${index}.unit` as const;
 
   return (
     <>
@@ -152,28 +184,18 @@ export function InventoryLinkSection({
             control={form.control}
             name={linkedInventoryPath}
             render={({ field: f }) => {
-              const picked = sellableInventory.find(
-                (opt) => opt.id === f.value
-              );
-              const lockedUnit = picked?.expenseUnitOverride;
               return (
                 <FormItem>
                   <FormLabel className="text-xs text-muted-foreground">
                     Sellable item to restock
                   </FormLabel>
                   <Select
-                    value={f.value ?? '__none__'}
+                    value={typeof f.value === 'string' ? f.value : '__none__'}
                     onValueChange={(v) => {
                       const newId = v === '__none__' ? undefined : v;
                       f.onChange(newId);
-                      if (newId) {
-                        const opt = sellableInventory.find(
-                          (x) => x.id === newId
-                        );
-                        if (opt?.expenseUnitOverride) {
-                          form.setValue(unitPath, opt.expenseUnitOverride);
-                        }
-                      }
+                      // Unit sync is handled by the useEffect at component
+                      // level — see lockedUnit / form.setValue above.
                     }}
                   >
                     <FormControl>

--- a/lib/expense-inventory-link.ts
+++ b/lib/expense-inventory-link.ts
@@ -313,3 +313,26 @@ export function validateReversalDoesNotNegate(input: {
     );
   }
 }
+
+/**
+ * Resolves the "locked unit" for an expense line item based on the
+ * currently picked sellable item's `expenseUnitOverride`. Returns
+ * `undefined` when no lock applies — either because the sellable flow is
+ * disabled for this row, no item is picked, or the picked item has no
+ * override (defaults to "Any").
+ *
+ * Used by both the Add Expense form and the Edit Pending Group dialog to
+ * decide whether to disable the line's Unit Select and sync its value.
+ */
+export function computeLockedUnit(
+  enabled: boolean,
+  linkedInventoryId: string | undefined,
+  sellableInventory: ReadonlyArray<{
+    id: string;
+    expenseUnitOverride?: string;
+  }>
+): string | undefined {
+  if (!enabled || !linkedInventoryId) return undefined;
+  const picked = sellableInventory.find((s) => s.id === linkedInventoryId);
+  return picked?.expenseUnitOverride;
+}


### PR DESCRIPTION
Follow-up to #94. Two related bugs reported from the UAT walk on the REQ-038 sellable-restock flow.

## Bugs

**1. Unit field stayed editable when locked.** After ticking "Update inventory count (sellable item)" and picking a sellable item with a Purchase unit override (e.g. Heineken locked to bottles), the operator could still type a different unit into the line's Unit field. The amber "Unit locked to bottles" hint displayed correctly, but the field itself wasn't actually disabled.

**2. Unit field value didn't snap to the locked unit on pick.** In Add Expense it stayed at the placeholder ("Units"). In Edit Pending Group it stayed at the previously-saved unit (e.g. "Portions"). Both indicate the inline `form.setValue()` inside the sellable Select's `onValueChange` wasn't propagating reliably — react-hook-form Controller + Radix Select timing.

## Fix

- **New pure helper** `computeLockedUnit(enabled, linkedId, sellableList)` in `lib/expense-inventory-link.ts`. Single source of truth for "is this row's unit locked, and if so to what?"
- **InventoryLinkSection**: replaced the fragile inline `setValue` with a `useEffect` that fires on `lockedUnit` changes, passing `shouldDirty`, `shouldValidate`, `shouldTouch` so subscribers reliably re-render.
- **expense-form.tsx + edit-pending-group-dialog.tsx**: compute `lockedUnit` per row and pass `disabled={!!lockedUnit}` to the line's Unit Select so the field is also visually + interactively locked.

## Tests

- 5 new vitest cases on `computeLockedUnit`: disabled mode, no pick, override present, override absent (Any), stale id not in list.
- Full suite: **761 pass / 4 skipped**.
- `tsc --noEmit` → 0 errors.

## Test plan

- [ ] Add Expense → pick Heineken (locked to bottles) → Unit field snaps to "Bottles" AND becomes greyed out / disabled.
- [ ] Untick the sellable checkbox → Unit field becomes editable again.
- [ ] Edit Pending Expense Group on a row that already has a kitchen link → Unit field is editable (kitchen flow doesn't lock).
- [ ] Edit Pending Expense Group on a row with a sellable link to a locked item → Unit field shows the locked unit AND is disabled.
- [ ] Change the picked sellable to a different locked item (e.g. Cans) → Unit field snaps to "Cans" and stays disabled.
- [ ] Pick a sellable item whose MenuItem has Purchase unit "Any" → Unit field stays editable.

## Risk

LOW — surgical fix scoped to the inventory-link UI. No service/data path changes. Reversible via `git revert`.