### PR TITLE
fix: recompute Inventory.status after expense-link $inc (#98)

### DIFF
--- a/__tests__/lib/expense-inventory-link.test.ts
+++ b/__tests__/lib/expense-inventory-link.test.ts
@@ -20,6 +20,7 @@ import {
   convertExpenseQuantityToInventoryUnit,
   validateExpenseUnitAgainstOverride,
   computeLockedUnit,
+  computeInventoryStatus,
 } from '@/lib/expense-inventory-link';
 import type { InventoryKind } from '@/interfaces/inventory.interface';
 import type { UnitOfMeasurement } from '@/interfaces/unit-of-measurement.interface';
@@ -497,5 +498,38 @@ describe('computeLockedUnit (#94 follow-up)', () => {
     expect(
       computeLockedUnit(true, 'inv-deleted', sellableInventory)
     ).toBeUndefined();
+  });
+});
+
+describe('computeInventoryStatus (#98)', () => {
+  it('returns "out-of-stock" when stock is zero', () => {
+    expect(computeInventoryStatus(0, 15)).toBe('out-of-stock');
+  });
+
+  it('returns "out-of-stock" when stock is negative (defensive)', () => {
+    expect(computeInventoryStatus(-3, 15)).toBe('out-of-stock');
+  });
+
+  it('returns "low-stock" when stock equals the minimum', () => {
+    expect(computeInventoryStatus(15, 15)).toBe('low-stock');
+  });
+
+  it('returns "low-stock" when stock is below the minimum but positive', () => {
+    expect(computeInventoryStatus(5, 15)).toBe('low-stock');
+  });
+
+  it('returns "in-stock" when stock is above the minimum', () => {
+    expect(computeInventoryStatus(50, 15)).toBe('in-stock');
+  });
+
+  it('returns "in-stock" when minimum is zero and stock is positive', () => {
+    expect(computeInventoryStatus(1, 0)).toBe('in-stock');
+  });
+
+  it('matches the user-reported case: 1 bottle, min 15 → low-stock (not out-of-stock)', () => {
+    // Per #98: restocking Tiger from 0 to 1 bottle (min 15) should flip
+    // status from out-of-stock → low-stock so the customer menu picks
+    // up the restock.
+    expect(computeInventoryStatus(1, 15)).toBe('low-stock');
   });
 });

--- a/__tests__/services/expense-inventory-link.reversal.test.ts
+++ b/__tests__/services/expense-inventory-link.reversal.test.ts
@@ -148,7 +148,9 @@ describe('REQ-034 AC7 — Expense → Inventory reversal: edit / delete flow', (
         _id: linkedInventoryId,
         currentStock: { $gte: 5 },
       },
-      { $inc: { currentStock: -5, totalRestocked: -5 } }
+      expect.objectContaining({
+        $inc: { currentStock: -5, totalRestocked: -5 },
+      })
     );
   });
 
@@ -228,6 +230,61 @@ describe('REQ-034 AC7 — Expense → Inventory reversal: edit / delete flow', (
     });
 
     expect(ExpenseModel.updateOne).not.toHaveBeenCalled();
