### PR TITLE
fix(inventory): route deduct/restore via locations[0] for trackByLocation rows

### DIFF
--- a/__tests__/services/inventory-service.track-by-location.test.ts
+++ b/__tests__/services/inventory-service.track-by-location.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Coverage for the trackByLocation routing in deductStockForOrder and
+ * restoreStockForOrder.
+ *
+ * Before the fix, direct assignments to `inventory.currentStock` were
+ * silently overwritten by the Inventory pre-save hook for any row with
+ * trackByLocation=true — so sales and restocks left location-tracked
+ * stock frozen. The service now mutates `locations[0]` so the hook's
+ * recompute (currentStock = sum(locations[].currentStock)) reflects the
+ * change.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import mongoose from 'mongoose';
+
+vi.mock('@/lib/mongodb', () => ({
+  default: vi.fn(),
+  connectDB: vi.fn(),
+}));
+
+const ORDER_ID = '65a1b2c3d4e5f6a7b8c9d0e1';
+const MENU_ITEM_ID = '65a1b2c3d4e5f6a7b8c9d0e2';
+const INVENTORY_ID = '65a1b2c3d4e5f6a7b8c9d0e3';
+
+const mockOrderFindById = vi.fn();
+const mockMenuItemFindById = vi.fn();
+const mockInventoryFindOne = vi.fn();
+const mockInventoryFindById = vi.fn();
+const mockStockMovementCreate = vi.fn().mockResolvedValue({ _id: 'sm-id' });
+
+vi.mock('@/models/order-model', () => ({
+  default: {
+    findById: (...args: unknown[]) => mockOrderFindById(...args),
+  },
+}));
+
+vi.mock('@/models/menu-item-model', () => ({
+  default: {
+    findById: (...args: unknown[]) => mockMenuItemFindById(...args),
+  },
+}));
+
+vi.mock('@/models/inventory-model', () => ({
+  default: {
+    findOne: (...args: unknown[]) => mockInventoryFindOne(...args),
+    findById: (...args: unknown[]) => mockInventoryFindById(...args),
+  },
+}));
+
+vi.mock('@/models/stock-movement-model', () => ({
+  default: {
+    create: (...args: unknown[]) => mockStockMovementCreate(...args),
+  },
+}));
+
+vi.mock('@/lib/email', () => ({
+  sendLowStockAlertEmail: vi.fn(),
+}));
+
+vi.mock('@/services/system-settings-service', () => ({
+  SystemSettingsService: {
+    getBusinessDayCutoff: vi.fn().mockResolvedValue(0),
+  },
+}));
+
+vi.mock('@/lib/customization-inventory', () => ({
+  resolveLinkedInventoryFor: vi.fn().mockReturnValue([]),
+}));
+
+import InventoryService from '@/services/inventory-service';
+
+type LocationDoc = {
+  location: string;
+  locationName?: string;
+  currentStock: number;
+  lastUpdated?: Date;
+  updatedBy?: mongoose.Types.ObjectId;
+  updatedByName?: string;
+};
+
+const buildInventory = (overrides: Record<string, unknown>) => {
+  const inv: Record<string, unknown> = {
+    _id: INVENTORY_ID,
+    menuItemId: MENU_ITEM_ID,
+    currentStock: 100,
+    minimumStock: 10,
+    totalSales: 0,
+    totalRestocked: 0,
+    lastSaleDate: null,
+    status: 'in-stock',
+    trackByLocation: false,
+    locations: [] as LocationDoc[],
+    save: vi.fn().mockImplementation(async function (this: typeof inv) {
+      // Mirror the pre-save hook: when trackByLocation, recompute
+      // currentStock from locations[].currentStock.
+      if (
+        this.trackByLocation &&
+        (this.locations as LocationDoc[]).length > 0
+      ) {
+        this.currentStock = (this.locations as LocationDoc[]).reduce(
+          (sum, loc) => sum + loc.currentStock,
+          0
+        );
+      }
+      // And status reflects the (post-recompute) currentStock.
+      const c = this.currentStock as number;
+      const min = this.minimumStock as number;
+      this.status =
+        c <= 0 ? 'out-of-stock' : c <= min ? 'low-stock' : 'in-stock';
+    }),
+    ...overrides,
+  };
+  return inv;
+};
+
+beforeEach(() => {
+  mockOrderFindById.mockReset();
+  mockMenuItemFindById.mockReset();
+  mockInventoryFindOne.mockReset();
+  mockInventoryFindById.mockReset();
+  mockStockMovementCreate.mockReset();
+  mockStockMovementCreate.mockResolvedValue({ _id: 'sm-id' });
+
+  mockOrderFindById.mockResolvedValue({
+    _id: ORDER_ID,
+    items: [
+      {
+        menuItemId: MENU_ITEM_ID,
+        quantity: 1,
+        portionMultiplier: 1,
+        portionSize: 'full',
+        customizations: [],
+      },
+    ],
+    inventoryDeducted: true,
+    save: vi.fn().mockResolvedValue(undefined),
+  });
+  mockMenuItemFindById.mockResolvedValue({
+    _id: MENU_ITEM_ID,
+    trackInventory: true,
+  });
+});
+
+describe('deductStockForOrder — trackByLocation routing', () => {
+  it('trackByLocation=false: decrements currentStock directly', async () => {
+    const inv = buildInventory({ trackByLocation: false, currentStock: 50 });
+    mockInventoryFindOne.mockResolvedValue(inv);
+
+    await InventoryService.deductStockForOrder(ORDER_ID);
+
+    expect(inv.currentStock).toBe(49);
+    expect((inv.locations as LocationDoc[]).length).toBe(0);
+    expect(inv.save).toHaveBeenCalledOnce();
+  });
+
+  it('trackByLocation=true: decrements locations[0], pre-save hook recomputes currentStock', async () => {
+    const inv = buildInventory({
+      trackByLocation: true,
+      currentStock: 198,
+      locations: [
+        { location: 'store', currentStock: 96 },
+        { location: 'chiller1', currentStock: 102 },
+      ],
+    });
+    mockInventoryFindOne.mockResolvedValue(inv);
+
+    await InventoryService.deductStockForOrder(ORDER_ID);
+
+    const locs = inv.locations as LocationDoc[];
+    expect(locs[0].currentStock).toBe(95);
+    expect(locs[1].currentStock).toBe(102);
+    expect(locs[0].updatedByName).toBe('System');
+    expect(locs[0].lastUpdated).toBeInstanceOf(Date);
+    // The simulated pre-save hook sums locations back into currentStock.
+    expect(inv.currentStock).toBe(197);
+  });
+
+  it('trackByLocation=true but locations empty: falls back to currentStock', async () => {
+    const inv = buildInventory({
+      trackByLocation: true,
+      currentStock: 10,
+      locations: [],
+    });
+    mockInventoryFindOne.mockResolvedValue(inv);
+
+    await InventoryService.deductStockForOrder(ORDER_ID);
+
+    expect(inv.currentStock).toBe(9);
+  });
+
+  it('trackByLocation=true: deduction clamps locations[0] at zero', async () => {
+    const inv = buildInventory({
+      trackByLocation: true,
+      currentStock: 1,
+      locations: [
+        { location: 'store', currentStock: 0 },
+        { location: 'chiller1', currentStock: 1 },
+      ],
+    });
+    mockInventoryFindOne.mockResolvedValue(inv);
+
+    await InventoryService.deductStockForOrder(ORDER_ID);
+
+    const locs = inv.locations as LocationDoc[];
+    expect(locs[0].currentStock).toBe(0);
+    expect(locs[1].currentStock).toBe(1);
+  });
+});
+
+describe('restoreStockForOrder — trackByLocation routing', () => {
+  it('trackByLocation=false: increments currentStock directly', async () => {
+    const inv = buildInventory({ trackByLocation: false, currentStock: 50 });
+    mockInventoryFindOne.mockResolvedValue(inv);
+
+    await InventoryService.restoreStockForOrder(ORDER_ID);
+
+    expect(inv.currentStock).toBe(51);
+  });
+
+  it('trackByLocation=true: increments locations[0], pre-save hook recomputes currentStock', async () => {
+    const inv = buildInventory({
+      trackByLocation: true,
+      currentStock: 198,
+      locations: [
+        { location: 'store', currentStock: 96 },
+        { location: 'chiller1', currentStock: 102 },
+      ],
+    });
+    mockInventoryFindOne.mockResolvedValue(inv);
+
+    await InventoryService.restoreStockForOrder(ORDER_ID);
+
+    const locs = inv.locations as LocationDoc[];
+    expect(locs[0].currentStock).toBe(97);
+    expect(locs[1].currentStock).toBe(102);
+    expect(locs[0].updatedByName).toBe('System');
+    expect(inv.currentStock).toBe(199);
+  });
+
+  it('trackByLocation=true but locations empty: falls back to currentStock', async () => {
+    const inv = buildInventory({
+      trackByLocation: true,
+      currentStock: 10,
+      locations: [],
+    });
+    mockInventoryFindOne.mockResolvedValue(inv);
+
+    await InventoryService.restoreStockForOrder(ORDER_ID);
+
+    expect(inv.currentStock).toBe(11);
+  });
+});

