### PR TITLE
refactor: simplify expense line auto-derive to qty + (unit OR total)

### DIFF
--- a/__tests__/lib/expense-line-derivation.test.ts
+++ b/__tests__/lib/expense-line-derivation.test.ts
@@ -1,15 +1,22 @@
 /**
- * Pure-helper coverage for the expense line {qty, unit, total}
- * auto-derivation logic.
+ * Pure-helper coverage for the simplified expense line auto-derive.
+ *
+ * Rules (#104):
+ * - `total = quantity × unitCost`. Qty is the anchor.
+ * - `computeTotal(q, u)` returns null when q ≤ 0; else q × u rounded to
+ *   2dp (currency).
+ * - `computeUnitCost(q, t)` returns null when q ≤ 0; else t / q rounded
+ *   to 4dp (sub-pound items).
+ * - `roundForField` rounding rules are unchanged from the earlier
+ *   implementation.
  *
  * Ref: #104
  */
 import { describe, it, expect } from 'vitest';
 import {
-  deriveLineField,
-  pushEdit,
+  computeTotal,
+  computeUnitCost,
   roundForField,
-  type LineFieldName,
 } from '@/lib/expense-line-derivation';
 
 describe('roundForField', () => {
@@ -30,151 +37,58 @@ describe('roundForField', () => {
   });
 });
 
