### PR TITLE
release: Tabs Management — pagination + saved filter

### DIFF
--- a/__tests__/services/tab-service.pagination.test.ts
+++ b/__tests__/services/tab-service.pagination.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Service-level coverage for the paginated tabs list + stats query.
+ *
+ * Mongoose chain is mocked: `TabModel.find(q).sort().skip().limit().lean()`
+ * resolves to the rows; `countDocuments(q)` resolves to the total;
+ * `aggregate(pipeline)` resolves to the orders-sum aggregate.
+ *
+ * Asserts:
+ * - `listAllTabsWithFilters` passes skip + limit through to the chain
+ * - returned shape is `{ tabs, total }`
+ * - `getTabStats` runs three counts in parallel and returns the live
+ *   totals (independent of any filter/page state)
+ *
+ * Ref: Tabs Management performance work.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/mongodb', () => ({
+  default: vi.fn(),
+  connectDB: vi.fn(),
+}));
+
+const limitSpy = vi.fn();
+const skipSpy = vi.fn();
+const sortSpy = vi.fn();
+const leanSpy = vi.fn();
+const findSpy = vi.fn();
+const countDocumentsSpy = vi.fn();
+const aggregateSpy = vi.fn();
+
+function resetChain(rows: unknown[]) {
+  // Build a chainable mock that exposes the spies as call sites but
+  // ultimately resolves the .lean() to the provided rows.
+  leanSpy.mockResolvedValue(rows);
+  limitSpy.mockReturnValue({ lean: leanSpy });
+  skipSpy.mockReturnValue({ limit: limitSpy, lean: leanSpy });
+  sortSpy.mockReturnValue({ skip: skipSpy, lean: leanSpy });
+  findSpy.mockReturnValue({ sort: sortSpy });
+}
+
+vi.mock('@/models/tab-model', () => ({
+  default: {
+    find: (...args: unknown[]) => findSpy(...args),
+    countDocuments: (...args: unknown[]) => countDocumentsSpy(...args),
+    aggregate: (...args: unknown[]) => aggregateSpy(...args),
+  },
+}));
+
+import { TabService } from '@/services/tab-service';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('TabService.listAllTabsWithFilters — pagination', () => {
+  it('passes skip + limit to the chain and returns { tabs, total }', async () => {
+    const stubRows = [{ _id: 'a' }, { _id: 'b' }];
+    resetChain(stubRows);
+    countDocumentsSpy.mockResolvedValue(42);
+
+    const result = await TabService.listAllTabsWithFilters({
+      statuses: ['open'],
+      skip: 50,
+      limit: 25,
+    });
+
+    expect(findSpy).toHaveBeenCalledWith({ status: { $in: ['open'] } });
+    expect(sortSpy).toHaveBeenCalledWith({ openedAt: -1 });
+    expect(skipSpy).toHaveBeenCalledWith(50);
+    expect(limitSpy).toHaveBeenCalledWith(25);
+    expect(countDocumentsSpy).toHaveBeenCalledWith({
+      status: { $in: ['open'] },
+    });
+    expect(result.tabs).toHaveLength(2);
+    expect(result.total).toBe(42);
+  });
+
+  it('legacy callers without pagination still get the whole result set', async () => {
+    const stubRows = new Array(10).fill(null).map((_, i) => ({ _id: i }));
+    resetChain(stubRows);
+    countDocumentsSpy.mockResolvedValue(10);
+
+    const result = await TabService.listAllTabsWithFilters({});
+
+    // No skip/limit on the chain when neither is provided.
+    expect(skipSpy).not.toHaveBeenCalled();
+    expect(limitSpy).not.toHaveBeenCalled();
+    expect(result.tabs).toHaveLength(10);
+    expect(result.total).toBe(10);
+  });
+
+  it('reconciled filter narrows the count query the same way as the find query', async () => {
+    resetChain([]);
+    countDocumentsSpy.mockResolvedValue(0);
+
+    await TabService.listAllTabsWithFilters({
+      reconciled: 'reconciled',
+      skip: 0,
+      limit: 25,
+    });
+
+    expect(findSpy).toHaveBeenCalledWith({ reconciled: true });
+    expect(countDocumentsSpy).toHaveBeenCalledWith({ reconciled: true });
+  });
+
+  it('date-range filter applies to both find and countDocuments', async () => {
+    resetChain([]);
+    countDocumentsSpy.mockResolvedValue(0);
+
+    const startDate = new Date('2026-05-01T00:00:00Z');
+    const endDate = new Date('2026-05-15T00:00:00Z');
+    await TabService.listAllTabsWithFilters({
+      startDate,
+      endDate,
+      skip: 0,
+      limit: 25,
+    });
+
+    const findCallArgs = findSpy.mock.calls[0][0];
+    const countCallArgs = countDocumentsSpy.mock.calls[0][0];
+    expect(findCallArgs).toMatchObject({
+      openedAt: { $gte: startDate },
+    });
+    expect(countCallArgs).toMatchObject({
+      openedAt: { $gte: startDate },
+    });
+  });
+});
+
+describe('TabService.getTabStats', () => {
+  it('returns the three live totals computed in parallel', async () => {
+    countDocumentsSpy
+      .mockResolvedValueOnce(1566) // totalTabs
+      .mockResolvedValueOnce(132); // totalOpenTabs
+    aggregateSpy.mockResolvedValueOnce([{ _id: null, sum: 2368 }]);
+
+    const stats = await TabService.getTabStats();
+
+    expect(stats).toEqual({
+      totalTabs: 1566,
+      totalOpenTabs: 132,
+      totalOrders: 2368,
+    });
+
+    // First countDocuments is the unfiltered total.
+    expect(countDocumentsSpy.mock.calls[0][0]).toEqual({});
+    // Second is the open-only filter.
+    expect(countDocumentsSpy.mock.calls[1][0]).toEqual({ status: 'open' });
+    // Aggregate sums orders.length across every tab.
+    expect(aggregateSpy).toHaveBeenCalled();
+  });
+
+  it('handles the empty-database case (no orders aggregate row)', async () => {
+    countDocumentsSpy.mockResolvedValueOnce(0).mockResolvedValueOnce(0);
+    aggregateSpy.mockResolvedValueOnce([]);
+
+    const stats = await TabService.getTabStats();
+
+    expect(stats).toEqual({
+      totalTabs: 0,
+      totalOpenTabs: 0,
+      totalOrders: 0,
+    });
+  });
+});