+  });
+
+  it('#98: recomputes Inventory.status from the new currentStock + minimumStock', async () => {
+    // Reversal of a restock that put stock above min: removing the
+    // restocked quantity should drop the status back to low-stock or
+    // out-of-stock depending on the remaining level.
+    const linkedInventoryId = new Types.ObjectId();
+    (InventoryModel.findById as ReturnType<typeof vi.fn>).mockResolvedValue({
+      _id: linkedInventoryId,
+      kind: 'menu-item',
+      currentStock: 16, // post-restock level
+      minimumStock: 15,
+      unit: 'bottles',
+    });
+
+    await reverseExpenseInventoryLink({
+      expenseId: new Types.ObjectId(),
+      linkedInventoryId,
+      quantity: 12, // reversing 12 leaves 4 (below min)
+      performedBy,
+      reason: 'edit',
+    });
+
+    expect(InventoryModel.updateOne).toHaveBeenCalledWith(
+      expect.objectContaining({ _id: linkedInventoryId }),
+      expect.objectContaining({
+        $set: expect.objectContaining({ status: 'low-stock' }),
+      })
+    );
+  });
+
+  it('#98: full reversal back to zero flips status to out-of-stock', async () => {
+    const linkedInventoryId = new Types.ObjectId();
+    (InventoryModel.findById as ReturnType<typeof vi.fn>).mockResolvedValue({
+      _id: linkedInventoryId,
+      kind: 'menu-item',
+      currentStock: 5,
+      minimumStock: 15,
+      unit: 'bottles',
+    });
+
+    await reverseExpenseInventoryLink({
+      expenseId: new Types.ObjectId(),
+      linkedInventoryId,
+      quantity: 5,
+      performedBy,
+      reason: 'delete',
+    });
+
+    expect(InventoryModel.updateOne).toHaveBeenCalledWith(
+      expect.objectContaining({ _id: linkedInventoryId }),
+      expect.objectContaining({
+        $set: expect.objectContaining({ status: 'out-of-stock' }),
+      })
+    );
   });
 });
 
@@ -312,7 +369,9 @@ describe('REQ-034 AC7 — block-on-negative', () => {
 
     expect(InventoryModel.updateOne).toHaveBeenCalledWith(
       { _id: linkedInventoryId, currentStock: { $gte: 1 } },
-      { $inc: { currentStock: -1, totalRestocked: -1 } }
+      expect.objectContaining({
+        $inc: { currentStock: -1, totalRestocked: -1 },
+      })
     );
   });
 });
@@ -341,7 +400,9 @@ describe('REQ-034 D10 — unit conversion on reversal path', () => {
 
     expect(InventoryModel.updateOne).toHaveBeenCalledWith(
       { _id: linkedInventoryId, currentStock: { $gte: 5000 } },
-      { $inc: { currentStock: -5000, totalRestocked: -5000 } }
+      expect.objectContaining({
+        $inc: { currentStock: -5000, totalRestocked: -5000 },
+      })
     );
     const movement = (StockMovementModel.create as ReturnType<typeof vi.fn>)
       .mock.calls[0][0];
@@ -394,7 +455,9 @@ describe('REQ-034 D10 — unit conversion on reversal path', () => {
 
     expect(InventoryModel.updateOne).toHaveBeenCalledWith(
       { _id: linkedInventoryId, currentStock: { $gte: 5 } },
-      { $inc: { currentStock: -5, totalRestocked: -5 } }
+      expect.objectContaining({
+        $inc: { currentStock: -5, totalRestocked: -5 },
+      })
     );
   });
 });

--- a/__tests__/services/expense-inventory-link.test.ts
+++ b/__tests__/services/expense-inventory-link.test.ts
@@ -401,6 +401,63 @@ describe('REQ-034 AC6 — applyExpenseInventoryLink save path', () => {
       })
     ).rejects.toThrow(/not found/);
   });
