### PR TITLE
fix: compute customer-menu stock status from currentStock at read time

### DIFF
--- a/services/category-service.ts
+++ b/services/category-service.ts
@@ -2,7 +2,31 @@ import { connectDB } from '@/lib/mongodb';
 import MenuItem from '@/models/menu-item-model';
 import Inventory from '@/models/inventory-model';
 import { IMenuItem } from '@/interfaces/menu-item.interface';
+import { computeInventoryStatus } from '@/lib/expense-inventory-link';
 import { SystemSettingsService } from './system-settings-service';
+
+/**
+ * Resolve the stock status to display on customer-facing surfaces.
+ *
+ * Computes from live `currentStock` + `minimumStock` rather than reading
+ * the cached `status` field. The cached field can drift from reality if
+ * any write path updates currentStock without re-running the schema's
+ * pre('save') hook (e.g. `$inc` via `updateOne` — see #98). Computing
+ * fresh on every read means menu surfaces are always accurate even when
+ * older inventory documents have stale `status` from before #99.
+ *
+ * Items with no Inventory record (e.g. menu items without inventory
+ * tracking) default to `'in-stock'` to preserve prior behaviour.
+ */
+function resolveStockStatus(
+  inventory: { currentStock?: number; minimumStock?: number } | null | undefined
+): 'in-stock' | 'low-stock' | 'out-of-stock' {
+  if (!inventory) return 'in-stock';
+  return computeInventoryStatus(
+    inventory.currentStock ?? 0,
+    inventory.minimumStock ?? 0
+  );
+}
 
 export interface MenuItemWithStock extends IMenuItem {
   stockStatus: 'in-stock' | 'low-stock' | 'out-of-stock';
@@ -42,7 +66,7 @@ export class CategoryService {
         }).lean();
         return serializeMenuItem({
           ...item,
-          stockStatus: inventory?.status || 'in-stock',
+          stockStatus: resolveStockStatus(inventory),
           currentStock: inventory?.currentStock,
         });
       })
@@ -74,7 +98,7 @@ export class CategoryService {
         }).lean();
         return serializeMenuItem({
           ...item,
-          stockStatus: inventory?.status || 'in-stock',
+          stockStatus: resolveStockStatus(inventory),
           currentStock: inventory?.currentStock,
         });
       })
@@ -106,7 +130,7 @@ export class CategoryService {
         }).lean();
         return serializeMenuItem({
           ...item,
-          stockStatus: inventory?.status || 'in-stock',
+          stockStatus: resolveStockStatus(inventory),
           currentStock: inventory?.currentStock,
         });
       })
@@ -133,7 +157,7 @@ export class CategoryService {
 
     return serializeMenuItem({
       ...item,
-      stockStatus: inventory?.status || 'in-stock',
+      stockStatus: resolveStockStatus(inventory),
       currentStock: inventory?.currentStock,
     }) as MenuItemWithStock;
   }
@@ -222,7 +246,7 @@ export class CategoryService {
         }).lean();
         return serializeMenuItem({
           ...item,
-          stockStatus: inventory?.status || 'in-stock',
+          stockStatus: resolveStockStatus(inventory),
           currentStock: inventory?.currentStock,
         });
       })


### PR DESCRIPTION
Follow-up to #99. Closes the second half of #98 visibility on UAT.

## What's left from #99

#99 fixed the **write path** (Inventory.status now updates correctly when restocking or reversing via the expense link). But every inventory document that hit the broken code path before #99 deployed has a **stale `status` field** baked in. New restocks heal individual items only when they're touched again — until then the customer menu still shows Out of Stock for items with positive currentStock.

User confirmed this on UAT 2026-05-22 01:32 — Tiger restocked earlier in the day is now correctly showing `currentStock: 1` AND status = `'low-stock'` on new restocks, but already-stuck items still display Out of Stock on the customer menu.

## Fix

Switch the customer-menu **read path** to compute `stockStatus` from the live `currentStock` + `minimumStock` rather than reading the cached `status` field.

- Heals every stuck item immediately on the next menu render. No migration needed.
- Stays correct if any future write path forgets to update the cached field.
- Items with no Inventory record (untracked menu items) keep the prior `'in-stock'` default.

`CategoryService` is the single source feeding the customer menu — both the React menu UI and the public `/api/public/menu/*` routes consume it. All 5 read sites now go through a shared `resolveStockStatus` helper that delegates to the same `computeInventoryStatus` from `lib/expense-inventory-link`.

## Out of scope (deliberate)

`Inventory.status` is now a denormalized convenience field. Admin surfaces that read it directly:

- Inventory dashboard list (`/dashboard/inventory`)
- `app/api/public/inventory/summary/route.ts` (status distribution counts)
- `services/inventory-service.ts` (low-stock alerts)

These will still see stale values for the items that were stuck before #99. They're admin-only and lower-stakes than the customer-visible bug. A second cleanup pass — either a one-shot backfill script, or applying the same read-side compute to those surfaces — can come as a follow-up if it bites.

## Tests

No new unit tests in this PR — the underlying `computeInventoryStatus` helper is already covered by 7 cases from #99, and `resolveStockStatus` is a 5-line wrapper. The full suite (**772 pass / 4 skipped**) still passes; tsc 0 errors.

## Test plan (post-merge on UAT)

- [ ] Browse to the customer menu (`/menu?category=beer-imported`). The drinks the user already restocked (Tiger from `0` → `1`, etc.) should no longer show Out of Stock — they should render normally as low-stock items.
- [ ] An item with `currentStock <= 0` (a genuinely empty drink) should still correctly show Out of Stock.
- [ ] An item with no inventory tracking should still show as available.

## Risk

LOW — pure read-side change, no writes touched. Reversible via `git revert`.