--- a/app/actions/tabs/tab-actions.ts
+++ b/app/actions/tabs/tab-actions.ts
@@ -322,7 +322,9 @@ export async function getDashboardFilteredTabsAction(filters: {
   startDate?: string;
   endDate?: string;
   reconciled?: 'all' | 'reconciled' | 'not-reconciled';
-}): Promise<ActionResult<{ tabs: ITab[] }>> {
+  skip?: number;
+  limit?: number;
+}): Promise<ActionResult<{ tabs: ITab[]; total: number }>> {
   try {
     const cookieStore = await cookies();
     const session = await getIronSession<SessionData>(
@@ -340,16 +342,18 @@ export async function getDashboardFilteredTabsAction(filters: {
       };
     }
 
-    const tabs = await TabService.listAllTabsWithFilters({
+    const { tabs, total } = await TabService.listAllTabsWithFilters({
       statuses: filters.statuses,
       startDate: filters.startDate ? new Date(filters.startDate) : undefined,
       endDate: filters.endDate ? new Date(filters.endDate) : undefined,
       reconciled: filters.reconciled,
+      skip: filters.skip,
+      limit: filters.limit,
     });
 
     return {
       success: true,
-      data: { tabs },
+      data: { tabs, total },
     };
   } catch (error) {
     console.error('Error getting filtered tabs:', error);

--- a/app/dashboard/orders/tabs/page.tsx
+++ b/app/dashboard/orders/tabs/page.tsx
@@ -1,15 +1,29 @@
 /**
  * @requirement REQ-012 - Pass partial payments data to tabs list
  * @requirement REQ-023 - Pass Staff Pot balance to tabs list
+ *
+ * Renders the Tabs Management dashboard. Pages 25 tabs at a time
+ * (server-side) so the page stays fast at >1500 tabs. Stats are
+ * computed server-side independent of the current page / filter.
  */
 import { TabService } from '@/services';
 import { getStaffPotDataAction } from '@/app/actions/admin/staff-pot-actions';
 import { DashboardTabsListClient } from '@/components/features/admin/tabs/dashboard-tabs-list-client';
 
-async function getAllTabs() {
-  const tabs = await TabService.listAllTabsWithFilters({});
+const PAGE_SIZE = 25;
 
-  // Fully serialize tabs to plain objects
+async function getInitialPage() {
+  // First-visit default: open tabs only, newest first, first 25.
+  // Operator can override via the filter UI which writes to localStorage
+  // and persists across visits. The localStorage default-fallback also
+  // hits this same "status: open" implicit default — see the filter
+  // component for details.
+  const { tabs, total } = await TabService.listAllTabsWithFilters({
+    statuses: ['open'],
+    skip: 0,
+    limit: PAGE_SIZE,
+  });
+
   const serializedTabs = tabs.map((tab: any) => ({
     _id: tab._id.toString(),
     tabNumber: tab.tabNumber,
@@ -44,12 +58,13 @@ async function getAllTabs() {
     reconciled: tab.reconciled || false,
   }));
 
-  return { tabs: serializedTabs };
+  return { tabs: serializedTabs, total };
 }
 
 export default async function DashboardTabsPage() {
-  const [{ tabs }, staffPotResult] = await Promise.all([
-    getAllTabs(),
+  const [{ tabs, total }, stats, staffPotResult] = await Promise.all([
+    getInitialPage(),
+    TabService.getTabStats(),
     getStaffPotDataAction().catch(() => ({ success: false as const })),
   ]);
 
@@ -70,6 +85,9 @@ export default async function DashboardTabsPage() {
 
       <DashboardTabsListClient
         initialTabs={tabs}
+        initialTotal={total}
+        pageSize={PAGE_SIZE}
+        stats={stats}
         staffPotBalance={staffPotBalance}
       />
     </div>

--- a/components/features/admin/tabs/dashboard-tabs-filter.tsx
+++ b/components/features/admin/tabs/dashboard-tabs-filter.tsx
@@ -3,10 +3,10 @@
  */
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { DateRange } from 'react-day-picker';
 import { format } from 'date-fns';
-import { Filter, X } from 'lucide-react';
+import { Filter, Save, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
@@ -31,6 +31,48 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
+import { useToast } from '@/hooks/use-toast';
+
+/**
+ * Persisted filter shape. Stored under this localStorage key per
+ * browser. Date range can't be serialised reliably across visits (and
+ * "last week's date range" is rarely the same thing twice), so only
+ * statuses + reconciliation persist; the date range resets each session.
+ */
+const STORAGE_KEY = 'wawagardenbar.tabs-filter';
+const DEFAULT_STATUSES = ['open'];
+const DEFAULT_RECONCILED: 'all' | 'reconciled' | 'not-reconciled' = 'all';
+
+interface SavedFilter {
+  statuses: string[];
+  reconciled: 'all' | 'reconciled' | 'not-reconciled';
+}
+
+function readSavedFilter(): SavedFilter {
+  if (typeof window === 'undefined') {
+    return { statuses: DEFAULT_STATUSES, reconciled: DEFAULT_RECONCILED };
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return { statuses: DEFAULT_STATUSES, reconciled: DEFAULT_RECONCILED };
+    }
+    const parsed = JSON.parse(raw) as Partial<SavedFilter>;
+    return {
+      statuses: Array.isArray(parsed.statuses)
+        ? parsed.statuses.filter((s) => typeof s === 'string')
+        : DEFAULT_STATUSES,
+      reconciled:
+        parsed.reconciled === 'reconciled' ||
+        parsed.reconciled === 'not-reconciled' ||
+        parsed.reconciled === 'all'
+          ? parsed.reconciled
+          : DEFAULT_RECONCILED,
+    };
+  } catch {
+    return { statuses: DEFAULT_STATUSES, reconciled: DEFAULT_RECONCILED };
+  }
+}
 
 interface DashboardTabsFilterProps {
   onFilterChange: (filters: {
@@ -56,12 +98,42 @@ const TAB_STATUSES = [
 export function DashboardTabsFilter({
   onFilterChange,
 }: DashboardTabsFilterProps) {
+  const { toast } = useToast();
   const [isOpen, setIsOpen] = useState(false);
-  const [selectedStatuses, setSelectedStatuses] = useState<string[]>([]);
+  // Hydrate from localStorage on mount. SSR-safe via the typeof window
+  // guard inside readSavedFilter().
+  const initialFilter = readSavedFilter();
+  const [selectedStatuses, setSelectedStatuses] = useState<string[]>(
+    initialFilter.statuses
+  );
   const [dateRange, setDateRange] = useState<DateRange | undefined>();
   const [reconciled, setReconciled] = useState<
     'all' | 'reconciled' | 'not-reconciled'
-  >('all');
+  >(initialFilter.reconciled);
+
+  // Track whether the saved filter has been emitted to the parent yet.
+  // On first mount we tell the parent about the persisted filter so the
+  // page reloads with it applied even if the server-side default-paint
+  // doesn't match.
+  const hasEmittedInitial = useRef(false);
+  useEffect(() => {
+    if (hasEmittedInitial.current) return;
+    hasEmittedInitial.current = true;
+    // Only emit on mount if the persisted filter differs from the
+    // server's first-paint default (`statuses: ['open'], reconciled: 'all'`).
+    const matchesDefault =
+      initialFilter.statuses.length === 1 &&
+      initialFilter.statuses[0] === 'open' &&
+      initialFilter.reconciled === 'all';
+    if (!matchesDefault) {
+      onFilterChange({
+        statuses: initialFilter.statuses,
+        dateRange: undefined,
+        reconciled: initialFilter.reconciled,
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleStatusChange = (status: string, checked: boolean) => {
     const newStatuses = checked
@@ -100,6 +172,58 @@ export function DashboardTabsFilter({
       statuses: [],
       dateRange: undefined,
       reconciled: 'all',
+    });
+  };
+
+  /**
+   * Persist the current filter to localStorage so the next visit to
+   * this page reloads with the same filter applied. Date range is
+   * deliberately excluded — "last Monday" rarely means the same thing
+   * across visits.
+   */
+  const handleSaveFilter = () => {
+    if (typeof window === 'undefined') return;
+    try {
+      const payload: SavedFilter = {
+        statuses: selectedStatuses,
+        reconciled,
+      };
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+      toast({
+        title: 'Filter saved',
+        description: 'This page will reload with your filter next visit.',
+      });
+    } catch (err) {
+      toast({
+        title: 'Could not save filter',
+        description: err instanceof Error ? err.message : 'Unknown error',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  /**
+   * Drop the saved filter and revert to the implicit default (open tabs).
+   */
+  const handleResetSaved = () => {
+    if (typeof window !== 'undefined') {
+      try {
+        window.localStorage.removeItem(STORAGE_KEY);
+      } catch {
+        /* localStorage unavailable; default still applies in-memory */
+      }
+    }
+    setSelectedStatuses(DEFAULT_STATUSES);
+    setDateRange(undefined);
+    setReconciled(DEFAULT_RECONCILED);
+    onFilterChange({
+      statuses: DEFAULT_STATUSES,
+      dateRange: undefined,
+      reconciled: DEFAULT_RECONCILED,
+    });
+    toast({
+      title: 'Default restored',
+      description: 'Showing open tabs (the default).',
     });
   };
 
@@ -240,6 +364,29 @@ export function DashboardTabsFilter({
                 )}
               </div>
             )}
+
+            {/* Save / Reset — persist the current filter to localStorage
+                so the page reloads with it on the next visit. Date
+                range is deliberately not persisted. */}
+            <div className="flex items-center gap-2 pt-3 border-t">
+              <Button
+                variant="default"
+                size="sm"
+                onClick={handleSaveFilter}
+                data-testid="save-filter"
+              >
+                <Save className="h-4 w-4 mr-1" />
+                Save filter
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleResetSaved}
+                data-testid="reset-filter"
+              >
+                Reset to default (open tabs)
+              </Button>
+            </div>
           </CardContent>
         </CollapsibleContent>
       </Collapsible>

--- a/components/features/admin/tabs/dashboard-tabs-list-client.tsx
+++ b/components/features/admin/tabs/dashboard-tabs-list-client.tsx
@@ -17,6 +17,8 @@ import {
   CheckCircle2,
   FolderOpen,
   Plus,
+  ChevronLeft,
+  ChevronRight,
 } from 'lucide-react';
 import { Checkbox } from '@/components/ui/checkbox';
 import Link from 'next/link';
@@ -56,18 +58,34 @@ interface Tab {
 
 interface DashboardTabsListClientProps {
   initialTabs: Tab[];
+  initialTotal: number;
+  pageSize: number;
+  stats: {
+    totalTabs: number;
+    totalOpenTabs: number;
+    totalOrders: number;
+  };
   staffPotBalance: number;
 }
 
 /**
- * Client component for dashboard tabs list with filtering
+ * Client component for dashboard tabs list with server-paginated
+ * filtering. The filter component is the single source of truth for the
+ * current filter (it also persists to localStorage); this component
+ * reacts to filter / page changes and fetches the matching slice from
+ * the server.
  */
 export function DashboardTabsListClient({
   initialTabs,
+  initialTotal,
+  pageSize,
+  stats,
   staffPotBalance,
 }: DashboardTabsListClientProps) {
   const { toast } = useToast();
   const [tabs, setTabs] = useState<Tab[]>(initialTabs);
+  const [total, setTotal] = useState<number>(initialTotal);
+  const [page, setPage] = useState<number>(1);
   const [isLoading, setIsLoading] = useState(false);
   const [selectedTab, setSelectedTab] = useState<Tab | null>(null);
   const [showPayDialog, setShowPayDialog] = useState(false);
@@ -76,29 +94,30 @@ export function DashboardTabsListClient({
     dateRange?: DateRange;
     reconciled?: 'all' | 'reconciled' | 'not-reconciled';
   }>({
-    statuses: [],
+    // Match the server's first-paint default so an immediate page change
+    // (without a filter touch) still fires the right query.
+    statuses: ['open'],
     dateRange: undefined,
     reconciled: undefined,
   });
 
-  const handleFilterChange = async (filters: {
-    statuses: string[];
-    dateRange?: DateRange;
-    reconciled?: 'all' | 'reconciled' | 'not-reconciled';
-  }) => {
-    setCurrentFilters(filters);
+  // Single fetcher used by both filter and page changes.
+  const fetchPage = async (
+    filters: typeof currentFilters,
+    nextPage: number
+  ) => {
     setIsLoading(true);
-
     try {
       const result = await getDashboardFilteredTabsAction({
         statuses: filters.statuses.length > 0 ? filters.statuses : undefined,
         startDate: filters.dateRange?.from?.toISOString(),
         endDate: filters.dateRange?.to?.toISOString(),
         reconciled: filters.reconciled,
+        skip: (nextPage - 1) * pageSize,
+        limit: pageSize,
       });
 
       if (result.success && result.data) {
-        // Serialize tabs to match Tab interface
         const serializedTabs = result.data.tabs.map((tab: any) => ({
           _id: tab._id.toString(),
           tabNumber: tab.tabNumber,
@@ -122,6 +141,8 @@ export function DashboardTabsListClient({
           reconciled: tab.reconciled || false,
         }));
         setTabs(serializedTabs);
+        setTotal(result.data.total);
+        setPage(nextPage);
       } else {
         toast({
           title: 'Error',
@@ -139,6 +160,20 @@ export function DashboardTabsListClient({
       setIsLoading(false);
     }
   };
+
+  const handleFilterChange = async (filters: {
+    statuses: string[];
+    dateRange?: DateRange;
+    reconciled?: 'all' | 'reconciled' | 'not-reconciled';
+  }) => {
+    setCurrentFilters(filters);
+    // Filter change resets pagination to page 1.
+    await fetchPage(filters, 1);
+  };
+
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const canPrev = page > 1;
+  const canNext = page < totalPages;
 
   const getStatusBadge = (status: string) => {
     const variants: Record<
@@ -160,12 +195,9 @@ export function DashboardTabsListClient({
     );
   };
 
-  const totalOrders = tabs.reduce((sum, tab) => sum + tab.orders.length, 0);
-  const totalOpenTabs = tabs.filter((tab) => tab.status === 'open').length;
-
   return (
     <div className="space-y-6" data-testid="tabs-dashboard">
-      {/* Stats Cards */}
+      {/* Stats Cards — server-computed, independent of filter/page state */}
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
@@ -173,7 +205,7 @@ export function DashboardTabsListClient({
             <Receipt className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{tabs.length}</div>
+            <div className="text-2xl font-bold">{stats.totalTabs}</div>
           </CardContent>
         </Card>
 
@@ -183,7 +215,7 @@ export function DashboardTabsListClient({
             <Receipt className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{totalOrders}</div>
+            <div className="text-2xl font-bold">{stats.totalOrders}</div>
           </CardContent>
         </Card>
 
@@ -195,7 +227,7 @@ export function DashboardTabsListClient({
             <FolderOpen className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{totalOpenTabs}</div>
+            <div className="text-2xl font-bold">{stats.totalOpenTabs}</div>
             <p className="text-xs text-muted-foreground mt-1">
               Currently active
             </p>
@@ -358,6 +390,40 @@ export function DashboardTabsListClient({
                 </div>
               ))}
             </div>
+            {/* Pagination — server-paginated 25 per page. */}
+            {total > pageSize && (
+              <div className="flex items-center justify-between pt-4 mt-4 border-t">
+                <p className="text-sm text-muted-foreground">
+                  Showing {(page - 1) * pageSize + 1}–
+                  {Math.min(page * pageSize, total)} of {total}
+                </p>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => fetchPage(currentFilters, page - 1)}
+                    disabled={!canPrev || isLoading}
+                    aria-label="Previous page"
+                  >
+                    <ChevronLeft className="h-4 w-4" />
+                    Prev
+                  </Button>
+                  <span className="text-sm" aria-live="polite">
+                    Page {page} of {totalPages}
+                  </span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => fetchPage(currentFilters, page + 1)}
+                    disabled={!canNext || isLoading}
+                    aria-label="Next page"
+                  >
+                    Next
+                    <ChevronRight className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            )}
           </CardContent>
         </Card>
       ) : null}

--- a/models/tab-model.ts
+++ b/models/tab-model.ts
@@ -172,6 +172,11 @@ tabSchema.index({ userId: 1, status: 1 });
 tabSchema.index({ openedAt: -1 });
 tabSchema.index({ businessDate: 1 });
 tabSchema.index({ tableNumber: 1, status: 1 });
+// Default Tabs Management page query: find({status:'open'}).sort({openedAt:-1}).
+// Compound covers the filter + sort + (skip/limit) without scanning every
+// tab. Builds in background; existing single-field openedAt index stays
+// for date-range queries that don't filter on status.
+tabSchema.index({ status: 1, openedAt: -1 });
 
 // REQ-035 — tab-level `tipAmount` is a derived sum of partial-payment
 // tips. Recompute on every save so callers cannot drift the two apart.

--- a/services/tab-service.ts
+++ b/services/tab-service.ts
@@ -468,14 +468,24 @@ export class TabService {
   }
 
   /**
-   * List all tabs (admin/staff) with filtering options
+   * List all tabs (admin/staff) with filtering + offset pagination.
+   *
+   * `skip` + `limit` follow the same pattern as `AuditLogService.getLogs`
+   * and `OrderService.getOrdersByUserId`. Default page size is 25; pass
+   * `limit: 0` (or no pagination args) to get the legacy "all rows"
+   * behaviour for callers that still need it.
+   *
+   * Returns `{ tabs, total }` so the UI can render Page X of Y without
+   * a second count round-trip.
    */
   static async listAllTabsWithFilters(filters: {
     statuses?: string[];
     startDate?: Date;
     endDate?: Date;
     reconciled?: 'all' | 'reconciled' | 'not-reconciled';
-  }): Promise<ITab[]> {
+    skip?: number;
+    limit?: number;
+  }): Promise<{ tabs: ITab[]; total: number }> {
     await connectDB();
 
     const query: any = {};
@@ -506,10 +516,51 @@ export class TabService {
       query.reconciled = { $ne: true };
     }
 
-    const tabs = await TabModel.find(query).sort({ openedAt: -1 }).lean();
+    const skip = filters.skip ?? 0;
+    const limit = filters.limit ?? 0;
+
+    const [tabs, total] = await Promise.all([
+      (limit > 0
+        ? TabModel.find(query).sort({ openedAt: -1 }).skip(skip).limit(limit)
+        : TabModel.find(query).sort({ openedAt: -1 })
+      ).lean(),
+      TabModel.countDocuments(query),
+    ]);
 
     // Ensure complete serialization to prevent client component errors
-    return JSON.parse(JSON.stringify(tabs));
+    return {
+      tabs: JSON.parse(JSON.stringify(tabs)) as ITab[],
+      total,
+    };
+  }
+
+  /**
+   * Top-of-page stats for the Tabs Management dashboard.
+   *
+   * Three counts in parallel, independent of any operator filter +
+   * pagination state. The Total Orders figure is the sum of each tab's
+   * `orders.length` — done as a single aggregate so we don't ship 1500+
+   * documents just to count the array sizes.
+   */
+  static async getTabStats(): Promise<{
+    totalTabs: number;
+    totalOpenTabs: number;
+    totalOrders: number;
+  }> {
+    await connectDB();
+    const [totalTabs, totalOpenTabs, totalOrdersAgg] = await Promise.all([
+      TabModel.countDocuments({}),
+      TabModel.countDocuments({ status: 'open' }),
+      TabModel.aggregate<{ _id: null; sum: number }>([
+        { $project: { count: { $size: { $ifNull: ['$orders', []] } } } },
+        { $group: { _id: null, sum: { $sum: '$count' } } },
+      ]),
+    ]);
+    return {
+      totalTabs,
+      totalOpenTabs,
+      totalOrders: totalOrdersAgg[0]?.sum ?? 0,
+    };
   }
 
   /**


### PR DESCRIPTION
Release of the Tabs Management performance work to prod.

## What changes for prod operators

`/dashboard/orders/tabs` loads quickly even with 1500+ tabs. Open tabs only are shown by default; the filter remembers your choice across visits.

| Surface | Before | After |
|---|---|---|
| First-paint payload | All 1566 tabs serialised + sent to client | 25 tabs + a `total` counter |
| Stats tiles | Reduced over the client-side array (wrong once paginated) | Live counts from Mongo, stable across page/filter changes |
| Filter | Forgotten on every visit | Persisted to localStorage (Save button); Reset reverts to open-only default |
| Pagination | None | Prev / Next / "Page X of Y", 25 per page |
| Default filter | All statuses | Open tabs only (implicit default for first-time visitors) |
| Index support | `{openedAt: -1}` single-field | + new `{status: 1, openedAt: -1}` compound for the default query |

## Commits in this release

| Commit | PR | What |
|---|---|---|
| `5fb3fff` | Merge #109 | Merge commit |
| `68903ea` | **#109** | feat(tabs): server-side pagination + saved filter on Tabs Management |

## Gates already passed

- `tsc --noEmit` → 0 errors on develop HEAD `5fb3fff3`
- vitest → **793 pass / 4 skipped**
- CI Pipeline on develop ✅ green

## Test plan (post-merge on prod)

- [ ] First visit to `/dashboard/orders/tabs` loads in well under 1s; shows 25 open tabs.
- [ ] Stats tiles match Mongo totals (Total Tabs / Total Orders / Total Open Tabs) — stable across filter and page changes.
- [ ] Untick Open + tick Closed → list updates to first 25 closed tabs; still fast.
- [ ] Prev / Next paginate at 25 per page; last page may have < 25 rows.
- [ ] Pick a non-default filter combination → click **Save filter** → "Saved" toast. Navigate away and back → page reloads with the saved filter.
- [ ] Click **Reset to default** → localStorage cleared → page reverts to open-only.
- [ ] `db.tabs.getIndexes()` on prod after deploy shows the new `{status:1, openedAt:-1}` compound index.

## Risk

LOW-MEDIUM. Read-side only; no write paths touched. Existing offset-pagination pattern is the established precedent (mirrors `AuditLogService.getLogs`, `OrderService.getOrdersByUserId`). LocalStorage persistence is per-browser and contains no sensitive data.