### PR TITLE
fix(tabs): emphasise Revert items as the safe default in delete dialog

### DIFF
--- a/components/features/admin/tabs/delete-tab-dialog.tsx
+++ b/components/features/admin/tabs/delete-tab-dialog.tsx
@@ -177,34 +177,53 @@ export function DeleteTabDialog({
           <RadioGroup
             value={revertChoice}
             onValueChange={(v) => setRevertChoice(v as RevertChoice)}
-            className="gap-3"
+            className="gap-2"
           >
-            <div className="flex items-start gap-2">
+            <Label
+              htmlFor="revert-items"
+              className={`flex items-start gap-3 rounded-md border p-3 cursor-pointer transition-colors font-normal ${
+                revertChoice === 'revert'
+                  ? 'border-primary bg-primary/5 ring-1 ring-primary'
+                  : 'border-border hover:bg-muted/50'
+              }`}
+            >
               <RadioGroupItem
                 value="revert"
                 id="revert-items"
-                className="mt-1"
+                className="mt-0.5"
               />
-              <Label htmlFor="revert-items" className="font-normal">
-                <span className="font-medium">Revert items</span>
-                <br />
-                <span className="text-xs text-muted-foreground">
+              <span className="flex-1">
+                <span className="flex items-center gap-2">
+                  <span className="font-semibold">Revert items</span>
+                  <span className="inline-flex items-center rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-primary">
+                    Recommended
+                  </span>
+                </span>
+                <span className="mt-0.5 block text-xs text-muted-foreground">
                   Restock inventory for each order on this tab and cancel those
-                  orders.
+                  orders. Use this for accidental opens, voided sales, or any
+                  delete where the items did not actually leave the bar.
                 </span>
-              </Label>
-            </div>
-            <div className="flex items-start gap-2">
-              <RadioGroupItem value="keep" id="keep-items" className="mt-1" />
-              <Label htmlFor="keep-items" className="font-normal">
-                <span className="font-medium">Leave as-is</span>
-                <br />
-                <span className="text-xs text-muted-foreground">
-                  Orders keep their current status and data. Inventory is not
-                  adjusted.
+              </span>
+            </Label>
+            <Label
+              htmlFor="keep-items"
+              className={`flex items-start gap-3 rounded-md border p-3 cursor-pointer transition-colors font-normal ${
+                revertChoice === 'keep'
+                  ? 'border-destructive bg-destructive/5 ring-1 ring-destructive'
+                  : 'border-border hover:bg-muted/50'
+              }`}
+            >
+              <RadioGroupItem value="keep" id="keep-items" className="mt-0.5" />
+              <span className="flex-1">
+                <span className="font-semibold">Leave as-is</span>
+                <span className="mt-0.5 block text-xs text-muted-foreground">
+                  Orders keep their current status and inventory stays
+                  decremented. Only pick this if the items were actually
+                  served/consumed and you just want to delete the tab record.
                 </span>
-              </Label>
-            </div>
+              </span>
+            </Label>
           </RadioGroup>
         )}
 


### PR DESCRIPTION
## Summary

In UAT a super-admin deleted a tab intending to restock inventory but the audit log recorded \`revertItems: false\`. The two radio options had equal visual weight, so a stray click on the second row silently flipped the choice without it being obvious.

This change keeps the two-option model but makes the selected option unmistakable:

- Each option becomes a bordered card with a hover state.
- Selected card gets a coloured ring + tinted background — **primary** tone for Revert (safe), **destructive** tone for Leave-as-is (caution).
- Revert gets a small **Recommended** pill.
- Copy is rewritten to be plainer about *when* to pick each one.

Pure visual + copy change — \`handleDelete\`, the action, and the service are untouched.

## Files

- \`components/features/admin/tabs/delete-tab-dialog.tsx\` — radio rendering.

## Tests

Existing 6 vitest cases on \`TabService.deleteTab\` still green. No new tests — the dialog has no JS branching changes, only Tailwind class differences.

## Test plan

- [ ] CI green
- [ ] On UAT as super-admin: open a tab with non-cancelled orders, click Delete, confirm:
  - Revert is clearly highlighted by default and carries the **Recommended** pill
  - Clicking Leave-as-is gives it a red ring so the choice is obvious
  - Deleting with the default (Revert) restocks correctly (verify via \`/dashboard/inventory\` and audit log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)