### PR TITLE
fix + feat: heal stale Inventory.status, hide kitchen stubs from Menu Management, and adjust stock from Edit Kitchen dialog

### DIFF
--- a/app/dashboard/inventory/[id]/page.tsx
+++ b/app/dashboard/inventory/[id]/page.tsx
@@ -8,7 +8,14 @@ import { Button } from '@/components/ui/button';
 import { StockAdjustmentActions } from '@/components/features/admin/stock-adjustment-actions';
 import { StockHistoryTable } from '@/components/features/admin/stock-history-table';
 import { LocationBreakdownCard } from '@/components/features/inventory/location-breakdown-card';
-import { Package, TrendingUp, TrendingDown, AlertTriangle, ArrowLeft } from 'lucide-react';
+import {
+  Package,
+  TrendingUp,
+  TrendingDown,
+  AlertTriangle,
+  ArrowLeft,
+} from 'lucide-react';
+import { computeInventoryStatus } from '@/lib/expense-inventory-link';
 
 interface Props {
   params: Promise<{
@@ -29,7 +36,16 @@ export default async function InventoryDetailPage({ params }: Props) {
   }
 
   const inventory = result.data as any;
-  const stockPercentage = (inventory.currentStock / inventory.maximumStock) * 100;
+  const stockPercentage =
+    (inventory.currentStock / inventory.maximumStock) * 100;
+  // Compute fresh from currentStock + minimumStock so a stale cached
+  // status from before #99 doesn't show a wrong badge here. The cached
+  // field is kept for non-display query convenience (low-stock alerts,
+  // etc.) but every display surface should compute live.
+  const stockStatus = computeInventoryStatus(
+    inventory.currentStock ?? 0,
+    inventory.minimumStock ?? 0
+  );
 
   // Get status badge variant
   const getStatusVariant = (status: string) => {
@@ -66,14 +82,21 @@ export default async function InventoryDetailPage({ params }: Props) {
               </Button>
             </Link>
           </div>
-          <h1 className="text-3xl font-bold">{inventory.menuItemId?.name || 'Unknown Item'}</h1>
+          <h1 className="text-3xl font-bold">
+            {inventory.menuItemId?.name || 'Unknown Item'}
+          </h1>
           <p className="text-muted-foreground">
-            {inventory.menuItemId?.mainCategory} • {inventory.menuItemId?.category}
-            {inventory.menuItemId?.price && ` • ₦${inventory.menuItemId.price.toLocaleString()}`}
+            {inventory.menuItemId?.mainCategory} •{' '}
+            {inventory.menuItemId?.category}
+            {inventory.menuItemId?.price &&
+              ` • ₦${inventory.menuItemId.price.toLocaleString()}`}
           </p>
         </div>
-        <Badge variant={getStatusVariant(inventory.status)} className="text-lg px-4 py-2">
-          {inventory.status.replace('-', ' ').toUpperCase()}
+        <Badge
+          variant={getStatusVariant(stockStatus)}
+          className="text-lg px-4 py-2"
+        >
+          {stockStatus.replace('-', ' ').toUpperCase()}
         </Badge>
       </div>
 
@@ -113,7 +136,8 @@ export default async function InventoryDetailPage({ params }: Props) {
           <CardContent>
             <div className="text-2xl font-bold">{inventory.totalWaste}</div>
             <p className="text-xs text-muted-foreground">
-              ₦{(inventory.totalWaste * inventory.costPerUnit).toLocaleString()} cost
+              ₦{(inventory.totalWaste * inventory.costPerUnit).toLocaleString()}{' '}
+              cost
             </p>
           </CardContent>
         </Card>
@@ -124,8 +148,13 @@ export default async function InventoryDetailPage({ params }: Props) {
             <AlertTriangle className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{Math.round(stockPercentage)}%</div>
-            <Progress value={stockPercentage} className={`mt-2 ${getProgressColor()}`} />
+            <div className="text-2xl font-bold">
+              {Math.round(stockPercentage)}%
+            </div>
+            <Progress
+              value={stockPercentage}
+              className={`mt-2 ${getProgressColor()}`}
+            />
           </CardContent>
         </Card>
       </div>
@@ -138,15 +167,23 @@ export default async function InventoryDetailPage({ params }: Props) {
         <CardContent>
           <div className="grid gap-4 md:grid-cols-3">
             <div>
-              <p className="text-sm font-medium text-muted-foreground">Supplier</p>
+              <p className="text-sm font-medium text-muted-foreground">
+                Supplier
+              </p>
               <p className="text-lg">{inventory.supplier || 'Not specified'}</p>
             </div>
             <div>
-              <p className="text-sm font-medium text-muted-foreground">Cost Per Unit</p>
-              <p className="text-lg">₦{inventory.costPerUnit.toLocaleString()}</p>
+              <p className="text-sm font-medium text-muted-foreground">
+                Cost Per Unit
+              </p>
+              <p className="text-lg">
+                ₦{inventory.costPerUnit.toLocaleString()}
+              </p>
             </div>
             <div>
-              <p className="text-sm font-medium text-muted-foreground">Last Restocked</p>
+              <p className="text-sm font-medium text-muted-foreground">
+                Last Restocked
+              </p>
               <p className="text-lg">
                 {inventory.lastRestocked
                   ? new Date(inventory.lastRestocked).toLocaleDateString()
@@ -154,7 +191,9 @@ export default async function InventoryDetailPage({ params }: Props) {
               </p>
             </div>
             <div>
-              <p className="text-sm font-medium text-muted-foreground">Last Sale</p>
+              <p className="text-sm font-medium text-muted-foreground">
+                Last Sale
+              </p>
               <p className="text-lg">
                 {inventory.lastSaleDate
                   ? new Date(inventory.lastSaleDate).toLocaleDateString()
@@ -162,15 +201,22 @@ export default async function InventoryDetailPage({ params }: Props) {
               </p>
             </div>
             <div>
-              <p className="text-sm font-medium text-muted-foreground">Total Restocked</p>
+              <p className="text-sm font-medium text-muted-foreground">
+                Total Restocked
+              </p>
               <p className="text-lg">
                 {inventory.totalRestocked} {inventory.unit}
               </p>
             </div>
             <div>
-              <p className="text-sm font-medium text-muted-foreground">Stock Value</p>
+              <p className="text-sm font-medium text-muted-foreground">
+                Stock Value
+              </p>
               <p className="text-lg">
-                ₦{(inventory.currentStock * inventory.costPerUnit).toLocaleString()}
+                ₦
+                {(
+                  inventory.currentStock * inventory.costPerUnit
+                ).toLocaleString()}
               </p>
             </div>
           </div>
@@ -178,20 +224,25 @@ export default async function InventoryDetailPage({ params }: Props) {
       </Card>
 
       {/* Location Breakdown */}
-      {inventory.trackByLocation && inventory.locations && inventory.locations.length > 0 && (
-        <LocationBreakdownCard
-          locations={inventory.locations.map((loc: any) => ({
-            location: loc.location,
-            locationName: loc.locationName,
-            currentStock: loc.currentStock,
-            percentage: inventory.currentStock > 0
-              ? ((loc.currentStock / inventory.currentStock) * 100).toFixed(1)
-              : '0',
-          }))}
-          totalStock={inventory.currentStock}
-          unit={inventory.unit}
-        />
-      )}
+      {inventory.trackByLocation &&
+        inventory.locations &&
+        inventory.locations.length > 0 && (
+          <LocationBreakdownCard
+            locations={inventory.locations.map((loc: any) => ({
+              location: loc.location,
+              locationName: loc.locationName,
+              currentStock: loc.currentStock,
+              percentage:
+                inventory.currentStock > 0
+                  ? ((loc.currentStock / inventory.currentStock) * 100).toFixed(
+                      1
+                    )
+                  : '0',
+            }))}
+            totalStock={inventory.currentStock}
+            unit={inventory.unit}
+          />
+        )}
 
       {/* Stock Adjustment Actions */}
       <Card>
@@ -209,10 +260,10 @@ export default async function InventoryDetailPage({ params }: Props) {
           <CardTitle>Stock Movement History</CardTitle>
         </CardHeader>
         <CardContent>
-          <StockHistoryTable 
-            history={inventory.stockHistory} 
-            unit={inventory.unit} 
-            locations={inventory.configLocations || []} 
+          <StockHistoryTable
+            history={inventory.stockHistory}
+            unit={inventory.unit}
+            locations={inventory.configLocations || []}
           />
         </CardContent>
       </Card>

--- a/app/dashboard/inventory/page.tsx
+++ b/app/dashboard/inventory/page.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { InventoryItemsClient } from '@/components/features/admin/inventory-items-client';
 import type { InventoryKind } from '@/interfaces/inventory.interface';
+import { computeInventoryStatus } from '@/lib/expense-inventory-link';
 import {
   AlertTriangle,
   ArrowRightLeft,
@@ -64,19 +65,36 @@ async function getInventoryByKind(kind: InventoryKind, archived = false) {
 }
 
 /**
- * Get inventory statistics
+ * Get inventory statistics.
+ *
+ * Counts are computed from live `currentStock` + `minimumStock` per row
+ * rather than counting on the cached `Inventory.status` field. The
+ * cached field can drift if any write path bypasses the schema's
+ * pre('save') hook (e.g. expense-link `$inc` before #99) — counting on
+ * it would inflate the Out of Stock / Low Stock badges. Single fetch +
+ * JS count is cheap for our inventory size (~150 rows).
  */
 async function getInventoryStats() {
   await connectDB();
 
-  const [totalItems, lowStockItems, outOfStockItems] = await Promise.all([
-    InventoryModel.countDocuments(),
-    InventoryModel.countDocuments({ status: 'low-stock' }),
-    InventoryModel.countDocuments({ status: 'out-of-stock' }),
-  ]);
+  const rows = await InventoryModel.find(
+    {},
+    'currentStock minimumStock'
+  ).lean();
+
+  let lowStockItems = 0;
+  let outOfStockItems = 0;
+  for (const r of rows) {
+    const s = computeInventoryStatus(
+      (r as { currentStock?: number }).currentStock ?? 0,
+      (r as { minimumStock?: number }).minimumStock ?? 0
+    );
+    if (s === 'low-stock') lowStockItems += 1;
+    else if (s === 'out-of-stock') outOfStockItems += 1;
+  }
 
   return {
-    totalItems,
+    totalItems: rows.length,
     lowStockItems,
     outOfStockItems,
   };

--- a/app/dashboard/menu/page.tsx
+++ b/app/dashboard/menu/page.tsx
@@ -9,12 +9,22 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { MenuItemsClient } from '@/components/features/admin/menu-items-client';
 
 /**
- * Get all menu items
+ * Get all menu items (customer-facing only — kind:'menu-item').
+ *
+ * Kitchen-ingredient stubs (created as foreign-key targets for
+ * kitchen-ingredient Inventory rows in REQ-034) are excluded. They have
+ * no price / customer-availability / image, so they'd render as nearly-
+ * empty rows here, and they're already fully managed via the dedicated
+ * Inventory → Kitchen tab (add / edit / archive). Mirrors the kind
+ * gating already in place on every customer-facing query in
+ * services/category-service.ts.
+ *
+ * Closes #91.
  */
 async function getMenuItems() {
   await connectDB();
 
-  const menuItems = await MenuItemModel.find()
+  const menuItems = await MenuItemModel.find({ kind: 'menu-item' })
     .sort({ mainCategory: 1, category: 1, name: 1 })
     .lean();
 
@@ -34,17 +44,25 @@ async function getMenuItems() {
 }
 
 /**
- * Get menu statistics
+ * Get menu statistics (customer-facing items only).
  */
 async function getMenuStats() {
   await connectDB();
 
-  const [totalItems, availableItems, foodItems, drinkItems] = await Promise.all([
-    MenuItemModel.countDocuments(),
-    MenuItemModel.countDocuments({ isAvailable: true }),
-    MenuItemModel.countDocuments({ mainCategory: 'food' }),
-    MenuItemModel.countDocuments({ mainCategory: 'drinks' }),
-  ]);
+  const [totalItems, availableItems, foodItems, drinkItems] = await Promise.all(
+    [
+      MenuItemModel.countDocuments({ kind: 'menu-item' }),
+      MenuItemModel.countDocuments({ kind: 'menu-item', isAvailable: true }),
+      MenuItemModel.countDocuments({
+        kind: 'menu-item',
+        mainCategory: 'food',
+      }),
+      MenuItemModel.countDocuments({
+        kind: 'menu-item',
+        mainCategory: 'drinks',
+      }),
+    ]
+  );
 
   return {
     totalItems,

--- a/components/features/admin/edit-kitchen-ingredient-dialog.tsx
+++ b/components/features/admin/edit-kitchen-ingredient-dialog.tsx
@@ -1,16 +1,18 @@
 'use client';
 
 /**
- * REQ-037 AC1 — Edit Kitchen Ingredient dialog.
+ * Edit Kitchen Ingredient dialog (REQ-037 AC1, extended).
  *
- * Pre-filled. Allows editing the name, COGS category, and min/max stock
- * thresholds. Unit is rendered as a disabled display-only field with a
- * tooltip explaining the lock (changing the unit retroactively would
- * corrupt every StockMovement, CostHistory row, and Recipe row that
- * references this ingredient).
+ * Pre-filled. Allows editing the name, COGS category, min/max stock
+ * thresholds, AND the current stock level. Unit is rendered as a
+ * disabled display-only field with a tooltip explaining the lock
+ * (changing the unit retroactively would corrupt every StockMovement,
+ * CostHistory row, and Recipe row that references this ingredient).
  *
- * currentStock is NOT editable here — that's an inventory adjustment
- * with its own audit-trail requirements; out of scope for REQ-037.
+ * Stock level adjustment goes through `adjustStockAction`, which writes
+ * a StockMovement audit record — same audit trail as the sellable item
+ * detail page's Add/Deduct/Adjust controls. A reason is required when
+ * the new stock value differs from the current value.
  */
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
@@ -25,6 +27,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
 import {
   Select,
   SelectContent,
@@ -41,6 +44,7 @@ import {
   getKitchenIngredientFormOptionsAction,
   updateKitchenIngredientAction,
 } from '@/app/actions/admin/kitchen-ingredient-actions';
+import { adjustStockAction } from '@/app/actions/admin/inventory-actions';
 import { buildDropdownSections } from '@/lib/expense-categories-display';
 import type { CategoryGroup } from '@/interfaces/expense.interface';
 
@@ -58,6 +62,7 @@ export interface EditKitchenIngredientDialogProps {
     name: string;
     category: string;
     unit: string;
+    currentStock: number;
     minimumStock: number;
     maximumStock: number;
   };
@@ -80,6 +85,13 @@ export function EditKitchenIngredientDialog({
   const [maximumStock, setMaximumStock] = useState<string>(
     String(inventory.maximumStock ?? 0)
   );
+  // Stock-adjustment fields. Default `newStock` to the current value so
+  // leaving them untouched is a no-op (no adjustStockAction call). A
+  // reason is required only when the new value differs from current.
+  const [newStock, setNewStock] = useState<string>(
+    String(inventory.currentStock ?? 0)
+  );
+  const [adjustReason, setAdjustReason] = useState<string>('');
 
   const [categories, setCategories] = useState<string[]>([]);
   const [categoryGroups, setCategoryGroups] = useState<CategoryGroup[]>([]);
@@ -92,6 +104,8 @@ export function EditKitchenIngredientDialog({
       setCategory(inventory.category);
       setMinimumStock(String(inventory.minimumStock ?? 0));
       setMaximumStock(String(inventory.maximumStock ?? 0));
+      setNewStock(String(inventory.currentStock ?? 0));
+      setAdjustReason('');
       setError(null);
     }
   }, [open, inventory]);
@@ -119,21 +133,62 @@ export function EditKitchenIngredientDialog({
   const lockedUnitLabel =
     units.find((u) => u.id === inventory.unit)?.label ?? inventory.unit;
 
+  const parsedNewStock = newStock === '' ? NaN : Number(newStock);
+  const stockChanged =
+    Number.isFinite(parsedNewStock) &&
+    parsedNewStock !== (inventory.currentStock ?? 0);
+
   async function onSubmit() {
     setBusy(true);
     setError(null);
-    const result = await updateKitchenIngredientAction({
+
+    // Validate stock adjustment fields before touching the server.
+    if (stockChanged) {
+      if (parsedNewStock < 0) {
+        setError('New stock cannot be negative');
+        setBusy(false);
+        return;
+      }
+      if (!adjustReason.trim()) {
+        setError(
+          'A reason is required when changing the stock level (writes to the audit trail)'
+        );
+        setBusy(false);
+        return;
+      }
+    }
+
+    // Two writes: metadata first, then the stock adjustment. Both use
+    // their own server actions; either can fail independently and we
+    // surface the error.
+    const metadataResult = await updateKitchenIngredientAction({
       inventoryId: inventory._id,
       name,
       category,
       minimumStock: minimumStock === '' ? 0 : Number(minimumStock),
       maximumStock: maximumStock === '' ? 0 : Number(maximumStock),
     });
-    setBusy(false);
-    if (!result.success) {
-      setError(result.error);
+    if (!metadataResult.success) {
+      setError(metadataResult.error);
+      setBusy(false);
       return;
     }
+
+    if (stockChanged) {
+      const adjustResult = await adjustStockAction(inventory._id, {
+        newStock: parsedNewStock,
+        reason: adjustReason.trim(),
+      });
+      if (!adjustResult.success) {
+        setError(
+          `Metadata saved but stock adjustment failed: ${adjustResult.error}`
+        );
+        setBusy(false);
+        return;
+      }
+    }
+
+    setBusy(false);
     onOpenChange(false);
     router.refresh();
   }
@@ -144,9 +199,9 @@ export function EditKitchenIngredientDialog({
         <DialogHeader>
           <DialogTitle>Edit Kitchen Ingredient</DialogTitle>
           <DialogDescription>
-            Update the ingredient's display name, COGS category, or stock
-            thresholds. The unit cannot be changed here — see the lock icon for
-            why.
+            Update the ingredient&apos;s display name, COGS category, stock
+            thresholds, or current stock level. The unit cannot be changed here
+            — see the lock icon for why.
           </DialogDescription>
         </DialogHeader>
 
@@ -246,6 +301,51 @@ export function EditKitchenIngredientDialog({
                 onChange={(e) => setMaximumStock(e.target.value)}
               />
             </div>
+          </div>
+
+          <div className="border-t pt-3 space-y-2">
+            <div className="flex items-baseline justify-between">
+              <Label className="text-sm font-medium">Stock level</Label>
+              <p className="text-xs text-muted-foreground">
+                Current: {inventory.currentStock} {lockedUnitLabel}
+              </p>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1">
+                <Label htmlFor="edit-ki-new-stock">New stock</Label>
+                <Input
+                  id="edit-ki-new-stock"
+                  type="number"
+                  min={0}
+                  step="any"
+                  value={newStock}
+                  onChange={(e) => setNewStock(e.target.value)}
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="edit-ki-adjust-reason">
+                  Reason{' '}
+                  {stockChanged && (
+                    <span className="text-destructive">(required)</span>
+                  )}
+                </Label>
+                <Textarea
+                  id="edit-ki-adjust-reason"
+                  placeholder="e.g. physical count, correction, waste"
+                  className="resize-none"
+                  rows={2}
+                  value={adjustReason}
+                  onChange={(e) => setAdjustReason(e.target.value)}
+                  disabled={!stockChanged}
+                />
+              </div>
+            </div>
+            {stockChanged && (
+              <p className="text-xs text-muted-foreground">
+                Writes a StockMovement audit record. Same trail as the sellable
+                item Add / Deduct / Adjust controls.
+              </p>
+            )}
           </div>
         </div>
 

--- a/components/features/admin/inventory-items-client.tsx
+++ b/components/features/admin/inventory-items-client.tsx
@@ -250,6 +250,7 @@ export function InventoryItemsClient({
             name: editTarget.menuItemId?.name ?? '',
             category: editTarget.menuItemId?.category ?? '',
             unit: editTarget.unit,
+            currentStock: editTarget.currentStock,
             minimumStock: editTarget.minStock,
             maximumStock: editTarget.maxStock,
           }}


### PR DESCRIPTION
Bundle of three small admin-UX changes that all touch the same inventory / kitchen surface. Replaces standalone PRs #101 (original scope) and #102 (now folded in).

Closes #91. Refs #98.

## Part 1 — Inventory dashboard still showed stale status (fix)

| Surface | Bug |
|---|---|
| `/dashboard/inventory` "Low Stock / Out of Stock" tiles | Counted on `Inventory.status` directly — inflated by stuck documents from before #99 |
| `/dashboard/inventory/[id]` headline badge | Read `inventory.status` directly — Tiger showed "OUT OF-STOCK" badge with `currentStock = 1` |

Both switched to compute from live `currentStock` + `minimumStock` via the existing `computeInventoryStatus` helper. The inventory list table already computed status client-side from `currentStock` vs `minStock`, so per-row badges there were already correct.

## Part 2 — Menu Management showed kitchen-ingredient stubs (fix, closes #91)

Page-level queries used `MenuItemModel.find()` / `countDocuments()` with no `kind` filter, so kind:'kitchen-ingredient' stubs (the foreign-key targets for kitchen-ingredient Inventory rows introduced in REQ-034) appeared mixed in with real customer-facing items.

**Decision: filter them out entirely, not a tab split.** Kitchen ingredients are recipe inputs, not menu items, and are already fully manageable via `Inventory → Kitchen` (add / edit / archive).

Both `getMenuItems()` and `getMenuStats()` now gate on `{ kind: 'menu-item' }`. Category filter chips derive from the items list, so they no longer surface kitchen-ingredient categories either.

## Part 3 — Adjust stock from the Edit Kitchen Ingredient dialog (feat)

Operators expected the pencil icon's Edit dialog to also handle stock-level adjustments alongside the existing metadata edit.

New **Stock level** section in the dialog:

- **Current stock** displayed read-only with the locked unit label.
- **New stock** input pre-filled with the current value — leaving it alone is a no-op.
- **Reason** textarea, disabled until the new value differs from current; required when it does.

On save: metadata goes through `updateKitchenIngredientAction`; if `newStock !== currentStock` AND a reason is provided, also calls `adjustStockAction` — same server action the sellable detail page uses, writes a `StockMovement{type:'adjustment'}` audit record. Unit stays locked.

## Files

| Part | File |
|---|---|
| 1 | `app/dashboard/inventory/page.tsx` |
| 1 | `app/dashboard/inventory/[id]/page.tsx` |
| 2 | `app/dashboard/menu/page.tsx` |
| 3 | `components/features/admin/edit-kitchen-ingredient-dialog.tsx` |
| 3 | `components/features/admin/inventory-items-client.tsx` |

## Tests

Full vitest **772 pass / 4 skipped**, `tsc` 0 errors. No new unit tests — all three changes are surgical reads / additive UI on already-tested helpers.

## Test plan (post-merge on UAT)

**Part 1:**
- [ ] `/dashboard/inventory` — Low Stock + Out of Stock tiles match actual counts.
- [ ] `/dashboard/inventory/[id]` for Tiger — headline badge shows LOW STOCK (or IN STOCK if above min).

**Part 2:**
- [ ] `/dashboard/menu` — no kitchen-ingredient items; category chips no longer include kitchen-only categories.

**Part 3:**
- [ ] `Inventory → Kitchen → edit Pomo Sauce` → dialog shows `Current: X kg` in the new Stock level section.
- [ ] Leave New stock untouched → no StockMovement.
- [ ] Change New stock without reason → save blocks.
- [ ] Change New stock + reason → save succeeds; new `adjustment` record appears in Stock Movement History.
- [ ] Sellable detail-page Add / Deduct / Adjust controls still work (no regression).

## Risk

LOW. All three parts are admin-UX changes on already-tested helpers. Reversible via `git revert` per commit.