### PR TITLE
fix: auto-derive — strip zero-valued fields from edit order

### DIFF
--- a/__tests__/lib/expense-line-derivation.test.ts
+++ b/__tests__/lib/expense-line-derivation.test.ts
@@ -130,6 +130,22 @@ describe('deriveLineField — override / ordering rules', () => {
     expect(r.field).toBeNull();
     expect(r.value).toBeNull();
   });
+
+  it('UAT regression: cleared field drops out of order → target stays on the right field', () => {
+    // The hook now strips zero-valued fields from editOrder before
+    // calling deriveLineField. So a user scenario of: type 2 in qty,
+    // touch unitCost and clear it, type 70000 in total → final
+    // editOrder is ['totalCost', 'quantity'] (unitCost dropped by the
+    // hook's `fieldValue > 0` guard). deriveLineField with these inputs
+    // correctly targets unitCost.
+    const r = deriveLineField({ quantity: 2, unitCost: 0, totalCost: 70000 }, [
+      'totalCost',
+      'quantity',
+    ]);
+    expect(r.field).toBe('unitCost');
+    expect(r.value).toBe(35000);
+    expect(r.hint).toBeUndefined();
+  });
 });
 
 describe('deriveLineField — divide-by-zero guards (AC5)', () => {

--- a/hooks/use-expense-line-auto-derive.ts
+++ b/hooks/use-expense-line-auto-derive.ts
@@ -40,17 +40,34 @@ export function useExpenseLineAutoDerive({
 
   const onFieldEdit = useCallback(
     (index: number, field: LineFieldName) => {
+      const item = form.getValues(`items.${index}`) ?? {};
+      const q = Number(item.quantity ?? 0);
+      const u = Number(item.unitCost ?? 0);
+      const t = Number(item.totalCost ?? 0);
+      const fieldValue =
+        field === 'quantity' ? q : field === 'unitCost' ? u : t;
+
+      // Edits with value 0 don't claim the field. Two reasons:
+      //
+      // 1. Per AC4, "the next blank/oldest recomputes" — blank = 0 here.
+      //    A field at 0 is by definition the recompute target candidate,
+      //    not a user-asserted constraint.
+      // 2. Clearing a field (backspacing 0.50 to empty) fires onChange
+      //    with value 0; that's a clear, not a "set to zero" assertion.
+      //    Without this guard, deriveLineField targets the wrong field —
+      //    see the UAT bug where Qty=2 + Total=70000 with a cleared
+      //    Unit Cost field wrongly targeted Quantity (asking the user
+      //    to "Enter a unit cost above 0 to auto-compute quantity"
+      //    instead of computing Unit Cost = 35000).
       const prev = editOrderRef.current[index] ?? [];
-      const next = pushEdit(prev, field);
+      const next =
+        fieldValue > 0
+          ? pushEdit(prev, field)
+          : prev.filter((f) => f !== field);
       editOrderRef.current[index] = next;
 
-      const item = form.getValues(`items.${index}`) ?? {};
       const result = deriveLineField(
-        {
-          quantity: Number(item.quantity ?? 0),
-          unitCost: Number(item.unitCost ?? 0),
-          totalCost: Number(item.totalCost ?? 0),
-        },
+        { quantity: q, unitCost: u, totalCost: t },
         next
       );
 


### PR DESCRIPTION
Follow-up to #105. UAT walk surfaced a regression in the bidirectional auto-derive shipped yesterday.

## Symptom (from UAT screenshot 2026-05-22)

Operator entered:
- Qty = 2
- Unit Cost = 0 (had touched and cleared)
- Total = 70,000

Expected: Unit Cost auto-fills to 35,000.
Actual: Unit Cost stays at 0; amber hint reads **"Enter a unit cost above 0 to auto-compute quantity."**

The hint mentions *quantity*, which means deriveLineField targeted Quantity — i.e. it thought Unit Cost was a user-asserted edit, not the recompute target.

## Root cause

`useExpenseLineAutoDerive.onFieldEdit` called `pushEdit(field)` on every `onChange`, including the case where the resulting field value was 0. Clearing Unit Cost back to 0 (or just focusing + backspacing) fired onChange with value 0 → field landed in the edit-order with a zero value → displaced Quantity from the two-most-recent window → target snapped to Quantity.

Per AC4: "the next blank/oldest recomputes". A field at 0 is by definition **blank**, not a constraint. The hook was treating it as a constraint.

## Fix

One small change in `hooks/use-expense-line-auto-derive.ts`:

- If the field's resulting value is **> 0**, push it to the front of the edit order (as before).
- If the field's resulting value is **0**, **remove** it from the edit order — that's a clear, not an assertion.

This keeps the "blank/oldest" rule of AC4 honest.

## Tests

- New vitest case `'UAT regression: cleared field drops out of order → target stays on the right field'` pinning the exact scenario.
- Full suite: **790 pass / 4 skipped**.
- `tsc --noEmit` → 0 errors.

## Test plan (post-merge on UAT)

- [ ] Reproduce the original bug path: enter Qty=2, click Unit Cost and clear it, enter Total=70000 → Unit Cost now auto-fills to 35,000 instead of staying at 0.
- [ ] AC1/2/3 regression: all three two-of-three paths still derive correctly.
- [ ] AC4 regression: override the auto-filled field → next oldest still recomputes.
- [ ] AC5 regression: divide-by-zero hint still appears when qty=0 with non-zero total + user-set unit cost.

## Risk

LOW. One-line guard in the hook; pure-helper math untouched. Reversible via `git revert`.