### PR TITLE
feat: surface stock + hard-block out-of-stock on Express Create Order

### DIFF
--- a/app/actions/admin/express-actions.ts
+++ b/app/actions/admin/express-actions.ts
@@ -13,7 +13,9 @@ import { TabService } from '@/services';
 import { OrderService } from '@/services/order-service';
 import TabModel from '@/models/tab-model';
 import MenuItemModel from '@/models/menu-item-model';
+import InventoryModel from '@/models/inventory-model';
 import { ITab, IMenuItem } from '@/interfaces';
+import { computeInventoryStatus } from '@/lib/expense-inventory-link';
 import {
   reconcileAndValidateOrderLines,
   type MenuItemForReconcile,
@@ -118,12 +120,23 @@ export async function expressCreateTabAction(params: {
 }
 
 /**
- * Search menu items for the express order flow
+ * Search menu items for the express order flow.
+ *
+ * Each returned item is enriched with live stock info (computed from
+ * Inventory.currentStock + Inventory.minimumStock, NOT the cached
+ * Inventory.status field — see #98) so the order-creation UI can
+ * surface "Out of Stock" / "Low Stock (N left)" to staff. Items
+ * without a paired Inventory record default to `'in-stock'`.
  */
+export type ExpressMenuItem = IMenuItem & {
+  stockStatus: 'in-stock' | 'low-stock' | 'out-of-stock';
+  currentStock?: number;
+};
+
 export async function expressSearchMenuAction(params: {
   query?: string;
   category?: string;
-}): Promise<ActionResult<{ items: IMenuItem[] }>> {
+}): Promise<ActionResult<{ items: ExpressMenuItem[] }>> {
   try {
     await requireAdminSession();
     await connectDB();
@@ -152,9 +165,36 @@ export async function expressSearchMenuAction(params: {
       .sort({ mainCategory: 1, category: 1, name: 1 })
       .lean();
 
+    // One batched fetch of paired Inventory rows; avoids N+1 lookups.
+    const itemIds = items.map((i) => i._id);
+    const inventories = await InventoryModel.find(
+      { menuItemId: { $in: itemIds } },
+      'menuItemId currentStock minimumStock'
+    ).lean();
+    const invByMenuItem = new Map(
+      inventories.map((inv) => [
+        String((inv as { menuItemId: unknown }).menuItemId),
+        inv,
+      ])
+    );
+
+    const enriched = items.map((item) => {
+      const inv = invByMenuItem.get(String(item._id)) as
+        | { currentStock?: number; minimumStock?: number }
+        | undefined;
+      const stockStatus = inv
+        ? computeInventoryStatus(inv.currentStock ?? 0, inv.minimumStock ?? 0)
+        : 'in-stock';
+      return {
+        ...item,
+        stockStatus,
+        currentStock: inv?.currentStock,
+      };
+    });
+
     return {
       success: true,
-      data: { items: JSON.parse(JSON.stringify(items)) },
+      data: { items: JSON.parse(JSON.stringify(enriched)) },
     };
   } catch (error) {
     return {

--- a/app/dashboard/orders/express/create-order/page.tsx
+++ b/app/dashboard/orders/express/create-order/page.tsx
@@ -389,20 +389,26 @@ function ExpressCreateOrderContent() {
               const stock = item.currentStock;
               const isOutOfStock = item.stockStatus === 'out-of-stock';
               const isLowStock = item.stockStatus === 'low-stock';
-              // Visibility, not blocking — staff may still take the order
-              // (e.g. they have one in the back); the badge informs them
-              // before they tell the customer or add another to the cart.
+              // Hard-block: out-of-stock items are not clickable from this
+              // grid. Staff who genuinely have stock in the back must
+              // adjust the count first via Inventory → Kitchen edit (or
+              // sellable item Add Stock on the detail page), then come
+              // back here. This keeps the inventory truthful.
               return (
                 <Card
                   key={item._id}
-                  className={`cursor-pointer transition-all ${
-                    qty > 0
-                      ? 'ring-2 ring-primary'
-                      : isOutOfStock
-                        ? 'opacity-60 hover:bg-accent/50'
-                        : 'hover:bg-accent/50'
+                  aria-disabled={isOutOfStock}
+                  className={`transition-all ${
+                    isOutOfStock
+                      ? 'opacity-60 cursor-not-allowed'
+                      : `cursor-pointer ${
+                          qty > 0 ? 'ring-2 ring-primary' : 'hover:bg-accent/50'
+                        }`
                   }`}
-                  onClick={() => addToCart(item)}
+                  onClick={() => {
+                    if (isOutOfStock) return;
+                    addToCart(item);
+                  }}
                 >
                   <CardContent className="p-4">
                     <div className="flex justify-between items-start">
@@ -414,10 +420,6 @@ function ExpressCreateOrderContent() {
                         <p className="font-bold mt-1">
                           ₦{item.price.toLocaleString()}
                         </p>
-                        {/* Stock visibility for staff. Doesn't block adding to
-                            cart — staff decides based on what's actually
-                            in the bar (e.g. a bottle in the back fridge that
-                            hasn't been counted). */}
                         {(isOutOfStock || isLowStock) && (
                           <p
                             className={`text-xs mt-1 font-medium ${
@@ -427,9 +429,7 @@ function ExpressCreateOrderContent() {
                             }`}
                           >
                             {isOutOfStock
-                              ? typeof stock === 'number'
-                                ? `Out of Stock${stock <= 0 ? '' : ` (${stock} left)`}`
-                                : 'Out of Stock'
+                              ? 'Out of Stock'
                               : `Low Stock${typeof stock === 'number' ? ` — ${stock} left` : ''}`}
                           </p>
                         )}

--- a/app/dashboard/orders/express/create-order/page.tsx
+++ b/app/dashboard/orders/express/create-order/page.tsx
@@ -46,6 +46,10 @@ interface MenuItem {
   mainCategory: string;
   description: string;
   isAvailable: boolean;
+  /** Computed stock status from currentStock + minimumStock (see #98). */
+  stockStatus: 'in-stock' | 'low-stock' | 'out-of-stock';
+  /** Live current stock from the paired Inventory row. */
+  currentStock?: number;
   portionOptions?: {
     halfPortionEnabled?: boolean;
     halfPortionSurcharge?: number;
@@ -382,10 +386,22 @@ function ExpressCreateOrderContent() {
           <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
             {menuItems.map((item) => {
               const qty = getCartQuantity(item._id);
+              const stock = item.currentStock;
+              const isOutOfStock = item.stockStatus === 'out-of-stock';
+              const isLowStock = item.stockStatus === 'low-stock';
+              // Visibility, not blocking — staff may still take the order
+              // (e.g. they have one in the back); the badge informs them
+              // before they tell the customer or add another to the cart.
               return (
                 <Card
                   key={item._id}
-                  className={`cursor-pointer transition-all ${qty > 0 ? 'ring-2 ring-primary' : 'hover:bg-accent/50'}`}
+                  className={`cursor-pointer transition-all ${
+                    qty > 0
+                      ? 'ring-2 ring-primary'
+                      : isOutOfStock
+                        ? 'opacity-60 hover:bg-accent/50'
+                        : 'hover:bg-accent/50'
+                  }`}
                   onClick={() => addToCart(item)}
                 >
                   <CardContent className="p-4">
@@ -398,6 +414,25 @@ function ExpressCreateOrderContent() {
                         <p className="font-bold mt-1">
                           ₦{item.price.toLocaleString()}
                         </p>
+                        {/* Stock visibility for staff. Doesn't block adding to
+                            cart — staff decides based on what's actually
+                            in the bar (e.g. a bottle in the back fridge that
+                            hasn't been counted). */}
+                        {(isOutOfStock || isLowStock) && (
+                          <p
+                            className={`text-xs mt-1 font-medium ${
+                              isOutOfStock
+                                ? 'text-destructive'
+                                : 'text-amber-700'
+                            }`}
+                          >
+                            {isOutOfStock
+                              ? typeof stock === 'number'
+                                ? `Out of Stock${stock <= 0 ? '' : ` (${stock} left)`}`
+                                : 'Out of Stock'
+                              : `Low Stock${typeof stock === 'number' ? ` — ${stock} left` : ''}`}
+                          </p>
+                        )}
                       </div>
                       {qty > 0 && (
                         <div


### PR DESCRIPTION
## Why

Operator feedback from UAT 2026-05-22: the Express Create Order grid (`/dashboard/orders/express/create-order`) showed every menu item with just name / category / price — no stock indicator. Staff had no way to know an item was out of stock before adding it to a customer's order.

The customer menu (`/menu`), reached via the orders dashboard "Quick Actions → Open a Order" card, already shows Low Stock / Out of Stock badges (from #100), so this was only an Express-flow gap.

## Change

**Server (`expressSearchMenuAction`)** — now joins each MenuItem with its paired Inventory row (single batched query, not N+1) and attaches:

- `stockStatus` — `'in-stock' | 'low-stock' | 'out-of-stock'`, computed live via `computeInventoryStatus` (the same #98/#99 helper used everywhere else). Does **not** read the cached `Inventory.status` field, so stuck items from before #99 don't show wrong badges here.
- `currentStock` — the live integer count.

Items without a paired Inventory record default to `'in-stock'` (untracked items always orderable).

**UI** — per-card stock indicators:

| State | Visual | Clickable? |
|---|---|---|
| In stock | unchanged | yes |
| Low stock | amber **"Low Stock — N left"** label | yes (informational) |
| Out of stock | opacity 60 + red **"Out of Stock"** label + `cursor-not-allowed` | **no** — hard-blocked |

Staff who genuinely have stock in the back must adjust the count first via `Inventory → Kitchen edit` (or the sellable item's `Add Stock` on the detail page), then come back here. Keeps the inventory truthful instead of letting orders silently drive it negative.

## Files

| File | Change |
|---|---|
| `app/actions/admin/express-actions.ts` | New `ExpressMenuItem` type, batched Inventory join, status computation |
| `app/dashboard/orders/express/create-order/page.tsx` | `stockStatus` + `currentStock` on the `MenuItem` interface; per-card badge render; click handler short-circuits when out of stock |

## Tests

Full vitest **772 pass / 4 skipped**, `tsc` 0 errors. No new unit tests — the change uses the already-tested `computeInventoryStatus` (7 cases from #99) plus standard Mongoose queries; manual UAT walk on the Express flow is the verification.

## Test plan (post-merge on UAT)

- [ ] Open `/dashboard/orders/express/create-order` — items with positive stock above min show no badge and are clickable normally.
- [ ] Items with stock = 0 show "Out of Stock" + opacity-60 card + cursor-not-allowed. Clicking does nothing.
- [ ] Items with stock > 0 but ≤ min show amber "Low Stock — N left" and are still clickable.
- [ ] After adjusting an out-of-stock item's count via `Inventory → Kitchen edit` (or sellable Add Stock), the Express grid lets you add it again (refresh required for the cached search results).
- [ ] The customer menu at `/menu` (Quick Actions path) still behaves as before — no regression.

## Out of scope (deliberate)

- **Tab add-item flow.** The Express Create Tab page (`/dashboard/orders/express/create-tab`) only takes a table number — no item picker. Adding items to an existing tab goes via "Add to Existing Tab" → tab list → customer menu, which already gates out-of-stock clicks correctly.

## Risk

LOW. One extra Mongoose query in the search action (batched, not N+1), additive UI on the cards, click handler gains a single guard line. Reversible via `git revert`.