--- a/services/inventory-service.ts
+++ b/services/inventory-service.ts
@@ -15,6 +15,30 @@ import type { InventoryKind } from '@/interfaces/inventory.interface';
  */
 class InventoryService {
   /**
+   * Apply a stock delta from an order operation (positive = restore on
+   * cancel, negative = deduction on sale). For trackByLocation items,
+   * mutate `locations[0]` so the model's pre-save hook (which recomputes
+   * `currentStock = sum(locations[].currentStock)` for location-tracked
+   * rows) reflects the change. Without this routing, direct assignments
+   * to `currentStock` on a location-tracked row are silently overwritten
+   * by the hook, leaving stock counts frozen at the last manual update.
+   */
+  private static applyOrderStockDelta(
+    inventory: InstanceType<typeof InventoryModel>,
+    delta: number
+  ): void {
+    if (inventory.trackByLocation && inventory.locations.length > 0) {
+      const loc = inventory.locations[0];
+      loc.currentStock = Math.max(0, loc.currentStock + delta);
+      loc.lastUpdated = new Date();
+      loc.updatedBy = new mongoose.Types.ObjectId('000000000000000000000000');
+      loc.updatedByName = 'System';
+    } else {
+      inventory.currentStock = Math.max(0, inventory.currentStock + delta);
+    }
+  }
+
+  /**
    * Deduct stock for completed order
    * Called when order status changes to 'completed'
    */
@@ -42,10 +66,7 @@ class InventoryService {
         });
 
         if (inventory) {
-          inventory.currentStock = Math.max(
-            0,
-            inventory.currentStock - actualQuantity
-          );
+          InventoryService.applyOrderStockDelta(inventory, -actualQuantity);
 
           let reason = 'Sale';
           let notes: string | undefined;
@@ -105,10 +126,7 @@ class InventoryService {
         if (!linkedInv) continue;
 
         const linkedAmount = actualQuantity * deductionPerUnit;
-        linkedInv.currentStock = Math.max(
-          0,
-          linkedInv.currentStock - linkedAmount
-        );
+        InventoryService.applyOrderStockDelta(linkedInv, -linkedAmount);
 
         await StockMovementModel.create({
           inventoryId: linkedInv._id,
@@ -177,7 +195,7 @@ class InventoryService {
         });
 
         if (inventory) {
-          inventory.currentStock += actualQuantity;
+          InventoryService.applyOrderStockDelta(inventory, actualQuantity);
 
           let notes: string | undefined;
           if (item.portionSize === 'half') {
@@ -228,7 +246,7 @@ class InventoryService {
         if (!linkedInv) continue;
 
         const linkedAmount = actualQuantity * deductionPerUnit;
-        linkedInv.currentStock += linkedAmount;
+        InventoryService.applyOrderStockDelta(linkedInv, linkedAmount);
 
         await StockMovementModel.create({
           inventoryId: linkedInv._id,


### PR DESCRIPTION
## Summary

A super-admin tab delete with **Revert items** restored some items but not others. Diagnosis:

- **C-Water** (\`trackByLocation: true\`, locations: \`[store: 96, chiller1: 102]\` = 198) — stockmovement was written (+1 with the right inventoryId), but \`currentStock\` stayed at 198.
- **Peppered Beef** (\`trackByLocation: false\`) — moved correctly.

Root cause: the Inventory model's pre-save hook recomputes \`currentStock\` as \`sum(locations[].currentStock)\` for every \`trackByLocation\` row. \`deductStockForOrder\` and \`restoreStockForOrder\` were assigning directly to \`inventory.currentStock\` — the hook silently overwrote them. So sales of location-tracked items have likely been no-ops on \`currentStock\` for the same reason; operators have been manually reconciling location stock via the inventory UI.

## Fix

A single helper \`applyOrderStockDelta(inventory, delta)\` that:
- Mutates \`locations[0].currentStock\` (clamped at zero) when the row is location-tracked, so the pre-save hook's recompute reflects the change.
- Falls back to mutating \`currentStock\` directly otherwise.
- Stamps the location subdoc's \`lastUpdated\`, \`updatedBy\` (zero ObjectId), and \`updatedByName: 'System'\` for audit traceability.

Called from four sites: deduct base, deduct linked-customization, restore base, restore linked-customization.

## Behaviour change

Per the user direction (UAT testing):
- Every sale of a location-tracked item now decrements \`locations[0]\` instead of being a no-op.
- Every restore (tab-delete revert, order cancel) increments \`locations[0]\`.
- For items with \`trackByLocation: false\`: no behaviour change.
- For items with \`trackByLocation: true\` and an empty \`locations\` array: falls back to direct \`currentStock\` (the pre-save hook also skips its recompute in this case, so they stay consistent).

\`locations[0]\` is the convention — operators can reorder if a different default is preferred. No new schema flag added.

## Files

- \`services/inventory-service.ts\` — new private helper + four call-site swaps.
- \`__tests__/services/inventory-service.track-by-location.test.ts\` — 7 vitest cases.

## Tests

7 new vitest cases on the routing:
- deduct trackByLocation=false → \`currentStock\` decrement
- deduct trackByLocation=true → \`locations[0]\` decrement + hook recompute
- deduct trackByLocation=true + empty locations → fallback to \`currentStock\`
- deduct trackByLocation=true + zero clamp
- restore trackByLocation=false → \`currentStock\` increment
- restore trackByLocation=true → \`locations[0]\` increment + hook recompute
- restore trackByLocation=true + empty locations → fallback to \`currentStock\`

Suite **809 pass / 4 skipped (813 total)**. tsc clean.

## Test plan

- [ ] CI green
- [ ] On UAT as super-admin: delete the same kind of tab again (something with C-Water and another tracked item). Verify both inventory rows move on \`/dashboard/inventory\` (currentStock + the relevant location's stock).
- [ ] Place a fresh sale of a location-tracked item (e.g. add a C-Water to a new tab and pay). Check that the bar/store location's stock drops by 1 and \`currentStock\` recomputes.
- [ ] Heads-up: this is the first time sales actually move \`currentStock\` for location-tracked items, so low-stock alerts may start firing on items where the historical manual reconciliation was masking drift. Worth a one-day watch on the alerts after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)