### PR TITLE
feat: bidirectional auto-derive on expense line {qty, unit, total} (#104)

### DIFF
--- a/__tests__/lib/expense-line-derivation.test.ts
+++ b/__tests__/lib/expense-line-derivation.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Pure-helper coverage for the expense line {qty, unit, total}
+ * auto-derivation logic.
+ *
+ * Ref: #104
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  deriveLineField,
+  pushEdit,
+  roundForField,
+  type LineFieldName,
+} from '@/lib/expense-line-derivation';
+
+describe('roundForField', () => {
+  it('rounds totalCost to 2 decimals (currency)', () => {
+    expect(roundForField('totalCost', 54.0)).toBe(54);
+    expect(roundForField('totalCost', 54.005)).toBe(54.01);
+    expect(roundForField('totalCost', 54.004)).toBe(54);
+  });
+
+  it('rounds unitCost to 4 decimals (sub-pound items)', () => {
+    expect(roundForField('unitCost', 0.082499)).toBe(0.0825);
+    expect(roundForField('unitCost', 4.50001)).toBe(4.5);
+  });
+
+  it('rounds quantity to 4 decimals (drift-safe)', () => {
+    expect(roundForField('quantity', 11.99999)).toBe(12);
+    expect(roundForField('quantity', 0.250001)).toBe(0.25);
+  });
+});
+
+describe('pushEdit', () => {
+  it('moves a field to the front when edited', () => {
+    expect(pushEdit(['unitCost', 'quantity'], 'totalCost')).toEqual([
+      'totalCost',
+      'unitCost',
+      'quantity',
+    ]);
+  });
+
+  it('dedupes when the same field is re-edited', () => {
+    expect(pushEdit(['quantity', 'unitCost'], 'quantity')).toEqual([
+      'quantity',
+      'unitCost',
+    ]);
+  });
+
+  it('clamps to 3 fields max', () => {
+    const four = pushEdit(['unitCost', 'totalCost', 'quantity'], 'unitCost');
+    expect(four).toHaveLength(3);
+    expect(four[0]).toBe('unitCost');
+  });
+
+  it('starts an empty order when nothing was edited yet', () => {
+    expect(pushEdit([], 'quantity')).toEqual(['quantity']);
+  });
+});
+
+describe('deriveLineField — happy paths', () => {
+  it('AC1: qty + unitCost edited → totalCost derives to qty × unit', () => {
+    const r = deriveLineField({ quantity: 12, unitCost: 4.5, totalCost: 0 }, [
+      'unitCost',
+      'quantity',
+    ]);
+    expect(r.field).toBe('totalCost');
+    expect(r.value).toBe(54);
+  });
+
+  it('AC2: qty + totalCost edited → unitCost derives to total ÷ qty (4dp)', () => {
+    const r = deriveLineField({ quantity: 12, unitCost: 0, totalCost: 54 }, [
+      'totalCost',
+      'quantity',
+    ]);
+    expect(r.field).toBe('unitCost');
+    expect(r.value).toBe(4.5);
+  });
+
+  it('AC3: unitCost + totalCost edited → quantity derives to total ÷ unit', () => {
+    const r = deriveLineField({ quantity: 0, unitCost: 4.5, totalCost: 54 }, [
+      'totalCost',
+      'unitCost',
+    ]);
+    expect(r.field).toBe('quantity');
+    expect(r.value).toBe(12);
+  });
+
+  it('handles sub-pound unit costs (eg spice mixes at £0.0825/g)', () => {
+    const r = deriveLineField(
+      { quantity: 0, unitCost: 0.0825, totalCost: 41.25 },
+      ['totalCost', 'unitCost']
+    );
+    expect(r.field).toBe('quantity');
+    expect(r.value).toBe(500);
+  });
+});
+
+describe('deriveLineField — override / ordering rules', () => {
+  it('AC4: editing the auto-filled field claims it; next-oldest becomes target', () => {
+    // Round 1: user enters qty + unit → total derives.
+    let order: LineFieldName[] = pushEdit([], 'quantity');
+    order = pushEdit(order, 'unitCost');
+    expect(
+      deriveLineField({ quantity: 12, unitCost: 4.5, totalCost: 0 }, order)
+        .field
+    ).toBe('totalCost');
+
+    // Round 2: user manually overrides total → total now claimed; qty is
+    // oldest, so it becomes the new derive target.
+    order = pushEdit(order, 'totalCost');
+    const r = deriveLineField(
+      { quantity: 12, unitCost: 4.5, totalCost: 60 },
+      order
+    );
+    expect(r.field).toBe('quantity');
+    // 60 / 4.5 = 13.333… rounded to 4dp = 13.3333.
+    expect(r.value).toBe(13.3333);
+  });
+
+  it('returns no field when only one field has been edited', () => {
+    const r = deriveLineField({ quantity: 12, unitCost: 0, totalCost: 0 }, [
+      'quantity',
+    ]);
+    expect(r.field).toBeNull();
+    expect(r.value).toBeNull();
+  });
+
+  it('returns no field when no fields have been edited (initial blank state)', () => {
+    const r = deriveLineField({ quantity: 0, unitCost: 0, totalCost: 0 }, []);
+    expect(r.field).toBeNull();
+    expect(r.value).toBeNull();
+  });
+});
+
+describe('deriveLineField — divide-by-zero guards (AC5)', () => {
+  it('quantity = 0 with non-zero total → no unitCost derivation, hint shown', () => {
+    const r = deriveLineField({ quantity: 0, unitCost: 0, totalCost: 54 }, [
+      'totalCost',
+      'quantity',
+    ]);
+    expect(r.field).toBeNull();
+    expect(r.value).toBeNull();
+    expect(r.hint).toMatch(/quantity above 0/i);
+  });
+
+  it('unitCost = 0 with non-zero total → no quantity derivation, hint shown', () => {
+    const r = deriveLineField({ quantity: 0, unitCost: 0, totalCost: 54 }, [
+      'totalCost',
+      'unitCost',
+    ]);
+    expect(r.field).toBeNull();
+    expect(r.value).toBeNull();
+    expect(r.hint).toMatch(/unit cost above 0/i);
+  });
+
+  it('qty = 0 and unit = 0 deriving total is allowed (total = 0, no divide)', () => {
+    const r = deriveLineField({ quantity: 0, unitCost: 0, totalCost: 0 }, [
+      'unitCost',
+      'quantity',
+    ]);
+    expect(r.field).toBe('totalCost');
+    expect(r.value).toBe(0);
+  });
+});

