### PR TITLE
feat(reports): order-type breakdown on Daily, Profitability, and Dashboard

### DIFF
--- a/__tests__/services/financial-report-service.order-type.test.ts
+++ b/__tests__/services/financial-report-service.order-type.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Coverage for the per-OrderType revenue breakdown on the Daily Summary
+ * report (and the date-range variant that mirrors it).
+ *
+ * Asserts:
+ *  1. Four orders, one of each type → byOrderType has revenue + 1 count
+ *     for each, and the bucket totals sum to the orders' raw total.
+ *  2. Order missing orderType (defensive — shouldn't happen on prod) is
+ *     treated as 'pay-now' so the row count still balances.
+ *  3. Tab-partial subtraction in `paymentBreakdown` does NOT affect the
+ *     byOrderType bucket — the type breakdown uses each order's full
+ *     `total`, not the cash-flow-adjusted amount.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/mongodb', () => ({
+  default: vi.fn(),
+  connectDB: vi.fn(),
+}));
+
+const orderFindMock = vi.fn();
+const tabFindMock = vi.fn();
+const expenseFindMock = vi.fn();
+const menuItemFindByIdMock = vi.fn();
+
+vi.mock('@/models/order-model', () => ({
+  default: {
+    find: (...args: unknown[]) => ({
+      lean: () => orderFindMock(...args),
+    }),
+    countDocuments: vi.fn().mockResolvedValue(0),
+  },
+}));
+
+vi.mock('@/models/tab-model', () => ({
+  default: {
+    find: (...args: unknown[]) => ({
+      lean: () => tabFindMock(...args),
+    }),
+  },
+}));
+
+vi.mock('@/models/expense-model', () => ({
+  ExpenseModel: {
+    find: (...args: unknown[]) => ({
+      populate: () => ({
+        lean: () => expenseFindMock(...args),
+      }),
+      lean: () => expenseFindMock(...args),
+    }),
+  },
+}));
+
+vi.mock('@/models/menu-item-model', () => ({
+  default: {
+    findById: (id: unknown) => ({
+      lean: () => menuItemFindByIdMock(id),
+    }),
+  },
+}));
+
+import { FinancialReportService } from '@/services/financial-report-service';
+
+beforeEach(() => {
+  orderFindMock.mockReset();
+  tabFindMock.mockReset();
+  expenseFindMock.mockReset();
+  menuItemFindByIdMock.mockReset();
+  expenseFindMock.mockResolvedValue([]);
+  tabFindMock.mockResolvedValue([]);
+  menuItemFindByIdMock.mockResolvedValue(null);
+});
+
+describe('financial-report — revenue.byOrderType', () => {
+  it('buckets four orders (one of each type) into separate rows', async () => {
+    orderFindMock.mockResolvedValue([
+      {
+        _id: 'o1',
+        total: 1000,
+        orderType: 'dine-in',
+        paymentMethod: 'cash',
+        items: [],
+      },
+      {
+        _id: 'o2',
+        total: 2000,
+        orderType: 'delivery',
+        paymentMethod: 'cash',
+        items: [],
+      },
+      {
+        _id: 'o3',
+        total: 3000,
+        orderType: 'pickup',
+        paymentMethod: 'cash',
+        items: [],
+      },
+      {
+        _id: 'o4',
+        total: 4000,
+        orderType: 'pay-now',
+        paymentMethod: 'cash',
+        items: [],
+      },
+    ]);
+
+    const report = await FinancialReportService.generateDailySummary(
+      new Date('2026-05-23')
+    );
+
+    expect(report.revenue.byOrderType['dine-in']).toEqual({
+      revenue: 1000,
+      orderCount: 1,
+    });
+    expect(report.revenue.byOrderType['delivery']).toEqual({
+      revenue: 2000,
+      orderCount: 1,
+    });
+    expect(report.revenue.byOrderType['pickup']).toEqual({
+      revenue: 3000,
+      orderCount: 1,
+    });
+    expect(report.revenue.byOrderType['pay-now']).toEqual({
+      revenue: 4000,
+      orderCount: 1,
+    });
+
+    const bucketSum =
+      report.revenue.byOrderType['dine-in'].revenue +
+      report.revenue.byOrderType['delivery'].revenue +
+      report.revenue.byOrderType['pickup'].revenue +
+      report.revenue.byOrderType['pay-now'].revenue;
+    expect(bucketSum).toBe(10000);
+  });
+
+  it('treats an order missing orderType as pay-now (defensive)', async () => {
+    orderFindMock.mockResolvedValue([
+      { _id: 'o1', total: 500, paymentMethod: 'cash', items: [] }, // no orderType
+    ]);
+
+    const report = await FinancialReportService.generateDailySummary(
+      new Date('2026-05-23')
+    );
+
+    expect(report.revenue.byOrderType['pay-now']).toEqual({
+      revenue: 500,
+      orderCount: 1,
+    });
+    expect(report.revenue.byOrderType['dine-in']).toEqual({
+      revenue: 0,
+      orderCount: 0,
+    });
+  });
+
+  it('byOrderType uses each order full total, NOT the tab-partial-adjusted amount', async () => {
+    // Tab-partial payment of 600 means paymentBreakdown.cash will see
+    // only the remaining 400, but the order's full 1000 should still
+    // count toward the dine-in bucket (byOrderType is sales-by-type,
+    // not cash-flow-by-channel).
+    orderFindMock.mockResolvedValue([
+      {
+        _id: 'o1',
+        total: 1000,
+        orderType: 'dine-in',
+        paymentMethod: 'cash',
+        tabId: 'tab1',
+        items: [],
+      },
+    ]);
+    tabFindMock.mockResolvedValue([
+      {
+        _id: 'tab1',
+        partialPayments: [
+          { amount: 600, paymentType: 'cash', paidAt: new Date() },
+        ],
+      },
+    ]);
+
+    const report = await FinancialReportService.generateDailySummary(
+      new Date('2026-05-23')
+    );
+
+    expect(report.revenue.byOrderType['dine-in'].revenue).toBe(1000);
+    expect(report.revenue.byOrderType['dine-in'].orderCount).toBe(1);
+  });
+});

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -16,6 +16,10 @@ import {
   Package,
 } from 'lucide-react';
 import { Skeleton } from '@/components/ui/skeleton';