+
+  it('#98: recomputes Inventory.status from the new currentStock + minimumStock', async () => {
+    // User scenario from #98: Tiger inventory at 0/15 (out-of-stock).
+    // Restocking 1 bottle should flip status to low-stock (NOT
+    // in-stock — still below min — and NOT stuck on out-of-stock).
+    const linkedInventoryId = new Types.ObjectId();
+    (InventoryModel.findById as ReturnType<typeof vi.fn>).mockResolvedValue({
+      _id: linkedInventoryId,
+      kind: 'menu-item',
+      currentStock: 0,
+      minimumStock: 15,
+      unit: 'bottles',
+    });
+
+    await applyExpenseInventoryLink({
+      expenseId: new Types.ObjectId(),
+      linkedInventoryId,
+      quantity: 1,
+      amount: 725,
+      date: new Date(),
+      performedBy,
+    });
+
+    expect(InventoryModel.updateOne).toHaveBeenCalledWith(
+      { _id: linkedInventoryId },
+      expect.objectContaining({
+        $set: expect.objectContaining({ status: 'low-stock' }),
+      })
+    );
+  });
+
+  it('#98: restock past minimum flips status to in-stock', async () => {
+    const linkedInventoryId = new Types.ObjectId();
+    (InventoryModel.findById as ReturnType<typeof vi.fn>).mockResolvedValue({
+      _id: linkedInventoryId,
+      kind: 'menu-item',
+      currentStock: 5,
+      minimumStock: 15,
+      unit: 'bottles',
+    });
+
+    await applyExpenseInventoryLink({
+      expenseId: new Types.ObjectId(),
+      linkedInventoryId,
+      quantity: 50,
+      amount: 5000,
+      date: new Date(),
+      performedBy,
+    });
+
+    expect(InventoryModel.updateOne).toHaveBeenCalledWith(
+      { _id: linkedInventoryId },
+      expect.objectContaining({
+        $set: expect.objectContaining({ status: 'in-stock' }),
+      })
+    );
+  });
 });
 
 describe('REQ-034 D10 — unit conversion on expense → inventory link', () => {

--- a/lib/expense-inventory-link.ts
+++ b/lib/expense-inventory-link.ts
@@ -336,3 +336,27 @@ export function computeLockedUnit(
   const picked = sellableInventory.find((s) => s.id === linkedInventoryId);
   return picked?.expenseUnitOverride;
 }
+
+/**
+ * Mirrors the Inventory schema's pre('save') hook
+ * (`models/inventory-model.ts`) so the status field stays consistent
+ * regardless of which write path updates currentStock.
+ *
+ * Why this lives here: the expense-link service writes via
+ * `updateOne({ $inc })`, which bypasses Mongoose's save middleware. Both
+ * apply and reversal paths must therefore recompute status manually.
+ * Keeping the rule in one place (here, plus the schema hook) prevents
+ * drift.
+ *
+ * Ref: #98
+ */
+export type StockStatus = 'in-stock' | 'low-stock' | 'out-of-stock';
+
+export function computeInventoryStatus(
+  currentStock: number,
+  minimumStock: number
+): StockStatus {
+  if (currentStock <= 0) return 'out-of-stock';
+  if (currentStock <= minimumStock) return 'low-stock';
+  return 'in-stock';
+}

--- a/services/expense-inventory-link-service.ts
+++ b/services/expense-inventory-link-service.ts
@@ -21,6 +21,7 @@ import { ExpenseModel } from '@/models';
 import {
   buildStockMovementFromExpense,
   buildCostHistoryRowFromExpense,
+  computeInventoryStatus,
   resolveExpenseQuantity,
   validateReversalDoesNotNegate,
   convertExpenseQuantityToInventoryUnit,
@@ -144,6 +145,13 @@ export async function applyExpenseInventoryLink(
     const movement = await StockMovementModel.create(movementPayload);
     stockMovementId = movement._id;
 
+    // #98 — Mongoose pre('save') hook is bypassed by updateOne/$inc, so
+    // recompute status manually from the known pre-write currentStock +
+    // quantity vs minimumStock. Single atomic write; no extra read.
+    const newStatus = computeInventoryStatus(
+      inventory.currentStock + quantity,
+      inventory.minimumStock
+    );
     const incResult = await InventoryModel.updateOne(
       { _id: input.linkedInventoryId },
       {
@@ -151,7 +159,7 @@ export async function applyExpenseInventoryLink(
           currentStock: quantity,
           totalRestocked: quantity,
         },
-        $set: { lastRestocked: input.date },
+        $set: { lastRestocked: input.date, status: newStatus },
       }
     );
     if (incResult.modifiedCount !== 1) {
@@ -291,12 +299,21 @@ export async function reverseExpenseInventoryLink(
     notes: `Expense link reversal (${input.expenseId.toString()})`,
   });
 
+  // #98 — same status-recompute requirement as the apply path. Reversal
+  // can leave stock below min or at 0; status must reflect the new level.
+  const reversedStatus = computeInventoryStatus(
+    inventory.currentStock - quantity,
+    inventory.minimumStock
+  );
   const incResult = await InventoryModel.updateOne(
     {
       _id: input.linkedInventoryId,
       currentStock: { $gte: quantity },
     },
-    { $inc: { currentStock: -quantity, totalRestocked: -quantity } }
+    {
+      $inc: { currentStock: -quantity, totalRestocked: -quantity },
+      $set: { status: reversedStatus },
+    }
   );
   if (incResult.modifiedCount !== 1) {
     // Race — inventory dropped below required threshold between the


### PR DESCRIPTION
Closes #98.

## Bug

UAT walk 2026-05-22: operator restocked a drink via the expense → inventory link flow. Inventory dashboard showed `currentStock: 1` for Tiger (correct), but the customer menu kept showing **Out of Stock** for the item. They couldn't add it to an order.

## Root cause

`InventoryModel.updateOne({...}, { $inc: { currentStock: q } })` in `services/expense-inventory-link-service.ts` bypasses Mongoose's `pre('save')` middleware (a known Mongoose gotcha). The save hook in `models/inventory-model.ts:86` is the only place that recomputes `Inventory.status` based on `currentStock` vs `minimumStock`. So:

| | currentStock | status |
|---|---|---|
| Pre-restock (after deduction) | 0 | `'out-of-stock'` |
| Post-`$inc` | 1 | `'out-of-stock'` ← stuck |

`services/category-service.ts:45` (and its siblings) feeds the customer menu directly from `inventory.status` (not from `currentStock`), so the menu kept rendering Out of Stock.

## Fix

- **New pure helper** `computeInventoryStatus(currentStock, minimumStock)` in `lib/expense-inventory-link.ts`. Mirrors the schema hook so the rule has one source of truth in code.
- **Apply path** (`applyExpenseInventoryLink`): compute new status from `inventory.currentStock + quantity` and include it in the same `updateOne`'s `$set`. One atomic write, no extra read.
- **Reverse path** (`reverseExpenseInventoryLink`): symmetric — `inventory.currentStock - quantity`.

The `deductStock` path in `services/inventory-service.ts` already recomputes status inline + uses `.save()`, so it was unaffected.

## Tests

- 7 new vitest cases on `computeInventoryStatus`: stock = 0 → out-of-stock; stock < 0 (defensive) → out-of-stock; stock = min → low-stock; stock < min → low-stock; stock > min → in-stock; min = 0 → in-stock; **user's exact case (1 bottle, min 15) → low-stock**.
- 2 new apply-path tests assert `$set: { status }` lands.
- 2 new reverse-path tests cover "reversal puts stock back below min" and "reversal back to zero → out-of-stock".
- 4 existing reverse tests updated to use `expect.objectContaining` so they don't care about the extra `$set` payload.
- Full suite: **772 pass / 4 skipped**. `tsc --noEmit` 0 errors.

## Test plan (post-merge on UAT)

- [ ] Set a sellable item's inventory to `currentStock: 0` (via a deduction). Confirm menu shows Out of Stock.
- [ ] Add an expense linked to that item with quantity 1. Confirm inventory shows `1 bottle` AND status flips from out-of-stock → low-stock (or in-stock if 1 ≥ min). Refresh customer menu — item is no longer Out of Stock.
- [ ] Edit the expense to a smaller quantity → confirm reversal lowers stock + flips status appropriately.
- [ ] Delete the expense (full reversal) → currentStock back to 0, status back to out-of-stock.

## Risk

**MEDIUM** — financial/inventory write path, customer-visible impact. Surgical fix (two `$set` additions + one pure helper). Reversible via `git revert`.