--- a/components/features/finance/edit-pending-group-dialog.tsx
+++ b/components/features/finance/edit-pending-group-dialog.tsx
@@ -54,6 +54,7 @@ import {
   type SellableInventoryOption,
 } from './inventory-link-section';
 import { computeLockedUnit } from '@/lib/expense-inventory-link';
+import { useExpenseLineAutoDerive } from '@/hooks/use-expense-line-auto-derive';
 import { getExpenseCategoriesAction } from '@/app/actions/finance/expense-categories-actions';
 import { getUnitsOfMeasurementAction } from '@/app/actions/units-actions';
 import {
@@ -161,12 +162,14 @@ export function EditPendingGroupDialog({
       fetchSellableInventory();
       setSellableLinkEnabled({});
       setSellableLoaded(false);
+      resetAutoDerive();
       form.reset({
         date: new Date(group.date),
         items: group.items.map((i) => ({ ...i })),
         notes: group.notes ?? '',
       });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, group]);
 
   // Hydrate the kitchen-vs-sellable mutex from the loaded sellable list.
@@ -249,15 +252,14 @@ export function EditPendingGroupDialog({
     0
   );
 
-  function handleQtyOrCostChange(index: number) {
-    const item = form.getValues(`items.${index}`);
-    const qty = item.quantity ?? 0;
-    const cost = item.unitCost ?? 0;
-    form.setValue(
-      `items.${index}.totalCost`,
-      parseFloat((qty * cost).toFixed(2))
-    );
-  }
+  // #104 — bidirectional auto-derive across {quantity, unitCost,
+  // totalCost}. Same hook the Add Expense form uses; the math lives in
+  // lib/expense-line-derivation.ts.
+  const {
+    onFieldEdit,
+    getHint,
+    resetAll: resetAutoDerive,
+  } = useExpenseLineAutoDerive({ form });
 
   async function handleDelete() {
     setIsDeleting(true);
@@ -501,7 +503,7 @@ export function EditPendingGroupDialog({
                                       ? parseFloat(e.target.value)
                                       : 0
                                   );
-                                  handleQtyOrCostChange(index);
+                                  onFieldEdit(index, 'quantity');
                                 }}
                                 value={f.value ?? ''}
                               />
@@ -559,7 +561,7 @@ export function EditPendingGroupDialog({
                               <Input
                                 className="h-8 text-sm"
                                 type="number"
-                                step="0.01"
+                                step="0.0001"
                                 {...f}
                                 onChange={(e) => {
                                   f.onChange(
@@ -567,7 +569,7 @@ export function EditPendingGroupDialog({
                                       ? parseFloat(e.target.value)
                                       : 0
                                   );
-                                  handleQtyOrCostChange(index);
+                                  onFieldEdit(index, 'unitCost');
                                 }}
                                 value={f.value ?? ''}
                               />
@@ -590,13 +592,14 @@ export function EditPendingGroupDialog({
                                 type="number"
                                 step="0.01"
                                 {...f}
-                                onChange={(e) =>
+                                onChange={(e) => {
                                   f.onChange(
                                     e.target.value
                                       ? parseFloat(e.target.value)
                                       : 0
-                                  )
-                                }
+                                  );
+                                  onFieldEdit(index, 'totalCost');
+                                }}
                                 value={f.value ?? ''}
                               />
                             </FormControl>
@@ -617,6 +620,15 @@ export function EditPendingGroupDialog({
                         </Button>
                       </div>
                     </div>
+                    {getHint(index) && (
+                      <p
+                        role="status"
+                        aria-live="polite"
+                        className="text-xs text-amber-700"
+                      >
+                        {getHint(index)}
+                      </p>
+                    )}
                     <InventoryLinkSection
                       form={form}
                       index={index}

--- a/components/features/finance/expense-form.tsx
+++ b/components/features/finance/expense-form.tsx
@@ -110,6 +110,7 @@ import {
   type SellableInventoryOption,
 } from './inventory-link-section';
 import { computeLockedUnit } from '@/lib/expense-inventory-link';
+import { useExpenseLineAutoDerive } from '@/hooks/use-expense-line-auto-derive';
 
 interface ExpenseFormProps {
   open: boolean;
@@ -185,6 +186,7 @@ export function ExpenseForm({
       fetchKitchenInventory();
       fetchSellableInventory();
       setSellableLinkEnabled({});
+      resetAutoDerive();
       form.reset({
         date: prefill?.date ?? new Date(),
         items:
@@ -194,6 +196,7 @@ export function ExpenseForm({
         notes: '',
       });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
   async function fetchCategories() {
@@ -263,15 +266,15 @@ export function ExpenseForm({
     return buildDropdownSections(categories, groups);
   }
 
-  function handleQtyOrCostChange(index: number) {
-    const item = form.getValues(`items.${index}`);
-    const qty = item.quantity ?? 0;
-    const cost = item.unitCost ?? 0;
-    form.setValue(
-      `items.${index}.totalCost`,
-      parseFloat((qty * cost).toFixed(2))
-    );
-  }
+  // #104 — bidirectional auto-derive across {quantity, unitCost, totalCost}.
+  // The hook tracks which two fields the operator touched most recently
+  // and computes the third via deriveLineField. Replaces the old
+  // unidirectional `handleQtyOrCostChange` (qty + unit → total only).
+  const {
+    onFieldEdit,
+    getHint,
+    resetAll: resetAutoDerive,
+  } = useExpenseLineAutoDerive({ form });
 
   const groupTotal = items.reduce(
     (sum, item) => sum + (item.totalCost || 0),
@@ -542,7 +545,7 @@ export function ExpenseForm({
                                       ? parseFloat(e.target.value)
                                       : 0
                                   );
-                                  handleQtyOrCostChange(index);
+                                  onFieldEdit(index, 'quantity');
                                 }}
                                 value={f.value ?? ''}
                               />
@@ -600,7 +603,7 @@ export function ExpenseForm({
                               <Input
                                 className="h-8 text-sm"
                                 type="number"
-                                step="0.01"
+                                step="0.0001"
                                 placeholder="0.00"
                                 {...f}
                                 onChange={(e) => {
@@ -609,7 +612,7 @@ export function ExpenseForm({
                                       ? parseFloat(e.target.value)
                                       : 0
                                   );
-                                  handleQtyOrCostChange(index);
+                                  onFieldEdit(index, 'unitCost');
                                 }}
                                 value={f.value ?? ''}
                               />
@@ -633,13 +636,14 @@ export function ExpenseForm({
                                 step="0.01"
                                 placeholder="0.00"
                                 {...f}
-                                onChange={(e) =>
+                                onChange={(e) => {
                                   f.onChange(
                                     e.target.value
                                       ? parseFloat(e.target.value)
                                       : 0
-                                  )
-                                }
+                                  );
+                                  onFieldEdit(index, 'totalCost');
+                                }}
                                 value={f.value ?? ''}
                               />
                             </FormControl>
@@ -660,6 +664,21 @@ export function ExpenseForm({
                         </Button>
                       </div>
                     </div>
+                    {/* #104 — auto-derive hint (e.g. "Enter a quantity
+                        above 0 to auto-compute unit cost"). Empty by
+                        default; populated by the hook only when the
+                        operator's entry pattern would otherwise hit a
+                        divide-by-zero. aria-live so screen readers hear
+                        the recalc / hint. */}
+                    {getHint(index) && (
+                      <p
+                        role="status"
+                        aria-live="polite"
+                        className="text-xs text-amber-700"
+                      >
+                        {getHint(index)}
+                      </p>
+                    )}
                     {/* Inventory linking — Direct Cost only. Shared with
                         the Edit Pending Group dialog via the same component. */}
                     <InventoryLinkSection

--- a/hooks/use-expense-line-auto-derive.ts
+++ b/hooks/use-expense-line-auto-derive.ts
@@ -1,0 +1,99 @@
+'use client';
+
+/**
+ * Per-row {qty, unit cost, total} auto-derivation hook for the expense
+ * line item editor.
+ *
+ * Both the Add Expense form (expense-form.tsx) and the Edit Pending
+ * Expense Group dialog (edit-pending-group-dialog.tsx) wire the same
+ * three inputs through this hook. The hook owns the per-row edit-order
+ * tracking (which two fields the operator touched most recently) and
+ * does the round-trip into react-hook-form's `setValue`. Math + rules
+ * live in `lib/expense-line-derivation.ts`.
+ *
+ * Hint string for the divide-by-zero edge cases is exposed via
+ * `getHint(index)` so the parent form can render a non-blocking
+ * `aria-live="polite"` message under the affected input.
+ *
+ * Ref: #104
+ */
+import { useRef, useState, useCallback } from 'react';
+import type { UseFormReturn } from 'react-hook-form';
+import {
+  deriveLineField,
+  pushEdit,
+  type LineFieldName,
+} from '@/lib/expense-line-derivation';
+
+interface UseExpenseLineAutoDeriveOptions {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  form: UseFormReturn<any>;
+}
+
+export function useExpenseLineAutoDerive({
+  form,
+}: UseExpenseLineAutoDeriveOptions) {
+  // Per-row edit-order. Kept in a ref so it doesn't trigger renders;
+  // hint state lives in React state because the UI needs to react.
+  const editOrderRef = useRef<Record<number, LineFieldName[]>>({});
+  const [hints, setHints] = useState<Record<number, string | undefined>>({});
+
+  const onFieldEdit = useCallback(
+    (index: number, field: LineFieldName) => {
+      const prev = editOrderRef.current[index] ?? [];
+      const next = pushEdit(prev, field);
+      editOrderRef.current[index] = next;
+
+      const item = form.getValues(`items.${index}`) ?? {};
+      const result = deriveLineField(
+        {
+          quantity: Number(item.quantity ?? 0),
+          unitCost: Number(item.unitCost ?? 0),
+          totalCost: Number(item.totalCost ?? 0),
+        },
+        next
+      );
+
+      // Update the hint (clears when there's nothing to say).
+      setHints((h) => ({ ...h, [index]: result.hint }));
+
+      if (result.field && result.value !== null) {
+        form.setValue(`items.${index}.${result.field}`, result.value, {
+          shouldDirty: true,
+          shouldValidate: false,
+          shouldTouch: false,
+        });
+      }
+    },
+    [form]
+  );
+
+  const getHint = useCallback(
+    (index: number): string | undefined => hints[index],
+    [hints]
+  );
+
+  /**
+   * Clears the tracking for an index — call when removing a row so a
+   * later row that re-uses that index doesn't inherit stale edits.
+   */
+  const resetRow = useCallback((index: number) => {
+    delete editOrderRef.current[index];
+    setHints((h) => {
+      const next = { ...h };
+      delete next[index];
+      return next;
+    });
+  }, []);
+
+  /**
+   * Clears all edit tracking — call from the dialog's open effect so a
+   * fresh session doesn't inherit history from the previous open.
+   */
+  const resetAll = useCallback(() => {
+    editOrderRef.current = {};
+    setHints({});
+  }, []);
+
+  return { onFieldEdit, getHint, resetRow, resetAll };
+}

--- a/lib/expense-line-derivation.ts
+++ b/lib/expense-line-derivation.ts
@@ -1,0 +1,143 @@
+/**
+ * Auto-derivation for the expense line item triple {quantity, unitCost, totalCost}.
+ *
+ * total = quantity × unitCost — given any two, the third is derivable.
+ * Operators currently have to compute the third by hand, which is
+ * error-prone (especially for spice-mix-style line items with sub-pound
+ * unit costs).
+ *
+ * This file is the pure logic: take the current values + which fields
+ * the user has touched recently, return the target field to recompute
+ * and its new value. The hook in `hooks/use-expense-line-auto-derive.ts`
+ * owns the per-row edit-tracking state and wires this into the form;
+ * the form itself just calls `onFieldEdit` from each input's onChange.
+ *
+ * Out of scope (see #104): pack-to-unit conversions, FX, CSV import.
+ *
+ * Ref: #104
+ */
+
+export type LineFieldName = 'quantity' | 'unitCost' | 'totalCost';
+
+export interface LineValues {
+  quantity: number;
+  unitCost: number;
+  totalCost: number;
+}
+
+export interface DerivationResult {
+  /** Which field to update (null if no derivation possible from the inputs). */
+  field: LineFieldName | null;
+  /** The computed value to set (matched to `field`). Always rounded. */
+  value: number | null;
+  /**
+   * Set when the inputs prevent derivation but the operator would
+   * benefit from knowing why (e.g. quantity = 0 makes unit cost
+   * undefined). UI surfaces this as a non-blocking inline hint.
+   */
+  hint?: string;
+}
+
+/**
+ * Round to the field's stored precision.
+ *
+ * - quantity: 4 decimals (operators may enter eg 0.2500 kg, or the
+ *   auto-derive could produce 11.9999 from total ÷ unit float drift).
+ * - unitCost: 4 decimals (per the issue — some line items are
+ *   £0.0825/g for spice mixes).
+ * - totalCost: 2 decimals (currency).
+ *
+ * Note: long-term we should store these as Mongoose Decimal128 to avoid
+ * float drift entirely (#104 non-functional note). The schema today is
+ * `Number`, so a fixed-precision round at the UI / helper boundary is
+ * the pragmatic interim.
+ */
+export function roundForField(field: LineFieldName, value: number): number {
+  const decimals = field === 'totalCost' ? 2 : 4;
+  const factor = Math.pow(10, decimals);
+  return Math.round(value * factor) / factor;
+}
+
+/**
+ * Given the order in which the user edited the three fields (most-recent
+ * first) and the current values, derive the target field to recompute
+ * and its new value.
+ *
+ * Rules (from #104 AC):
+ * 1. The two most-recently-edited fields drive the third.
+ * 2. If only one field has been edited, no derivation yet (returns
+ *    `{ field: null, value: null }`).
+ * 3. Operator override of an auto-filled value claims that field (it
+ *    becomes most-recent) and the next-oldest becomes the recompute
+ *    target.
+ * 4. Quantity = 0 cannot divide — return a hint, no field update.
+ * 5. Unit cost = 0 with non-zero total cannot divide for quantity —
+ *    same hint pattern.
+ *
+ * The function does NOT touch any state of its own. Tests should
+ * exercise the matrix directly.
+ */
+export function deriveLineField(
+  values: LineValues,
+  editOrder: ReadonlyArray<LineFieldName>
+): DerivationResult {
+  // Need at least two fields edited to know what to derive.
+  const recent = editOrder.slice(0, 2);
+  if (recent.length < 2) return { field: null, value: null };
+
+  const allFields: LineFieldName[] = ['quantity', 'unitCost', 'totalCost'];
+  const target = allFields.find((f) => !recent.includes(f));
+  if (!target) return { field: null, value: null };
+
+  const { quantity, unitCost, totalCost } = values;
+
+  if (target === 'totalCost') {
+    // qty + unit → total
+    const next = quantity * unitCost;
+    return {
+      field: 'totalCost',
+      value: roundForField('totalCost', next),
+    };
+  }
+
+  if (target === 'unitCost') {
+    // qty + total → unit
+    if (quantity === 0) {
+      return {
+        field: null,
+        value: null,
+        hint: 'Enter a quantity above 0 to auto-compute unit cost.',
+      };
+    }
+    const next = totalCost / quantity;
+    return {
+      field: 'unitCost',
+      value: roundForField('unitCost', next),
+    };
+  }
+
+  // target === 'quantity' — unit + total → qty
+  if (unitCost === 0) {
+    return {
+      field: null,
+      value: null,
+      hint: 'Enter a unit cost above 0 to auto-compute quantity.',
+    };
+  }
+  const next = totalCost / unitCost;
+  return {
+    field: 'quantity',
+    value: roundForField('quantity', next),
+  };
+}
+
+/**
+ * Push a fresh edit to the front of the order, dedupe, and clamp to the
+ * three fields. Used by callers to maintain the per-row edit-order list.
+ */
+export function pushEdit(
+  current: ReadonlyArray<LineFieldName>,
+  field: LineFieldName
+): LineFieldName[] {
+  return [field, ...current.filter((f) => f !== field)].slice(0, 3);
+}


### PR DESCRIPTION
Closes #104.

## Why

Operators have to manually compute the third of three numerically-linked fields when entering an expense line: `total = quantity × unit_cost`. Error-prone, especially for spice-mix-style items at sub-pound unit cost (e.g. £0.0825/g).

## Change

Bidirectional auto-derive: any two of the three fields drive the third. Recompute target is the field with the **oldest edit timestamp** (or the un-edited field, if only two were ever touched).

### Acceptance criteria

| AC | Status |
|---|---|
| AC1: qty + unitCost → totalCost | ✅ |
| AC2: qty + totalCost → unitCost | ✅ |
| AC3: unitCost + totalCost → quantity | ✅ |
| AC4: edit auto-filled field → claims it; oldest recomputes | ✅ |
| AC5: qty = 0 → no divide, inline hint with `aria-live="polite"` | ✅ |
| AC6: Playwright e2e for all three paths | ⏸ **Deferred to follow-up** (see below) |
| AC7: No regression on existing save flow | ✅ Schema + save path untouched |

### Files

| File | Change |
|---|---|
| `lib/expense-line-derivation.ts` | **New** pure helper (`deriveLineField`, `pushEdit`, `roundForField`) |
| `__tests__/lib/expense-line-derivation.test.ts` | **New** — 17 vitest cases (AC matrix + override + divide-by-zero + rounding) |
| `hooks/use-expense-line-auto-derive.ts` | **New** hook owns per-row edit-order state + RHF `setValue` round-trip |
| `components/features/finance/expense-form.tsx` | Replace unidirectional `handleQtyOrCostChange` with `onFieldEdit`; add hint slot; `step="0.0001"` on Unit Cost |
| `components/features/finance/edit-pending-group-dialog.tsx` | Same wiring (single shared hook) |

### Rounding

| Field | Decimals | Why |
|---|---|---|
| `unitCost` | 4 | Sub-pound items (£0.0825/g for spice mixes) |
| `quantity` | 4 | Float-drift safety on `total ÷ unit` |
| `totalCost` | 2 | Currency |

Schema stays `Number`. Long-term `Decimal128` migration noted inline as a non-functional follow-up.

### Out of scope (deliberate per #104)

Pack-to-unit conversions, FX, CSV import.

## E2E coverage — deferred to follow-up

This PR was originally going to bundle an E2E backfill covering 10 audit gaps (including AC6 for #104). The specs were written but **not executed** locally; selectors are modelled on existing passing specs but may need a Playwright run to validate. To avoid shipping unvalidated tests, the E2E commit has been parked on `e2e/backfill-10-gaps` (branch pushed). A follow-up PR opens against develop once those tests have been run.

What's still on `e2e/backfill-10-gaps`:

- Auto-derive (AC6 for this PR / #104)
- #94 Edit Pending Group preserves `linkedInventoryId`
- #99 restock flips status from out-of-stock
- REQ-038 sellable restock + #97 unit lock UI
- #103 Express Create Order out-of-stock hard-block
- REQ-039 missing-cost column + Summary cell
- #91/#101 Menu Management hides kitchen stubs
- #101 Edit Kitchen adjust-stock + reason gate
- #100 `/api/public/menu` computed stockStatus contract

## Tests (this PR)

- **17 new vitest cases** on `deriveLineField`, `pushEdit`, `roundForField`
- Full vitest: **789 pass / 4 skipped**
- `tsc --noEmit` → 0 errors

## Test plan (post-merge on UAT)

- [ ] Add Expense → Qty=12, Unit Cost=4.50 → Total auto-fills to 54.00
- [ ] Add Expense → Qty=12, Total=54 → Unit Cost auto-fills to 4.5000
- [ ] Add Expense → Unit Cost=4.50, Total=54 → Qty auto-fills to 12
- [ ] Edit Pending Expense Group → same three checks above (same hook)
- [ ] Override the auto-filled field → it now drives the next derive; the oldest field recomputes
- [ ] Set Qty=0 with Total=54 → no NaN, amber inline hint appears
- [ ] Existing expense save flow still works (regression)

## Risk

**MEDIUM** — touches the expense entry form (financial-data path). Bounded scope (math + UI wiring; schema and save path untouched). Pure-helper has comprehensive unit coverage.