+import {
+  ORDER_TYPE_LABELS,
+  ORDER_TYPE_DISPLAY_ORDER,
+} from '@/lib/order-type-labels';
 
 export const dynamic = 'force-dynamic';
 
@@ -81,27 +85,82 @@ async function DashboardMetrics() {
   ];
 
   return (
-    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-      {cards.map((card) => {
-        const Icon = card.icon;
-        return (
-          <Card key={card.title}>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">
-                {card.title}
-              </CardTitle>
-              <Icon className={`h-4 w-4 ${card.color}`} />
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">{card.value}</div>
-              <p className="text-xs text-muted-foreground">
-                {card.description}
-              </p>
-            </CardContent>
-          </Card>
-        );
-      })}
+    <div className="space-y-4">
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        {cards.map((card) => {
+          const Icon = card.icon;
+          return (
+            <Card key={card.title}>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">
+                  {card.title}
+                </CardTitle>
+                <Icon className={`h-4 w-4 ${card.color}`} />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{card.value}</div>
+                <p className="text-xs text-muted-foreground">
+                  {card.description}
+                </p>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+      <TodaysRevenueByType
+        revenueByType={metrics.today.revenueByType}
+        ordersByType={metrics.today.ordersByType}
+        totalRevenue={metrics.today.totalRevenue}
+      />
     </div>
+  );
+}
+
+/**
+ * Per-order-type breakdown for today's revenue. Sourced from
+ * `OrderService.getOrderStats(today)`. Operator-friendly labels via
+ * `lib/order-type-labels`.
+ */
+function TodaysRevenueByType({
+  revenueByType,
+  ordersByType,
+  totalRevenue,
+}: {
+  revenueByType: Record<string, number>;
+  ordersByType: Record<string, number>;
+  totalRevenue: number;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">
+          Today&apos;s revenue by type
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          {ORDER_TYPE_DISPLAY_ORDER.map((type) => {
+            const revenue = revenueByType[type] ?? 0;
+            const count = ordersByType[type] ?? 0;
+            const pct = totalRevenue > 0 ? (revenue / totalRevenue) * 100 : 0;
+            return (
+              <div key={type} className="space-y-1">
+                <p className="text-xs text-muted-foreground">
+                  {ORDER_TYPE_LABELS[type]}
+                </p>
+                <p className="text-lg font-semibold">
+                  ₦{revenue.toLocaleString()}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {count} {count === 1 ? 'order' : 'orders'}
+                  {totalRevenue > 0 ? ` · ${pct.toFixed(0)}%` : ''}
+                </p>
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
   );
 }
 

--- a/app/dashboard/reports/daily/daily-report-client.tsx
+++ b/app/dashboard/reports/daily/daily-report-client.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/app/actions/reports/report-actions';
 import type { DailySummaryReport } from '@/services/financial-report-service';
 import { RevenueSection } from '@/components/features/reports/revenue-section';
+import { OrdersByTypeSection } from '@/components/features/reports/orders-by-type-section';
 import { CostSection } from '@/components/features/reports/cost-section';
 import { ProfitSection } from '@/components/features/reports/profit-section';
 import { ExpensesSection } from '@/components/features/reports/expenses-section';
@@ -523,6 +524,7 @@ export function DailyReportClient() {
 
             <TabsContent value="revenue" className="space-y-4">
               <RevenueSection report={report} />
+              <OrdersByTypeSection report={report} />
             </TabsContent>
 
             <TabsContent value="costs" className="space-y-4">

--- a/components/features/admin/profitability-charts.tsx
+++ b/components/features/admin/profitability-charts.tsx
@@ -1,16 +1,27 @@
 'use client';
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { LineChart, BarChart3 } from 'lucide-react';
 import type { ProfitabilityReport } from '@/services/profitability-analytics-service';
+import { ORDER_TYPE_LABELS } from '@/lib/order-type-labels';
+import type { OrderType } from '@/interfaces/order.interface';
 
 interface ProfitabilityChartsProps {
   report: ProfitabilityReport | null;
   isLoading: boolean;
 }
 
-export function ProfitabilityCharts({ report, isLoading }: ProfitabilityChartsProps) {
+export function ProfitabilityCharts({
+  report,
+  isLoading,
+}: ProfitabilityChartsProps) {
   if (isLoading) {
     return (
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -41,7 +52,9 @@ export function ProfitabilityCharts({ report, isLoading }: ProfitabilityChartsPr
             <LineChart className="h-5 w-5" />
             Revenue vs Cost vs Profit
           </CardTitle>
-          <CardDescription>Daily trends over the selected period</CardDescription>
+          <CardDescription>
+            Daily trends over the selected period
+          </CardDescription>
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
@@ -52,9 +65,12 @@ export function ProfitabilityCharts({ report, isLoading }: ProfitabilityChartsPr
             ) : (
               <div className="space-y-2">
                 {trends.daily.slice(-14).map((day) => {
-                  const revenueWidth = maxValue > 0 ? (day.revenue / maxValue) * 100 : 0;
-                  const costWidth = maxValue > 0 ? (day.costs / maxValue) * 100 : 0;
-                  const profitWidth = maxValue > 0 ? (day.profit / maxValue) * 100 : 0;
+                  const revenueWidth =
+                    maxValue > 0 ? (day.revenue / maxValue) * 100 : 0;
+                  const costWidth =
+                    maxValue > 0 ? (day.costs / maxValue) * 100 : 0;
+                  const profitWidth =
+                    maxValue > 0 ? (day.profit / maxValue) * 100 : 0;
 
                   return (
                     <div key={day.date} className="space-y-1">
@@ -65,11 +81,15 @@ export function ProfitabilityCharts({ report, isLoading }: ProfitabilityChartsPr
                             day: 'numeric',
                           })}
                         </span>
-                        <span className="font-medium">₦{day.revenue.toLocaleString()}</span>
+                        <span className="font-medium">
+                          ₦{day.revenue.toLocaleString()}
+                        </span>
                       </div>
                       <div className="space-y-1">
                         <div className="flex items-center gap-2">
-                          <div className="w-16 text-xs text-muted-foreground">Revenue</div>
+                          <div className="w-16 text-xs text-muted-foreground">
+                            Revenue
+                          </div>
                           <div className="flex-1 h-2 bg-muted rounded-full overflow-hidden">
                             <div
                               className="h-full bg-blue-500"
@@ -78,7 +98,9 @@ export function ProfitabilityCharts({ report, isLoading }: ProfitabilityChartsPr
                           </div>
                         </div>
                         <div className="flex items-center gap-2">
-                          <div className="w-16 text-xs text-muted-foreground">Cost</div>
+                          <div className="w-16 text-xs text-muted-foreground">
+                            Cost
+                          </div>
                           <div className="flex-1 h-2 bg-muted rounded-full overflow-hidden">
                             <div
                               className="h-full bg-red-500"
@@ -87,7 +109,9 @@ export function ProfitabilityCharts({ report, isLoading }: ProfitabilityChartsPr
                           </div>
                         </div>
                         <div className="flex items-center gap-2">
-                          <div className="w-16 text-xs text-muted-foreground">Profit</div>
+                          <div className="w-16 text-xs text-muted-foreground">
+                            Profit
+                          </div>
                           <div className="flex-1 h-2 bg-muted rounded-full overflow-hidden">
                             <div
                               className="h-full bg-green-500"
@@ -112,7 +136,9 @@ export function ProfitabilityCharts({ report, isLoading }: ProfitabilityChartsPr
             <BarChart3 className="h-5 w-5" />
             Profitability by Order Type
           </CardTitle>
-          <CardDescription>Compare performance across order types</CardDescription>
+          <CardDescription>
+            Compare performance across order types
+          </CardDescription>
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
@@ -122,22 +148,34 @@ export function ProfitabilityCharts({ report, isLoading }: ProfitabilityChartsPr
               </p>
             ) : (
               byOrderType.map((type) => {
-                const maxTypeRevenue = Math.max(...byOrderType.map((t) => t.totalRevenue));
-                const width = maxTypeRevenue > 0 ? (type.totalRevenue / maxTypeRevenue) * 100 : 0;
+                const maxTypeRevenue = Math.max(
+                  ...byOrderType.map((t) => t.totalRevenue)
+                );
+                const width =
+                  maxTypeRevenue > 0
+                    ? (type.totalRevenue / maxTypeRevenue) * 100
+                    : 0;
 
+                const label =
+                  ORDER_TYPE_LABELS[type.orderType as OrderType] ??
+                  type.orderType;
                 return (
                   <div key={type.orderType} className="space-y-2">
                     <div className="flex items-center justify-between">
                       <div>
-                        <p className="font-medium capitalize">{type.orderType}</p>
+                        <p className="font-medium">{label}</p>
                         <p className="text-xs text-muted-foreground">
                           {type.orderCount} orders · Avg: ₦
                           {type.averageOrderValue.toLocaleString()}
                         </p>
                       </div>
                       <div className="text-right">
-                        <p className="font-bold">₦{type.totalRevenue.toLocaleString()}</p>
-                        <p className="text-xs text-green-600">{type.profitMargin.toFixed(1)}%</p>
+                        <p className="font-bold">
+                          ₦{type.totalRevenue.toLocaleString()}
+                        </p>
+                        <p className="text-xs text-green-600">
+                          {type.profitMargin.toFixed(1)}%
+                        </p>
                       </div>
                     </div>
                     <div className="h-3 bg-muted rounded-full overflow-hidden">

--- a/components/features/admin/profitability-filters.tsx
+++ b/components/features/admin/profitability-filters.tsx
@@ -53,7 +53,12 @@ export function ProfitabilityFilters({
                 type="date"
                 value={startDate}
                 onChange={(e) =>
-                  onFilterChange({ startDate: e.target.value, endDate, orderType, category })
+                  onFilterChange({
+                    startDate: e.target.value,
+                    endDate,
+                    orderType,
+                    category,
+                  })
                 }
                 disabled={isLoading}
               />
@@ -65,7 +70,12 @@ export function ProfitabilityFilters({
                 type="date"
                 value={endDate}
                 onChange={(e) =>
-                  onFilterChange({ startDate, endDate: e.target.value, orderType, category })
+                  onFilterChange({
+                    startDate,
+                    endDate: e.target.value,
+                    orderType,
+                    category,
+                  })
                 }
                 disabled={isLoading}
               />
@@ -78,7 +88,12 @@ export function ProfitabilityFilters({
             <Select
               value={orderType || 'all'}
               onValueChange={(value) =>
-                onFilterChange({ startDate, endDate, orderType: value === 'all' ? '' : value, category })
+                onFilterChange({
+                  startDate,
+                  endDate,
+                  orderType: value === 'all' ? '' : value,
+                  category,
+                })
               }
               disabled={isLoading}
             >
@@ -87,9 +102,10 @@ export function ProfitabilityFilters({
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="all">All order types</SelectItem>
-                <SelectItem value="dine-in">Dine-in</SelectItem>
+                <SelectItem value="dine-in">Sit-in</SelectItem>
+                <SelectItem value="delivery">Takeaway</SelectItem>
                 <SelectItem value="pickup">Pickup</SelectItem>
-                <SelectItem value="delivery">Delivery</SelectItem>
+                <SelectItem value="pay-now">Pay-now</SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -100,7 +116,12 @@ export function ProfitabilityFilters({
             <Select
               value={category || 'all'}
               onValueChange={(value) =>
-                onFilterChange({ startDate, endDate, orderType, category: value === 'all' ? '' : value })
+                onFilterChange({
+                  startDate,
+                  endDate,
+                  orderType,
+                  category: value === 'all' ? '' : value,
+                })
               }
               disabled={isLoading}
             >
@@ -122,7 +143,11 @@ export function ProfitabilityFilters({
 
           {/* Export Button */}
           <div className="flex items-end">
-            <Button onClick={handleExportCSV} variant="outline" disabled={isLoading}>
+            <Button
+              onClick={handleExportCSV}
+              variant="outline"
+              disabled={isLoading}
+            >
               <Download className="mr-2 h-4 w-4" />
               Export CSV
             </Button>

--- a/components/features/reports/orders-by-type-section.tsx
+++ b/components/features/reports/orders-by-type-section.tsx
@@ -1,0 +1,101 @@
+/**
+ * Per-order-type revenue card for the Daily Summary Report.
+ *
+ * Renders one row per OrderType (Sit-in / Takeaway / Pickup / Pay-now)
+ * with revenue, order count, and share of total. Source is
+ * `report.revenue.byOrderType` populated server-side by
+ * `FinancialReportService.generateDailySummary` /
+ * `generateDateRangeReport`.
+ *
+ * Data source uses each order's full `total` (not the partial-payment-
+ * adjusted amount in `paymentBreakdown`), answering "what was sold
+ * per type" rather than "what cash arrived per channel".
+ */
+'use client';
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  ORDER_TYPE_DISPLAY_ORDER,
+  ORDER_TYPE_LABELS,
+} from '@/lib/order-type-labels';
+import type { DailySummaryReport } from '@/services/financial-report-service';
+
+interface OrdersByTypeSectionProps {
+  report: DailySummaryReport;
+}
+
+function formatCurrency(value: number): string {
+  return `₦${value.toLocaleString('en-NG', { maximumFractionDigits: 0 })}`;
+}
+
+export function OrdersByTypeSection({ report }: OrdersByTypeSectionProps) {
+  const byType = report.revenue.byOrderType;
+  const totalRevenue = ORDER_TYPE_DISPLAY_ORDER.reduce(
+    (sum, t) => sum + (byType[t]?.revenue ?? 0),
+    0
+  );
+
+  return (
+    <Card data-testid="orders-by-type-section">
+      <CardHeader>
+        <CardTitle>Orders by type</CardTitle>
+        <CardDescription>
+          Revenue and order count split by Sit-in, Takeaway, Pickup, and
+          Pay-now. Uses each order&apos;s full total, so the sum may differ
+          slightly from the Payment breakdown which tracks cash received.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-left text-muted-foreground">
+                <th className="pb-2 font-medium">Type</th>
+                <th className="pb-2 font-medium text-right">Orders</th>
+                <th className="pb-2 font-medium text-right">Revenue</th>
+                <th className="pb-2 font-medium text-right">% of total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {ORDER_TYPE_DISPLAY_ORDER.map((type) => {
+                const bucket = byType[type] ?? { revenue: 0, orderCount: 0 };
+                const pct =
+                  totalRevenue > 0 ? (bucket.revenue / totalRevenue) * 100 : 0;
+                return (
+                  <tr key={type} className="border-b last:border-0">
+                    <td className="py-2 font-medium">
+                      {ORDER_TYPE_LABELS[type]}
+                    </td>
+                    <td className="py-2 text-right">{bucket.orderCount}</td>
+                    <td className="py-2 text-right">
+                      {formatCurrency(bucket.revenue)}
+                    </td>
+                    <td className="py-2 text-right text-muted-foreground">
+                      {totalRevenue > 0 ? `${pct.toFixed(1)}%` : '—'}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+            <tfoot>
+              <tr className="border-t font-medium">
+                <td className="pt-2">Total</td>
+                <td className="pt-2 text-right">{report.metrics.orderCount}</td>
+                <td className="pt-2 text-right">
+                  {formatCurrency(totalRevenue)}
+                </td>
+                <td className="pt-2"></td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/lib/order-type-labels.ts
+++ b/lib/order-type-labels.ts
@@ -1,0 +1,45 @@
+/**
+ * Display labels for the OrderType enum.
+ *
+ * The model enum uses developer-friendly slugs (`dine-in`, `pickup`,
+ * `delivery`, `pay-now`); the reports / dashboard surfaces operators
+ * read use restaurant-friendly labels. Keep this map as the single
+ * source of truth so the same wording appears everywhere a per-type
+ * breakdown is rendered.
+ *
+ * The order in `ORDER_TYPE_DISPLAY_ORDER` is the canonical display
+ * order — keep it consistent across tables/cards so operators can
+ * compare two reports at a glance.
+ */
+import type { OrderType } from '@/interfaces/order.interface';
+
+export const ORDER_TYPE_LABELS: Record<OrderType, string> = {
+  'dine-in': 'Sit-in',
+  delivery: 'Takeaway',
+  pickup: 'Pickup',
+  'pay-now': 'Pay-now',
+};
+
+export const ORDER_TYPE_DISPLAY_ORDER: readonly OrderType[] = [
+  'dine-in',
+  'delivery',
+  'pickup',
+  'pay-now',
+] as const;
+
+/**
+ * Empty record initialiser keyed by every enum value, with 0 / null
+ * values. Use this to seed report buckets so iteration order is stable
+ * and every type has a row even when the period has no orders of that
+ * type.
+ */
+export function emptyByOrderType<T extends number>(
+  zero: T
+): Record<OrderType, T> {
+  return {
+    'dine-in': zero,
+    delivery: zero,
+    pickup: zero,
+    'pay-now': zero,
+  };
+}

--- a/services/financial-report-service.ts
+++ b/services/financial-report-service.ts
@@ -8,6 +8,7 @@ import OrderModel from '@/models/order-model';
 import TabModel from '@/models/tab-model';
 import { ExpenseModel } from '@/models/expense-model';
 import MenuItemModel from '@/models/menu-item-model';
+import type { OrderType } from '@/interfaces/order.interface';
 
 /**
  * WAT (West Africa Time) is UTC+1.
@@ -52,6 +53,16 @@ export interface DailySummaryReport {
       }>;
       totalRevenue: number;
     };
+    /**
+     * Order-type breakdown — revenue and order count per OrderType. Source
+     * is `Order.orderType` on each order in the period; bucketed by sum
+     * of `order.total` and a 1-per-order count. The bucket sums to the
+     * orders' raw total (not paymentBreakdown.total, which subtracts
+     * partial payments to track cash-flow). Use this to answer
+     * "how much sit-in vs takeaway today" rather than "how much cash
+     * came in by channel".
+     */
+    byOrderType: Record<OrderType, { revenue: number; orderCount: number }>;
     totalRevenue: number;
   };
   costs: {
@@ -237,6 +248,12 @@ export class FinancialReportService {
       revenue: {
         food: { items: [], totalRevenue: 0 },
         drink: { items: [], totalRevenue: 0 },
+        byOrderType: {
+          'dine-in': { revenue: 0, orderCount: 0 },
+          delivery: { revenue: 0, orderCount: 0 },
+          pickup: { revenue: 0, orderCount: 0 },
+          'pay-now': { revenue: 0, orderCount: 0 },
+        },
         totalRevenue: 0,
       },
       costs: {
@@ -331,6 +348,18 @@ export class FinancialReportService {
     for (const order of orders) {
       let amount = order.total || 0;
       const method = order.paymentMethod as string | undefined;
+
+      // Bucket order by orderType BEFORE the partial-payment subtraction.
+      // The orderType breakdown answers "what was sold per type today",
+      // which uses each order's full total — not the cash-flow-adjusted
+      // amount that paymentBreakdown tracks.
+      const orderTotalForType = order.total || 0;
+      const orderType = (order.orderType ?? 'pay-now') as OrderType;
+      const bucket = report.revenue.byOrderType[orderType];
+      if (bucket) {
+        bucket.revenue += orderTotalForType;
+        bucket.orderCount += 1;
+      }
 
       // If this order belongs to a tab with partial payments, subtract the
       // partial payment total so only the final payment portion is attributed
@@ -547,6 +576,12 @@ export class FinancialReportService {
       revenue: {
         food: { items: [], totalRevenue: 0 },
         drink: { items: [], totalRevenue: 0 },
+        byOrderType: {
+          'dine-in': { revenue: 0, orderCount: 0 },
+          delivery: { revenue: 0, orderCount: 0 },
+          pickup: { revenue: 0, orderCount: 0 },
+          'pay-now': { revenue: 0, orderCount: 0 },
+        },
         totalRevenue: 0,
       },
       costs: {
@@ -633,6 +668,16 @@ export class FinancialReportService {
     for (const order of orders) {
       let amount = order.total || 0;
       const method = order.paymentMethod as string | undefined;
+
+      // Bucket by orderType BEFORE the partial-payment subtraction — see
+      // the matching block in generateDailySummary for the rationale.
+      const orderTotalForType = order.total || 0;
+      const orderType = (order.orderType ?? 'pay-now') as OrderType;
+      const bucket = report.revenue.byOrderType[orderType];
+      if (bucket) {
+        bucket.revenue += orderTotalForType;
+        bucket.orderCount += 1;
+      }
 
       if (order.tabId) {
         const tabId = order.tabId.toString();

--- a/services/order-service.ts
+++ b/services/order-service.ts
@@ -527,6 +527,13 @@ export class OrderService {
     averageOrderValue: number;
     ordersByStatus: Record<OrderStatus, number>;
     ordersByType: Record<OrderType, number>;
+    /**
+     * Per-type revenue (sum of `Order.total` grouped by `Order.orderType`).
+     * Companion to `ordersByType` — counts answer "how many", this answers
+     * "how much". Every enum value is present (0 when absent) so the
+     * caller can iterate the canonical display order without null-checks.
+     */
+    revenueByType: Record<OrderType, number>;
   }> {
     await connectDB();
 
@@ -562,12 +569,15 @@ export class OrderService {
           },
         },
       ]),
+      // Single pipeline returns both count + revenue per orderType.
+      // One round-trip; no extra query vs the previous count-only shape.
       Order.aggregate([
         { $match: dateQuery },
         {
           $group: {
             _id: '$orderType',
             count: { $sum: 1 },
+            revenue: { $sum: '$total' },
           },
         },
       ]),
@@ -581,13 +591,25 @@ export class OrderService {
       },
       {} as Record<OrderStatus, number>
     );
-    const ordersByType = typeStats.reduce(
-      (acc, item) => {
-        acc[item._id as OrderType] = item.count;
-        return acc;
-      },
-      {} as Record<OrderType, number>
-    );
+    const ordersByType: Record<OrderType, number> = {
+      'dine-in': 0,
+      delivery: 0,
+      pickup: 0,
+      'pay-now': 0,
+    };
+    const revenueByType: Record<OrderType, number> = {
+      'dine-in': 0,
+      delivery: 0,
+      pickup: 0,
+      'pay-now': 0,
+    };
+    for (const item of typeStats) {
+      const t = item._id as OrderType | null;
+      if (t && t in ordersByType) {
+        ordersByType[t] = item.count ?? 0;
+        revenueByType[t] = item.revenue ?? 0;
+      }
+    }
 
     return {
       totalOrders: stats.totalOrders,
@@ -596,6 +618,7 @@ export class OrderService {
         stats.totalOrders > 0 ? stats.totalRevenue / stats.totalOrders : 0,
       ordersByStatus,
       ordersByType,
+      revenueByType,
     };
   }
 


### PR DESCRIPTION
## Summary

Operators couldn't see how revenue split across order types. The data was always there (`Order.orderType` is required, four enum values), the reports just didn't surface it. This is a pure read-side change — no schema/migration.

Surfaces the breakdown in three places:

- **Daily Summary report** — new \"Orders by Type\" card under the Revenue tab: revenue / orders / % of total per type, with a footer total.
- **Profitability report** — existing per-type panel now uses operator labels (Sit-in / Takeaway / Pickup / Pay-now). Filter dropdown gets the same labels plus the missing Pay-now option.
- **Dashboard** — new \"Today's revenue by type\" card under the four headline tiles.

### What changed

- **New** `lib/order-type-labels.ts` — single source of truth for operator labels and display order. Maps slugs (`dine-in`, `delivery`, `pickup`, `pay-now`) to labels (Sit-in, Takeaway, Pickup, Pay-now).
- `services/financial-report-service.ts` — `DailySummaryReport.revenue` gains a `byOrderType: Record<OrderType, { revenue, orderCount }>` field, populated in both `generateDailySummary` and the range variant. Uses each order's **full** `total` (not the tab-partial-adjusted amount that `paymentBreakdown` tracks) — \"sales by type\" vs \"cash flow by channel\".
- `services/order-service.ts` — `getOrderStats()` return shape extended with `revenueByType`. Combined into a single `\$group` pipeline (count + revenue in one round-trip).
- **New** `components/features/reports/orders-by-type-section.tsx` — the daily-report card.
- `app/dashboard/page.tsx` — new `TodaysRevenueByType` mini-display.
- `components/features/admin/profitability-charts.tsx` + `profitability-filters.tsx` — switch from raw enum values to operator labels; add Pay-now to the filter.

### Tests

3 new vitest cases on the bucketing logic:

1. Four orders, one of each type → `byOrderType` rows sum to the same total.
2. Order missing `orderType` (defensive) → falls back to Pay-now.
3. Tab-partial subtraction does NOT touch the type bucket (full `total` is used).

**Suite:** 796 pass / 4 skipped (800 total). `tsc --noEmit` clean.

## Test plan

- [ ] CI green (lint + tsc + vitest)
- [ ] On UAT: open Daily Report → Revenue tab → \"Orders by Type\" card sums to the headline total
- [ ] Dashboard → \"Today's revenue by type\" matches the Daily Report headline for today
- [ ] Profitability page → per-type panel uses Sit-in / Takeaway / Pickup / Pay-now; filter dropdown includes Pay-now

🤖 Generated with [Claude Code](https://claude.com/claude-code)