-describe('pushEdit', () => {
-  it('moves a field to the front when edited', () => {
-    expect(pushEdit(['unitCost', 'quantity'], 'totalCost')).toEqual([
-      'totalCost',
-      'unitCost',
-      'quantity',
-    ]);
+describe('computeTotal', () => {
+  it('qty × unitCost rounded to 2dp', () => {
+    expect(computeTotal(2, 4.5)).toBe(9);
+    expect(computeTotal(12, 4.5)).toBe(54);
   });
 
-  it('dedupes when the same field is re-edited', () => {
-    expect(pushEdit(['quantity', 'unitCost'], 'quantity')).toEqual([
-      'quantity',
-      'unitCost',
-    ]);
+  it('handles fractional qty', () => {
+    expect(computeTotal(0.5, 4.5)).toBe(2.25);
   });
 
-  it('clamps to 3 fields max', () => {
-    const four = pushEdit(['unitCost', 'totalCost', 'quantity'], 'unitCost');
-    expect(four).toHaveLength(3);
-    expect(four[0]).toBe('unitCost');
+  it('returns null when qty is 0', () => {
+    expect(computeTotal(0, 4.5)).toBeNull();
   });
 
-  it('starts an empty order when nothing was edited yet', () => {
-    expect(pushEdit([], 'quantity')).toEqual(['quantity']);
-  });
-});
-
-describe('deriveLineField — happy paths', () => {
-  it('AC1: qty + unitCost edited → totalCost derives to qty × unit', () => {
-    const r = deriveLineField({ quantity: 12, unitCost: 4.5, totalCost: 0 }, [
-      'unitCost',
-      'quantity',
-    ]);
-    expect(r.field).toBe('totalCost');
-    expect(r.value).toBe(54);
+  it('returns null when qty is negative (defensive)', () => {
+    expect(computeTotal(-1, 4.5)).toBeNull();
   });
 
-  it('AC2: qty + totalCost edited → unitCost derives to total ÷ qty (4dp)', () => {
-    const r = deriveLineField({ quantity: 12, unitCost: 0, totalCost: 54 }, [
-      'totalCost',
-      'quantity',
-    ]);
-    expect(r.field).toBe('unitCost');
-    expect(r.value).toBe(4.5);
+  it('zero unit cost with positive qty yields total = 0', () => {
+    expect(computeTotal(5, 0)).toBe(0);
   });
 
-  it('AC3: unitCost + totalCost edited → quantity derives to total ÷ unit', () => {
-    const r = deriveLineField({ quantity: 0, unitCost: 4.5, totalCost: 54 }, [
-      'totalCost',
-      'unitCost',
-    ]);
-    expect(r.field).toBe('quantity');
-    expect(r.value).toBe(12);
-  });
-
-  it('handles sub-pound unit costs (eg spice mixes at £0.0825/g)', () => {
-    const r = deriveLineField(
-      { quantity: 0, unitCost: 0.0825, totalCost: 41.25 },
-      ['totalCost', 'unitCost']
-    );
-    expect(r.field).toBe('quantity');
-    expect(r.value).toBe(500);
+  it('does not throw on NaN inputs (returns null)', () => {
+    expect(computeTotal(Number.NaN, 4.5)).toBeNull();
   });
 });
 
-describe('deriveLineField — override / ordering rules', () => {
-  it('AC4: editing the auto-filled field claims it; next-oldest becomes target', () => {
-    // Round 1: user enters qty + unit → total derives.
-    let order: LineFieldName[] = pushEdit([], 'quantity');
-    order = pushEdit(order, 'unitCost');
-    expect(
-      deriveLineField({ quantity: 12, unitCost: 4.5, totalCost: 0 }, order)
-        .field
-    ).toBe('totalCost');
-
-    // Round 2: user manually overrides total → total now claimed; qty is
-    // oldest, so it becomes the new derive target.
-    order = pushEdit(order, 'totalCost');
-    const r = deriveLineField(
-      { quantity: 12, unitCost: 4.5, totalCost: 60 },
-      order
-    );
-    expect(r.field).toBe('quantity');
-    // 60 / 4.5 = 13.333… rounded to 4dp = 13.3333.
-    expect(r.value).toBe(13.3333);
+describe('computeUnitCost', () => {
+  it('total / qty rounded to 4dp', () => {
+    expect(computeUnitCost(2, 70000)).toBe(35000);
+    expect(computeUnitCost(12, 54)).toBe(4.5);
   });
 
-  it('returns no field when only one field has been edited', () => {
-    const r = deriveLineField({ quantity: 12, unitCost: 0, totalCost: 0 }, [
-      'quantity',
-    ]);
-    expect(r.field).toBeNull();
-    expect(r.value).toBeNull();
+  it('handles spice-mix corner case (sub-pound unit cost)', () => {
+    expect(computeUnitCost(500, 41.25)).toBe(0.0825);
   });
 
-  it('returns no field when no fields have been edited (initial blank state)', () => {
-    const r = deriveLineField({ quantity: 0, unitCost: 0, totalCost: 0 }, []);
-    expect(r.field).toBeNull();
-    expect(r.value).toBeNull();
+  it('returns null when qty is 0 (would divide by zero)', () => {
+    expect(computeUnitCost(0, 70000)).toBeNull();
   });
 
-  it('UAT regression: cleared field drops out of order → target stays on the right field', () => {
-    // The hook now strips zero-valued fields from editOrder before
-    // calling deriveLineField. So a user scenario of: type 2 in qty,
-    // touch unitCost and clear it, type 70000 in total → final
-    // editOrder is ['totalCost', 'quantity'] (unitCost dropped by the
-    // hook's `fieldValue > 0` guard). deriveLineField with these inputs
-    // correctly targets unitCost.
-    const r = deriveLineField({ quantity: 2, unitCost: 0, totalCost: 70000 }, [
-      'totalCost',
-      'quantity',
-    ]);
-    expect(r.field).toBe('unitCost');
-    expect(r.value).toBe(35000);
-    expect(r.hint).toBeUndefined();
-  });
-});
-
-describe('deriveLineField — divide-by-zero guards (AC5)', () => {
-  it('quantity = 0 with non-zero total → no unitCost derivation, hint shown', () => {
-    const r = deriveLineField({ quantity: 0, unitCost: 0, totalCost: 54 }, [
-      'totalCost',
-      'quantity',
-    ]);
-    expect(r.field).toBeNull();
-    expect(r.value).toBeNull();
-    expect(r.hint).toMatch(/quantity above 0/i);
+  it('returns null when qty is negative', () => {
+    expect(computeUnitCost(-1, 70000)).toBeNull();
   });
 
-  it('unitCost = 0 with non-zero total → no quantity derivation, hint shown', () => {
-    const r = deriveLineField({ quantity: 0, unitCost: 0, totalCost: 54 }, [
-      'totalCost',
-      'unitCost',
-    ]);
-    expect(r.field).toBeNull();
-    expect(r.value).toBeNull();
-    expect(r.hint).toMatch(/unit cost above 0/i);
+  it('zero total yields unit cost = 0', () => {
+    expect(computeUnitCost(5, 0)).toBe(0);
   });
 
-  it('qty = 0 and unit = 0 deriving total is allowed (total = 0, no divide)', () => {
-    const r = deriveLineField({ quantity: 0, unitCost: 0, totalCost: 0 }, [
-      'unitCost',
-      'quantity',
-    ]);
-    expect(r.field).toBe('totalCost');
-    expect(r.value).toBe(0);
+  it('UAT scenario: qty=2 + total=70000 → unitCost=35000', () => {
+    // The exact scenario the operator reported (#106 prompt). With
+    // qty=2 entered and total=70000 entered, unit cost auto-derives.
+    expect(computeUnitCost(2, 70000)).toBe(35000);
   });
 });

--- a/components/features/finance/edit-pending-group-dialog.tsx
+++ b/components/features/finance/edit-pending-group-dialog.tsx
@@ -252,14 +252,11 @@ export function EditPendingGroupDialog({
     0
   );
 
-  // #104 — bidirectional auto-derive across {quantity, unitCost,
-  // totalCost}. Same hook the Add Expense form uses; the math lives in
-  // lib/expense-line-derivation.ts.
-  const {
-    onFieldEdit,
-    getHint,
-    resetAll: resetAutoDerive,
-  } = useExpenseLineAutoDerive({ form });
+  // #104 — auto-derive across {quantity, unitCost, totalCost}. Same hook
+  // the Add Expense form uses; math lives in lib/expense-line-derivation.ts.
+  const { onFieldEdit, resetAll: resetAutoDerive } = useExpenseLineAutoDerive({
+    form,
+  });
 
   async function handleDelete() {
     setIsDeleting(true);
@@ -620,15 +617,6 @@ export function EditPendingGroupDialog({
                         </Button>
                       </div>
                     </div>
-                    {getHint(index) && (
-                      <p
-                        role="status"
-                        aria-live="polite"
-                        className="text-xs text-amber-700"
-                      >
-                        {getHint(index)}
-                      </p>
-                    )}
                     <InventoryLinkSection
                       form={form}
                       index={index}

--- a/components/features/finance/expense-form.tsx
+++ b/components/features/finance/expense-form.tsx
@@ -267,14 +267,13 @@ export function ExpenseForm({
   }
 
   // #104 — bidirectional auto-derive across {quantity, unitCost, totalCost}.
-  // The hook tracks which two fields the operator touched most recently
-  // and computes the third via deriveLineField. Replaces the old
-  // unidirectional `handleQtyOrCostChange` (qty + unit → total only).
-  const {
-    onFieldEdit,
-    getHint,
-    resetAll: resetAutoDerive,
-  } = useExpenseLineAutoDerive({ form });
+  // The hook tracks which of {unitCost, totalCost} was last edited per
+  // row and recomputes the other side when qty changes. Editing Unit
+  // Cost recomputes Total; editing Total recomputes Unit Cost. Qty is
+  // the anchor — if qty isn't > 0, nothing computes.
+  const { onFieldEdit, resetAll: resetAutoDerive } = useExpenseLineAutoDerive({
+    form,
+  });
 
   const groupTotal = items.reduce(
     (sum, item) => sum + (item.totalCost || 0),
@@ -664,21 +663,6 @@ export function ExpenseForm({
                         </Button>
                       </div>
                     </div>
-                    {/* #104 — auto-derive hint (e.g. "Enter a quantity
-                        above 0 to auto-compute unit cost"). Empty by
-                        default; populated by the hook only when the
-                        operator's entry pattern would otherwise hit a
-                        divide-by-zero. aria-live so screen readers hear
-                        the recalc / hint. */}
-                    {getHint(index) && (
-                      <p
-                        role="status"
-                        aria-live="polite"
-                        className="text-xs text-amber-700"
-                      >
-                        {getHint(index)}
-                      </p>
-                    )}
                     {/* Inventory linking — Direct Cost only. Shared with
                         the Edit Pending Group dialog via the same component. */}
                     <InventoryLinkSection

--- a/hooks/use-expense-line-auto-derive.ts
+++ b/hooks/use-expense-line-auto-derive.ts
@@ -1,27 +1,33 @@
 'use client';
 
 /**
- * Per-row {qty, unit cost, total} auto-derivation hook for the expense
- * line item editor.
+ * Per-row auto-derive hook for the expense line item editor.
  *
- * Both the Add Expense form (expense-form.tsx) and the Edit Pending
- * Expense Group dialog (edit-pending-group-dialog.tsx) wire the same
- * three inputs through this hook. The hook owns the per-row edit-order
- * tracking (which two fields the operator touched most recently) and
- * does the round-trip into react-hook-form's `setValue`. Math + rules
- * live in `lib/expense-line-derivation.ts`.
+ * Rules (#104, simplified):
+ * - Qty is the anchor — if qty is not > 0, nothing computes.
+ * - User edits Unit Cost → Total recomputes as qty × unitCost. Unit Cost
+ *   becomes "last edited of {unitCost, totalCost}".
+ * - User edits Total → Unit Cost recomputes as total / qty. Total becomes
+ *   "last edited".
+ * - User edits Qty → recompute whichever of {Unit Cost, Total} is NOT the
+ *   last-edited one (so the operator's most recent number stays stable).
+ *   If neither has been edited yet, no-op.
  *
- * Hint string for the divide-by-zero edge cases is exposed via
- * `getHint(index)` so the parent form can render a non-blocking
- * `aria-live="polite"` message under the affected input.
+ * State per row: just one bit — `lastEdited: 'unitCost' | 'totalCost' | null`.
+ * No edit-order array, no pushEdit. The zero-value-clear ambiguity the
+ * earlier 3-field tracker was vulnerable to (#106) doesn't exist here
+ * because Qty isn't tracked at all.
+ *
+ * Both `expense-form.tsx` and `edit-pending-group-dialog.tsx` call
+ * `onFieldEdit(index, field)` from each input's onChange.
  *
  * Ref: #104
  */
-import { useRef, useState, useCallback } from 'react';
+import { useRef, useCallback } from 'react';
 import type { UseFormReturn } from 'react-hook-form';
 import {
-  deriveLineField,
-  pushEdit,
+  computeTotal,
+  computeUnitCost,
   type LineFieldName,
 } from '@/lib/expense-line-derivation';
 
@@ -30,13 +36,14 @@ interface UseExpenseLineAutoDeriveOptions {
   form: UseFormReturn<any>;
 }
 
+type LastEdited = 'unitCost' | 'totalCost' | null;
+
 export function useExpenseLineAutoDerive({
   form,
 }: UseExpenseLineAutoDeriveOptions) {
-  // Per-row edit-order. Kept in a ref so it doesn't trigger renders;
-  // hint state lives in React state because the UI needs to react.
-  const editOrderRef = useRef<Record<number, LineFieldName[]>>({});
-  const [hints, setHints] = useState<Record<number, string | undefined>>({});
+  // Per-row last-edited tracker. Kept in a ref so updates don't trigger
+  // renders — the form re-renders on its own when we call setValue.
+  const lastEditedRef = useRef<Record<number, LastEdited>>({});
 
   const onFieldEdit = useCallback(
     (index: number, field: LineFieldName) => {
@@ -44,73 +51,61 @@ export function useExpenseLineAutoDerive({
       const q = Number(item.quantity ?? 0);
       const u = Number(item.unitCost ?? 0);
       const t = Number(item.totalCost ?? 0);
-      const fieldValue =
-        field === 'quantity' ? q : field === 'unitCost' ? u : t;
 
-      // Edits with value 0 don't claim the field. Two reasons:
-      //
-      // 1. Per AC4, "the next blank/oldest recomputes" — blank = 0 here.
-      //    A field at 0 is by definition the recompute target candidate,
-      //    not a user-asserted constraint.
-      // 2. Clearing a field (backspacing 0.50 to empty) fires onChange
-      //    with value 0; that's a clear, not a "set to zero" assertion.
-      //    Without this guard, deriveLineField targets the wrong field —
-      //    see the UAT bug where Qty=2 + Total=70000 with a cleared
-      //    Unit Cost field wrongly targeted Quantity (asking the user
-      //    to "Enter a unit cost above 0 to auto-compute quantity"
-      //    instead of computing Unit Cost = 35000).
-      const prev = editOrderRef.current[index] ?? [];
-      const next =
-        fieldValue > 0
-          ? pushEdit(prev, field)
-          : prev.filter((f) => f !== field);
-      editOrderRef.current[index] = next;
-
-      const result = deriveLineField(
-        { quantity: q, unitCost: u, totalCost: t },
-        next
-      );
-
-      // Update the hint (clears when there's nothing to say).
-      setHints((h) => ({ ...h, [index]: result.hint }));
-
-      if (result.field && result.value !== null) {
-        form.setValue(`items.${index}.${result.field}`, result.value, {
+      const setIfNumber = (
+        target: 'unitCost' | 'totalCost',
+        value: number | null
+      ) => {
+        if (value === null) return;
+        form.setValue(`items.${index}.${target}`, value, {
           shouldDirty: true,
           shouldValidate: false,
           shouldTouch: false,
         });
+      };
+
+      if (field === 'unitCost') {
+        // Operator asserted Unit Cost. Recompute Total.
+        setIfNumber('totalCost', computeTotal(q, u));
+        lastEditedRef.current[index] = 'unitCost';
+        return;
+      }
+
+      if (field === 'totalCost') {
+        // Operator asserted Total. Recompute Unit Cost.
+        setIfNumber('unitCost', computeUnitCost(q, t));
+        lastEditedRef.current[index] = 'totalCost';
+        return;
+      }
+
+      // field === 'quantity'. Recompute the NON-last-edited of
+      // {unitCost, totalCost} so the operator's last-asserted figure
+      // stays stable. If neither has been edited yet, no-op.
+      const last = lastEditedRef.current[index] ?? null;
+      if (last === 'unitCost') {
+        setIfNumber('totalCost', computeTotal(q, u));
+      } else if (last === 'totalCost') {
+        setIfNumber('unitCost', computeUnitCost(q, t));
       }
     },
     [form]
   );
 
-  const getHint = useCallback(
-    (index: number): string | undefined => hints[index],
-    [hints]
-  );
-
   /**
    * Clears the tracking for an index — call when removing a row so a
-   * later row that re-uses that index doesn't inherit stale edits.
+   * later row that re-uses that index doesn't inherit stale state.
    */
   const resetRow = useCallback((index: number) => {
-    delete editOrderRef.current[index];
-    setHints((h) => {
-      const next = { ...h };
-      delete next[index];
-      return next;
-    });
+    delete lastEditedRef.current[index];
   }, []);
 
   /**
-   * Clears all edit tracking — call from the dialog's open effect so a
-   * fresh session doesn't inherit history from the previous open.
+   * Clears all tracking — call from the dialog's open effect so a fresh
+   * session doesn't inherit state from the previous open.
    */
   const resetAll = useCallback(() => {
-    editOrderRef.current = {};
-    setHints({});
+    lastEditedRef.current = {};
   }, []);
 
-  return { onFieldEdit, getHint, resetRow, resetAll };
+  return { onFieldEdit, resetRow, resetAll };
 }

--- a/lib/expense-line-derivation.ts
+++ b/lib/expense-line-derivation.ts
@@ -1,42 +1,20 @@
 /**
- * Auto-derivation for the expense line item triple {quantity, unitCost, totalCost}.
+ * Auto-derivation for the expense line {quantity, unitCost, totalCost}
+ * triple. `total = quantity × unitCost` — given qty plus either of the
+ * other two, the third is derivable.
  *
- * total = quantity × unitCost — given any two, the third is derivable.
- * Operators currently have to compute the third by hand, which is
- * error-prone (especially for spice-mix-style line items with sub-pound
- * unit costs).
+ * Operators enter qty first, then either Unit Cost OR Total. The hook
+ * (`hooks/use-expense-line-auto-derive.ts`) tracks which of {Unit Cost,
+ * Total} was last edited and uses that single bit to decide which field
+ * to recompute on a subsequent qty change. Math + rules live here;
+ * state + DOM round-trip live in the hook.
  *
- * This file is the pure logic: take the current values + which fields
- * the user has touched recently, return the target field to recompute
- * and its new value. The hook in `hooks/use-expense-line-auto-derive.ts`
- * owns the per-row edit-tracking state and wires this into the form;
- * the form itself just calls `onFieldEdit` from each input's onChange.
- *
- * Out of scope (see #104): pack-to-unit conversions, FX, CSV import.
+ * Out of scope: pack-to-unit conversions, FX, CSV import.
  *
  * Ref: #104
  */
 
 export type LineFieldName = 'quantity' | 'unitCost' | 'totalCost';
-
-export interface LineValues {
-  quantity: number;
-  unitCost: number;
-  totalCost: number;
-}
-
-export interface DerivationResult {
-  /** Which field to update (null if no derivation possible from the inputs). */
-  field: LineFieldName | null;
-  /** The computed value to set (matched to `field`). Always rounded. */
-  value: number | null;
-  /**
-   * Set when the inputs prevent derivation but the operator would
-   * benefit from knowing why (e.g. quantity = 0 makes unit cost
-   * undefined). UI surfaces this as a non-blocking inline hint.
-   */
-  hint?: string;
-}
 
 /**
  * Round to the field's stored precision.
@@ -59,85 +37,29 @@ export function roundForField(field: LineFieldName, value: number): number {
 }
 
 /**
- * Given the order in which the user edited the three fields (most-recent
- * first) and the current values, derive the target field to recompute
- * and its new value.
+ * Compute Total from quantity × unitCost.
  *
- * Rules (from #104 AC):
- * 1. The two most-recently-edited fields drive the third.
- * 2. If only one field has been edited, no derivation yet (returns
- *    `{ field: null, value: null }`).
- * 3. Operator override of an auto-filled value claims that field (it
- *    becomes most-recent) and the next-oldest becomes the recompute
- *    target.
- * 4. Quantity = 0 cannot divide — return a hint, no field update.
- * 5. Unit cost = 0 with non-zero total cannot divide for quantity —
- *    same hint pattern.
- *
- * The function does NOT touch any state of its own. Tests should
- * exercise the matrix directly.
+ * Returns `null` when qty is non-positive — the caller should leave the
+ * Total field untouched. Qty is the anchor; nothing computes without it.
  */
-export function deriveLineField(
-  values: LineValues,
-  editOrder: ReadonlyArray<LineFieldName>
-): DerivationResult {
-  // Need at least two fields edited to know what to derive.
-  const recent = editOrder.slice(0, 2);
-  if (recent.length < 2) return { field: null, value: null };
-
-  const allFields: LineFieldName[] = ['quantity', 'unitCost', 'totalCost'];
-  const target = allFields.find((f) => !recent.includes(f));
-  if (!target) return { field: null, value: null };
-
-  const { quantity, unitCost, totalCost } = values;
-
-  if (target === 'totalCost') {
-    // qty + unit → total
-    const next = quantity * unitCost;
-    return {
-      field: 'totalCost',
-      value: roundForField('totalCost', next),
-    };
-  }
-
-  if (target === 'unitCost') {
-    // qty + total → unit
-    if (quantity === 0) {
-      return {
-        field: null,
-        value: null,
-        hint: 'Enter a quantity above 0 to auto-compute unit cost.',
-      };
-    }
-    const next = totalCost / quantity;
-    return {
-      field: 'unitCost',
-      value: roundForField('unitCost', next),
-    };
-  }
-
-  // target === 'quantity' — unit + total → qty
-  if (unitCost === 0) {
-    return {
-      field: null,
-      value: null,
-      hint: 'Enter a unit cost above 0 to auto-compute quantity.',
-    };
-  }
-  const next = totalCost / unitCost;
-  return {
-    field: 'quantity',
-    value: roundForField('quantity', next),
-  };
+export function computeTotal(
+  quantity: number,
+  unitCost: number
+): number | null {
+  if (!(quantity > 0)) return null;
+  return roundForField('totalCost', quantity * unitCost);
 }
 
 /**
- * Push a fresh edit to the front of the order, dedupe, and clamp to the
- * three fields. Used by callers to maintain the per-row edit-order list.
+ * Compute Unit Cost from totalCost / quantity.
+ *
+ * Returns `null` when qty is non-positive — division would be undefined
+ * or infinite, and the operator hasn't anchored the line yet.
  */
-export function pushEdit(
-  current: ReadonlyArray<LineFieldName>,
-  field: LineFieldName
-): LineFieldName[] {
-  return [field, ...current.filter((f) => f !== field)].slice(0, 3);
+export function computeUnitCost(
+  quantity: number,
+  totalCost: number
+): number | null {
+  if (!(quantity > 0)) return null;
+  return roundForField('unitCost', totalCost / quantity);
 }


### PR DESCRIPTION
Supersedes PRs #105 + #106 (both merged but over-engineered). Closes the loop on the #104 conversation per the simpler model the user landed on.

## Why

PR #105 shipped a bidirectional auto-derive that tracked edit order across all three fields, supported three derivation directions, and had override-claim semantics. UAT surfaced a real regression (PR #106, zero-value-clear ambiguity in the edit-order tracker). Both designs are more than the operator actually wanted.

The user's actual flow is simpler:

- Qty is the anchor — entered first.
- Then either Unit Cost OR Total — the other one auto-fills.

That's it. No third direction. No override claim. No edit-order list.

## Behaviour

Single bit of state per row: which of {Unit Cost, Total} was last edited.

| User edits | What happens |
|---|---|
| **Unit Cost** | `Total = qty × unitCost` (if qty > 0). Unit Cost marked as last-edited. |
| **Total** | `Unit Cost = total / qty` (if qty > 0). Total marked as last-edited. |
| **Qty** | Recompute whichever of {Unit Cost, Total} is NOT the last-edited (so the operator's last-stated number stays stable). If neither has been edited yet, no-op. |
| `qty <= 0` | Nothing computes. Silent. |

The #106 bug (zero-value-clear ambiguity) **cannot occur** here because Qty isn't tracked at all — only the two-way last-edited bit between Unit Cost and Total matters.

## Files

**Modified:**
- `lib/expense-line-derivation.ts` — replaced `deriveLineField` + `pushEdit` with `computeTotal` + `computeUnitCost`. Kept `roundForField` unchanged.
- `hooks/use-expense-line-auto-derive.ts` — collapsed to one-bit-per-row state. No more `getHint` / hint state.
- `components/features/finance/expense-form.tsx` — removed the hint render slot. Kept `onFieldEdit` wiring on all three inputs.
- `components/features/finance/edit-pending-group-dialog.tsx` — same.
- `__tests__/lib/expense-line-derivation.test.ts` — rewrote against the new helper shape (14 cases).

**Net diff:** **5 files, 143 insertions(+), 340 deletions(-)**. Removing complexity feels good.

## Tests

- 14 new vitest cases covering `computeTotal` / `computeUnitCost` happy paths + edge cases (qty=0, qty<0, NaN inputs, fractional qty, spice-mix sub-pound unit cost, zero values), plus the operator's UAT scenario (qty=2 + total=70000 → unit=35000) as an explicit regression guard.
- Full suite: **787 pass / 4 skipped**.
- `tsc --noEmit` → 0 errors.

## Test plan (post-merge on UAT)

- [ ] Qty=2, Unit Cost=4.50 → Total auto-fills to 9.00 (existing prod behaviour, no regression).
- [ ] Qty=2, Total=70000 → Unit Cost auto-fills to 35000 (the new direction).
- [ ] From state (2): change Qty to 4 → Unit Cost recomputes to 17500 (Total stays at 70000 — it was last-edited).
- [ ] From state (1): change Qty to 4 → Total recomputes to 18.00 (Unit Cost stays at 4.50 — it was last-edited).
- [ ] Qty=0 with anything in Total → no computation, no NaN, no errors.
- [ ] Same six checks on Edit Pending Expense Group dialog (shared hook).

## Risk

LOW. Net deletion: -340 lines, +143. Behaviour is a strict subset of what was on develop. Reversible via `git revert`.