### PR TITLE
release: super-admin tab delete + inventory revert (PRs #113, #114, #115)

### DIFF
--- a/__tests__/services/inventory-service.track-by-location.test.ts
+++ b/__tests__/services/inventory-service.track-by-location.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Coverage for the trackByLocation routing in deductStockForOrder and
+ * restoreStockForOrder.
+ *
+ * Before the fix, direct assignments to `inventory.currentStock` were
+ * silently overwritten by the Inventory pre-save hook for any row with
+ * trackByLocation=true — so sales and restocks left location-tracked
+ * stock frozen. The service now mutates `locations[0]` so the hook's
+ * recompute (currentStock = sum(locations[].currentStock)) reflects the
+ * change.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import mongoose from 'mongoose';
+
+vi.mock('@/lib/mongodb', () => ({
+  default: vi.fn(),
+  connectDB: vi.fn(),
+}));
+
+const ORDER_ID = '65a1b2c3d4e5f6a7b8c9d0e1';
+const MENU_ITEM_ID = '65a1b2c3d4e5f6a7b8c9d0e2';
+const INVENTORY_ID = '65a1b2c3d4e5f6a7b8c9d0e3';
+
+const mockOrderFindById = vi.fn();
+const mockMenuItemFindById = vi.fn();
+const mockInventoryFindOne = vi.fn();
+const mockInventoryFindById = vi.fn();
+const mockStockMovementCreate = vi.fn().mockResolvedValue({ _id: 'sm-id' });
+
+vi.mock('@/models/order-model', () => ({
+  default: {
+    findById: (...args: unknown[]) => mockOrderFindById(...args),
+  },
+}));
+
+vi.mock('@/models/menu-item-model', () => ({
+  default: {
+    findById: (...args: unknown[]) => mockMenuItemFindById(...args),
+  },
+}));
+
+vi.mock('@/models/inventory-model', () => ({
+  default: {
+    findOne: (...args: unknown[]) => mockInventoryFindOne(...args),
+    findById: (...args: unknown[]) => mockInventoryFindById(...args),
+  },
+}));
+
+vi.mock('@/models/stock-movement-model', () => ({
+  default: {
+    create: (...args: unknown[]) => mockStockMovementCreate(...args),
+  },
+}));
+
+vi.mock('@/lib/email', () => ({
+  sendLowStockAlertEmail: vi.fn(),
+}));
+
+vi.mock('@/services/system-settings-service', () => ({
+  SystemSettingsService: {
+    getBusinessDayCutoff: vi.fn().mockResolvedValue(0),
+  },
+}));
+
+vi.mock('@/lib/customization-inventory', () => ({
+  resolveLinkedInventoryFor: vi.fn().mockReturnValue([]),
+}));
+
+import InventoryService from '@/services/inventory-service';
+
+type LocationDoc = {
+  location: string;
+  locationName?: string;
+  currentStock: number;
+  lastUpdated?: Date;
+  updatedBy?: mongoose.Types.ObjectId;
+  updatedByName?: string;
+};
+
+const buildInventory = (overrides: Record<string, unknown>) => {
+  const inv: Record<string, unknown> = {
+    _id: INVENTORY_ID,
+    menuItemId: MENU_ITEM_ID,
+    currentStock: 100,
+    minimumStock: 10,
+    totalSales: 0,
+    totalRestocked: 0,
+    lastSaleDate: null,
+    status: 'in-stock',
+    trackByLocation: false,
+    locations: [] as LocationDoc[],
+    save: vi.fn().mockImplementation(async function (this: typeof inv) {
+      // Mirror the pre-save hook: when trackByLocation, recompute
+      // currentStock from locations[].currentStock.
+      if (
+        this.trackByLocation &&
+        (this.locations as LocationDoc[]).length > 0
+      ) {
+        this.currentStock = (this.locations as LocationDoc[]).reduce(
+          (sum, loc) => sum + loc.currentStock,
+          0
+        );
+      }
+      // And status reflects the (post-recompute) currentStock.
+      const c = this.currentStock as number;
+      const min = this.minimumStock as number;
+      this.status =
+        c <= 0 ? 'out-of-stock' : c <= min ? 'low-stock' : 'in-stock';
+    }),
+    ...overrides,
+  };
+  return inv;
+};
+
+beforeEach(() => {
+  mockOrderFindById.mockReset();
+  mockMenuItemFindById.mockReset();
+  mockInventoryFindOne.mockReset();
+  mockInventoryFindById.mockReset();
+  mockStockMovementCreate.mockReset();
+  mockStockMovementCreate.mockResolvedValue({ _id: 'sm-id' });
+
+  mockOrderFindById.mockResolvedValue({
+    _id: ORDER_ID,
+    items: [
+      {
+        menuItemId: MENU_ITEM_ID,
+        quantity: 1,
+        portionMultiplier: 1,
+        portionSize: 'full',
+        customizations: [],
+      },
+    ],
+    inventoryDeducted: true,
+    save: vi.fn().mockResolvedValue(undefined),
+  });
+  mockMenuItemFindById.mockResolvedValue({
+    _id: MENU_ITEM_ID,
+    trackInventory: true,
+  });
+});
+
+describe('deductStockForOrder — trackByLocation routing', () => {
+  it('trackByLocation=false: decrements currentStock directly', async () => {
+    const inv = buildInventory({ trackByLocation: false, currentStock: 50 });
+    mockInventoryFindOne.mockResolvedValue(inv);
+
+    await InventoryService.deductStockForOrder(ORDER_ID);
+
+    expect(inv.currentStock).toBe(49);
+    expect((inv.locations as LocationDoc[]).length).toBe(0);
+    expect(inv.save).toHaveBeenCalledOnce();
+  });
+
+  it('trackByLocation=true: decrements locations[0], pre-save hook recomputes currentStock', async () => {
+    const inv = buildInventory({
+      trackByLocation: true,
+      currentStock: 198,
+      locations: [
+        { location: 'store', currentStock: 96 },
+        { location: 'chiller1', currentStock: 102 },
+      ],
+    });
+    mockInventoryFindOne.mockResolvedValue(inv);
+
+    await InventoryService.deductStockForOrder(ORDER_ID);
+
+    const locs = inv.locations as LocationDoc[];
+    expect(locs[0].currentStock).toBe(95);
+    expect(locs[1].currentStock).toBe(102);
+    expect(locs[0].updatedByName).toBe('System');
+    expect(locs[0].lastUpdated).toBeInstanceOf(Date);
+    // The simulated pre-save hook sums locations back into currentStock.
+    expect(inv.currentStock).toBe(197);
+  });
+
+  it('trackByLocation=true but locations empty: falls back to currentStock', async () => {
+    const inv = buildInventory({
+      trackByLocation: true,
+      currentStock: 10,
+      locations: [],
+    });
+    mockInventoryFindOne.mockResolvedValue(inv);
+
+    await InventoryService.deductStockForOrder(ORDER_ID);
+
+    expect(inv.currentStock).toBe(9);
+  });
+
+  it('trackByLocation=true: deduction clamps locations[0] at zero', async () => {
+    const inv = buildInventory({
+      trackByLocation: true,
+      currentStock: 1,
+      locations: [
+        { location: 'store', currentStock: 0 },
+        { location: 'chiller1', currentStock: 1 },
+      ],
+    });
+    mockInventoryFindOne.mockResolvedValue(inv);
+
+    await InventoryService.deductStockForOrder(ORDER_ID);
+
+    const locs = inv.locations as LocationDoc[];
+    expect(locs[0].currentStock).toBe(0);
+    expect(locs[1].currentStock).toBe(1);
+  });
+});
+
+describe('restoreStockForOrder — trackByLocation routing', () => {
+  it('trackByLocation=false: increments currentStock directly', async () => {
+    const inv = buildInventory({ trackByLocation: false, currentStock: 50 });
+    mockInventoryFindOne.mockResolvedValue(inv);
+
+    await InventoryService.restoreStockForOrder(ORDER_ID);
+
+    expect(inv.currentStock).toBe(51);
+  });
+
+  it('trackByLocation=true: increments locations[0], pre-save hook recomputes currentStock', async () => {
+    const inv = buildInventory({
+      trackByLocation: true,
+      currentStock: 198,
+      locations: [
+        { location: 'store', currentStock: 96 },
+        { location: 'chiller1', currentStock: 102 },
+      ],
+    });
+    mockInventoryFindOne.mockResolvedValue(inv);
+
+    await InventoryService.restoreStockForOrder(ORDER_ID);
+
+    const locs = inv.locations as LocationDoc[];
+    expect(locs[0].currentStock).toBe(97);
+    expect(locs[1].currentStock).toBe(102);
+    expect(locs[0].updatedByName).toBe('System');
+    expect(inv.currentStock).toBe(199);
+  });
+
+  it('trackByLocation=true but locations empty: falls back to currentStock', async () => {
+    const inv = buildInventory({
+      trackByLocation: true,
+      currentStock: 10,
+      locations: [],
+    });
+    mockInventoryFindOne.mockResolvedValue(inv);
+
+    await InventoryService.restoreStockForOrder(ORDER_ID);
+
+    expect(inv.currentStock).toBe(11);
+  });
+});

--- a/__tests__/services/tab-service.delete-super-admin.test.ts
+++ b/__tests__/services/tab-service.delete-super-admin.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Service-level coverage for TabService.deleteTab with the super-admin
+ * override opts. The default (no-opts) path retains its existing guards.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/mongodb', () => ({
+  default: vi.fn(),
+  connectDB: vi.fn(),
+}));
+
+const TAB_ID = '65a1b2c3d4e5f6a7b8c9d0e1';
+const DELETED_BY = '65a1b2c3d4e5f6a7b8c9d0e2';
+const ORDER_ID_A = '65a1b2c3d4e5f6a7b8c9d0aa';
+const ORDER_ID_B = '65a1b2c3d4e5f6a7b8c9d0bb';
+
+type OrderStub = {
+  _id: string;
+  status:
+    | 'pending'
+    | 'confirmed'
+    | 'preparing'
+    | 'ready'
+    | 'delivered'
+    | 'cancelled';
+  inventoryDeducted?: boolean;
+};
+
+const buildTab = (overrides: Record<string, unknown> = {}) => ({
+  _id: TAB_ID,
+  tabNumber: 'TAB-A1-123456',
+  tableNumber: 'A1',
+  status: 'open' as 'open' | 'settling' | 'closed',
+  paymentStatus: 'pending' as 'pending' | 'paid' | 'failed',
+  customerEmail: 'guest@example.com',
+  orders: [ORDER_ID_A, ORDER_ID_B],
+  ...overrides,
+});
+
+const mockTabFindById = vi.fn();
+const mockTabFindByIdAndDelete = vi.fn().mockResolvedValue(undefined);
+const mockOrderFind = vi.fn();
+const mockOrderUpdateOne = vi.fn().mockResolvedValue({ modifiedCount: 1 });
+const mockAuditCreateLog = vi.fn().mockResolvedValue(undefined);
+const mockRestoreStockForOrder = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@/models/tab-model', () => ({
+  default: {
+    findById: (...args: unknown[]) => mockTabFindById(...args),
+    findByIdAndDelete: (...args: unknown[]) =>
+      mockTabFindByIdAndDelete(...args),
+  },
+}));
+
+vi.mock('@/models/order-model', () => ({
+  default: {
+    find: (...args: unknown[]) => mockOrderFind(...args),
+    updateOne: (...args: unknown[]) => mockOrderUpdateOne(...args),
+  },
+}));
+
+vi.mock('@/services/audit-log-service', () => ({
+  AuditLogService: {
+    createLog: (...args: unknown[]) => mockAuditCreateLog(...args),
+  },
+}));
+
+vi.mock('@/services/inventory-service', () => ({
+  default: {
+    restoreStockForOrder: (...args: unknown[]) =>
+      mockRestoreStockForOrder(...args),
+  },
+}));
+
+vi.mock('@/services/system-settings-service', () => ({
+  SystemSettingsService: {
+    getBusinessDayCutoff: vi.fn().mockResolvedValue(0),
+  },
+}));
+
+vi.mock('@/services/settings-service', () => ({
+  default: {},
+}));
+
+vi.mock('@/lib/business-date', () => ({
+  deriveBusinessDate: vi.fn(() => new Date('2026-05-23T00:00:00Z')),
+}));
+
+import { TabService } from '@/services/tab-service';
+
+beforeEach(() => {
+  mockTabFindById.mockReset();
+  mockTabFindByIdAndDelete.mockReset();
+  mockTabFindByIdAndDelete.mockResolvedValue(undefined);
+  mockOrderFind.mockReset();
+  mockOrderUpdateOne.mockReset();
+  mockOrderUpdateOne.mockResolvedValue({ modifiedCount: 1 });
+  mockAuditCreateLog.mockReset();
+  mockAuditCreateLog.mockResolvedValue(undefined);
+  mockRestoreStockForOrder.mockReset();
+  mockRestoreStockForOrder.mockResolvedValue(undefined);
+});
+
+describe('TabService.deleteTab — default (no opts) path', () => {
+  it('throws when tab is closed and paid', async () => {
+    mockTabFindById.mockResolvedValue(
+      buildTab({ status: 'closed', paymentStatus: 'paid' })
+    );
+    mockOrderFind.mockResolvedValue([]);
+
+    await expect(TabService.deleteTab(TAB_ID, DELETED_BY)).rejects.toThrow(
+      /closed\/paid tab/i
+    );
+    expect(mockTabFindByIdAndDelete).not.toHaveBeenCalled();
+  });
+
+  it('throws when any linked order is not cancelled', async () => {
+    mockTabFindById.mockResolvedValue(buildTab());
+    const orders: OrderStub[] = [
+      { _id: ORDER_ID_A, status: 'delivered', inventoryDeducted: true },
+      { _id: ORDER_ID_B, status: 'cancelled' },
+    ];
+    mockOrderFind.mockResolvedValue(orders);
+
+    await expect(TabService.deleteTab(TAB_ID, DELETED_BY)).rejects.toThrow(
+      /cancel all 1 order/i
+    );
+    expect(mockTabFindByIdAndDelete).not.toHaveBeenCalled();
+    expect(mockRestoreStockForOrder).not.toHaveBeenCalled();
+  });
+});
+
+describe('TabService.deleteTab — super-admin override', () => {
+  it('with revertItems=true: restocks and cancels each non-cancelled order, deletes tab, writes per-order + tab audit logs', async () => {
+    mockTabFindById.mockResolvedValue(buildTab());
+    const orders: OrderStub[] = [
+      { _id: ORDER_ID_A, status: 'delivered', inventoryDeducted: true },
+      { _id: ORDER_ID_B, status: 'preparing', inventoryDeducted: true },
+    ];
+    mockOrderFind.mockResolvedValue(orders);
+
+    await TabService.deleteTab(TAB_ID, DELETED_BY, {
+      superAdminOverride: true,
+      revertItems: true,
+    });
+
+    expect(mockRestoreStockForOrder).toHaveBeenCalledTimes(2);
+    expect(mockRestoreStockForOrder).toHaveBeenCalledWith(ORDER_ID_A);
+    expect(mockRestoreStockForOrder).toHaveBeenCalledWith(ORDER_ID_B);
+
+    expect(mockOrderUpdateOne).toHaveBeenCalledTimes(2);
+    const setCalls = mockOrderUpdateOne.mock.calls.map((c) => c[1]);
+    for (const setCall of setCalls) {
+      expect(setCall.$set).toEqual({ status: 'cancelled' });
+      expect(setCall.$push.statusHistory.status).toBe('cancelled');
+      expect(setCall.$push.statusHistory.note).toMatch(/super-admin/i);
+    }
+
+    const cancelLogs = mockAuditCreateLog.mock.calls.filter(
+      (c) => c[0].action === 'order.cancel'
+    );
+    expect(cancelLogs).toHaveLength(2);
+    for (const [log] of cancelLogs) {
+      expect(log.userRole).toBe('super-admin');
+      expect(log.details.viaTabDelete).toBe(true);
+      expect(log.details.inventoryRestored).toBe(true);
+    }
+
+    const tabLog = mockAuditCreateLog.mock.calls.find(
+      (c) => c[0].action === 'tab.delete'
+    );
+    expect(tabLog).toBeDefined();
+    expect(tabLog![0].userRole).toBe('super-admin');
+    expect(tabLog![0].details.superAdminOverride).toBe(true);
+    expect(tabLog![0].details.revertItems).toBe(true);
+    expect(tabLog![0].details.ordersAffected).toEqual([ORDER_ID_A, ORDER_ID_B]);
+    expect(tabLog![0].details.inventoryRestored).toBe(2);
+
+    expect(mockTabFindByIdAndDelete).toHaveBeenCalledWith(TAB_ID);
+  });
+
+  it('with revertItems=false: leaves orders untouched, deletes tab, writes only tab.delete log', async () => {
+    mockTabFindById.mockResolvedValue(buildTab());
+    const orders: OrderStub[] = [
+      { _id: ORDER_ID_A, status: 'delivered', inventoryDeducted: true },
+    ];
+    mockOrderFind.mockResolvedValue(orders);
+
+    await TabService.deleteTab(TAB_ID, DELETED_BY, {
+      superAdminOverride: true,
+      revertItems: false,
+    });
+
+    expect(mockRestoreStockForOrder).not.toHaveBeenCalled();
+    expect(mockOrderUpdateOne).not.toHaveBeenCalled();
+
+    const cancelLogs = mockAuditCreateLog.mock.calls.filter(
+      (c) => c[0].action === 'order.cancel'
+    );
+    expect(cancelLogs).toHaveLength(0);
+
+    const tabLog = mockAuditCreateLog.mock.calls.find(
+      (c) => c[0].action === 'tab.delete'
+    );
+    expect(tabLog).toBeDefined();
+    expect(tabLog![0].details.superAdminOverride).toBe(true);
+    expect(tabLog![0].details.revertItems).toBe(false);
+    expect(tabLog![0].details.ordersAffected).toEqual([]);
+    expect(tabLog![0].details.inventoryRestored).toBe(0);
+
+    expect(mockTabFindByIdAndDelete).toHaveBeenCalledWith(TAB_ID);
+  });
+
+  it('deletes a closed+paid tab', async () => {
+    mockTabFindById.mockResolvedValue(
+      buildTab({ status: 'closed', paymentStatus: 'paid', orders: [] })
+    );
+    mockOrderFind.mockResolvedValue([]);
+
+    await TabService.deleteTab(TAB_ID, DELETED_BY, {
+      superAdminOverride: true,
+      revertItems: true,
+    });
+
+    expect(mockTabFindByIdAndDelete).toHaveBeenCalledWith(TAB_ID);
+    const tabLog = mockAuditCreateLog.mock.calls.find(
+      (c) => c[0].action === 'tab.delete'
+    );
+    expect(tabLog![0].details.superAdminOverride).toBe(true);
+  });
+
+  it('skips restock when order.inventoryDeducted=false, still cancels and audit-logs', async () => {
+    mockTabFindById.mockResolvedValue(buildTab({ orders: [ORDER_ID_A] }));
+    const orders: OrderStub[] = [
+      { _id: ORDER_ID_A, status: 'delivered', inventoryDeducted: false },
+    ];
+    mockOrderFind.mockResolvedValue(orders);
+
+    await TabService.deleteTab(TAB_ID, DELETED_BY, {
+      superAdminOverride: true,
+      revertItems: true,
+    });
+
+    expect(mockRestoreStockForOrder).not.toHaveBeenCalled();
+    expect(mockOrderUpdateOne).toHaveBeenCalledTimes(1);
+
+    const cancelLogs = mockAuditCreateLog.mock.calls.filter(
+      (c) => c[0].action === 'order.cancel'
+    );
+    expect(cancelLogs).toHaveLength(1);
+    expect(cancelLogs[0][0].details.inventoryRestored).toBe(false);
+
+    const tabLog = mockAuditCreateLog.mock.calls.find(
+      (c) => c[0].action === 'tab.delete'
+    );
+    expect(tabLog![0].details.inventoryRestored).toBe(0);
+  });
+});

--- a/app/actions/tabs/tab-actions.ts
+++ b/app/actions/tabs/tab-actions.ts
@@ -634,12 +634,20 @@ export async function createAdminTabAction(params: {
 }
 
 /**
- * Delete a tab
- * Requirements:
- * - Tab must not be closed/paid
- * - All orders on the tab must be cancelled first
+ * Delete a tab.
+ *
+ * Default (admin or super-admin): tab must not be closed+paid and all
+ * linked orders must be cancelled (enforced inside `TabService.deleteTab`).
+ *
+ * Super-admin override (`opts.superAdminOverride === true`): bypasses
+ * both guards. Requires `session.role === 'super-admin'` here — admin
+ * cannot override. `opts.revertItems === true` restocks inventory and
+ * cancels each linked non-cancelled order.
  */
-export async function deleteTabAction(tabId: string): Promise<ActionResult> {
+export async function deleteTabAction(
+  tabId: string,
+  opts?: { superAdminOverride?: boolean; revertItems?: boolean }
+): Promise<ActionResult> {
   try {
     const cookieStore = await cookies();
     const session = await getIronSession<SessionData>(
@@ -654,7 +662,13 @@ export async function deleteTabAction(tabId: string): Promise<ActionResult> {
       };
     }
 
-    // Only admin and super-admin can delete tabs
+    if (opts?.superAdminOverride && session.role !== 'super-admin') {
+      return {
+        success: false,
+        error: 'Only super-admin can override tab-delete guards',
+      };
+    }
+
     if (session.role !== 'admin' && session.role !== 'super-admin') {
       return {
         success: false,
@@ -662,9 +676,7 @@ export async function deleteTabAction(tabId: string): Promise<ActionResult> {
       };
     }
 
-    console.log('Attempting to delete tab:', tabId, 'by user:', session.userId);
-    await TabService.deleteTab(tabId, session.userId);
-    console.log('Tab deleted successfully:', tabId);
+    await TabService.deleteTab(tabId, session.userId, opts);
 
     revalidatePath('/dashboard/orders/tabs');
     revalidatePath(`/dashboard/orders/tabs/${tabId}`);
@@ -675,10 +687,6 @@ export async function deleteTabAction(tabId: string): Promise<ActionResult> {
     };
   } catch (error) {
     console.error('Error deleting tab:', error);
-    console.error(
-      'Error stack:',
-      error instanceof Error ? error.stack : 'No stack trace'
-    );
     return {
       success: false,
       error: error instanceof Error ? error.message : 'Failed to delete tab',

--- a/app/dashboard/orders/tabs/[tabId]/page.tsx
+++ b/app/dashboard/orders/tabs/[tabId]/page.tsx
@@ -115,14 +115,18 @@ async function getTabDetails(tabId: string) {
     })
   );
 
-  return { tab: serializedTab, orders: serializedOrders };
+  return {
+    tab: serializedTab,
+    orders: serializedOrders,
+    isSuperAdmin: session.role === 'super-admin',
+  };
 }
 
 export default async function DashboardTabDetailsPage({
   params,
 }: DashboardTabDetailsPageProps) {
   const { tabId } = await params;
-  const { tab, orders } = await getTabDetails(tabId);
+  const { tab, orders, isSuperAdmin } = await getTabDetails(tabId);
 
   // Count non-cancelled orders
   const nonCancelledOrderCount = orders.filter(
@@ -180,6 +184,7 @@ export default async function DashboardTabDetailsPage({
               paymentStatus={tab.paymentStatus}
               orderCount={orders.length}
               nonCancelledOrderCount={nonCancelledOrderCount}
+              isSuperAdmin={isSuperAdmin}
             />
           </div>
         </div>

--- a/components/features/admin/tabs/delete-tab-dialog.tsx
+++ b/components/features/admin/tabs/delete-tab-dialog.tsx
@@ -16,6 +16,8 @@ import {
 } from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { Label } from '@/components/ui/label';
 import { toast } from '@/hooks/use-toast';
 import { deleteTabAction } from '@/app/actions/tabs/tab-actions';
 
@@ -26,7 +28,16 @@ interface DeleteTabDialogProps {
   paymentStatus: 'pending' | 'paid' | 'failed';
   orderCount: number;
   nonCancelledOrderCount: number;
+  /**
+   * When true, the dialog renders a super-admin override flow: the
+   * closed+paid and non-cancelled-order guards are bypassed and the
+   * user picks between restocking inventory (Revert items) or leaving
+   * orders as-is. The action layer re-enforces the role gate.
+   */
+  isSuperAdmin?: boolean;
 }
+
+type RevertChoice = 'revert' | 'keep';
 
 export function DeleteTabDialog({
   tabId,
@@ -35,19 +46,38 @@ export function DeleteTabDialog({
   paymentStatus,
   orderCount,
   nonCancelledOrderCount,
+  isSuperAdmin = false,
 }: DeleteTabDialogProps) {
   const [isDeleting, setIsDeleting] = useState(false);
   const [open, setOpen] = useState(false);
+  const [revertChoice, setRevertChoice] = useState<RevertChoice>('revert');
   const router = useRouter();
 
-  const canDelete = status !== 'closed' || paymentStatus !== 'paid';
+  const closedPaid = status === 'closed' && paymentStatus === 'paid';
   const hasNonCancelledOrders = nonCancelledOrderCount > 0;
+
+  // For super-admin, both guards are overridable. For everyone else,
+  // closed+paid disables the button entirely and non-cancelled orders
+  // disable the confirm.
+  const buttonDisabled = !isSuperAdmin && closedPaid;
+  const confirmDisabled =
+    isDeleting || (!isSuperAdmin && hasNonCancelledOrders);
 
   async function handleDelete() {
     setIsDeleting(true);
 
     try {
-      const result = await deleteTabAction(tabId);
+      const overrideRequired =
+        isSuperAdmin && (closedPaid || hasNonCancelledOrders);
+      const result = await deleteTabAction(
+        tabId,
+        overrideRequired
+          ? {
+              superAdminOverride: true,
+              revertItems: revertChoice === 'revert',
+            }
+          : undefined
+      );
 
       if (result.success) {
         toast({
@@ -63,7 +93,7 @@ export function DeleteTabDialog({
           variant: 'destructive',
         });
       }
-    } catch (error) {
+    } catch {
       toast({
         title: 'Error',
         description: 'An unexpected error occurred',
@@ -74,7 +104,7 @@ export function DeleteTabDialog({
     }
   }
 
-  if (!canDelete) {
+  if (buttonDisabled) {
     return (
       <Button variant="destructive" disabled>
         <Trash2 className="mr-2 h-4 w-4" />
@@ -83,10 +113,15 @@ export function DeleteTabDialog({
     );
   }
 
+  const showRevertChoice = isSuperAdmin && hasNonCancelledOrders;
+
   return (
     <AlertDialog open={open} onOpenChange={setOpen}>
       <AlertDialogTrigger asChild>
-        <Button variant="destructive" disabled={hasNonCancelledOrders}>
+        <Button
+          variant="destructive"
+          disabled={!isSuperAdmin && hasNonCancelledOrders}
+        >
           <Trash2 className="mr-2 h-4 w-4" />
           Delete Tab
         </Button>
@@ -99,22 +134,35 @@ export function DeleteTabDialog({
           </AlertDialogDescription>
         </AlertDialogHeader>
 
-        {hasNonCancelledOrders ? (
+        {isSuperAdmin && (closedPaid || hasNonCancelledOrders) ? (
+          <Alert variant="destructive">
+            <AlertTriangle className="h-4 w-4" />
+            <AlertDescription>
+              <strong>Super-admin override.</strong>
+              <br />
+              {closedPaid ? 'This tab is closed and paid. ' : ''}
+              {hasNonCancelledOrders
+                ? `This tab has ${nonCancelledOrderCount} non-cancelled order(s). `
+                : ''}
+              Deletion is irreversible.
+            </AlertDescription>
+          </Alert>
+        ) : hasNonCancelledOrders ? (
           <Alert variant="destructive">
             <AlertTriangle className="h-4 w-4" />
             <AlertDescription>
               <strong>Cannot delete this tab.</strong>
               <br />
-              Please cancel all {nonCancelledOrderCount} order(s) on this tab first before
-              deleting.
+              Please cancel all {nonCancelledOrderCount} order(s) on this tab
+              first before deleting.
             </AlertDescription>
           </Alert>
         ) : orderCount > 0 ? (
           <Alert>
             <AlertTriangle className="h-4 w-4" />
             <AlertDescription>
-              This tab has {orderCount} cancelled order(s). These orders will remain in the
-              system after the tab is deleted.
+              This tab has {orderCount} cancelled order(s). These orders will
+              remain in the system after the tab is deleted.
             </AlertDescription>
           </Alert>
         ) : (
@@ -125,6 +173,41 @@ export function DeleteTabDialog({
           </Alert>
         )}
 
+        {showRevertChoice && (
+          <RadioGroup
+            value={revertChoice}
+            onValueChange={(v) => setRevertChoice(v as RevertChoice)}
+            className="gap-3"
+          >
+            <div className="flex items-start gap-2">
+              <RadioGroupItem
+                value="revert"
+                id="revert-items"
+                className="mt-1"
+              />
+              <Label htmlFor="revert-items" className="font-normal">
+                <span className="font-medium">Revert items</span>
+                <br />
+                <span className="text-xs text-muted-foreground">
+                  Restock inventory for each order on this tab and cancel those
+                  orders.
+                </span>
+              </Label>
+            </div>
+            <div className="flex items-start gap-2">
+              <RadioGroupItem value="keep" id="keep-items" className="mt-1" />
+              <Label htmlFor="keep-items" className="font-normal">
+                <span className="font-medium">Leave as-is</span>
+                <br />
+                <span className="text-xs text-muted-foreground">
+                  Orders keep their current status and data. Inventory is not
+                  adjusted.
+                </span>
+              </Label>
+            </div>
+          </RadioGroup>
+        )}
+
         <AlertDialogFooter>
           <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
           <AlertDialogAction
@@ -132,7 +215,7 @@ export function DeleteTabDialog({
               e.preventDefault();
               handleDelete();
             }}
-            disabled={isDeleting || hasNonCancelledOrders}
+            disabled={confirmDisabled}
             className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
           >
             {isDeleting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}

--- a/components/features/admin/tabs/delete-tab-dialog.tsx
+++ b/components/features/admin/tabs/delete-tab-dialog.tsx
@@ -177,34 +177,53 @@ export function DeleteTabDialog({
           <RadioGroup
             value={revertChoice}
             onValueChange={(v) => setRevertChoice(v as RevertChoice)}
-            className="gap-3"
+            className="gap-2"
           >
-            <div className="flex items-start gap-2">
+            <Label
+              htmlFor="revert-items"
+              className={`flex items-start gap-3 rounded-md border p-3 cursor-pointer transition-colors font-normal ${
+                revertChoice === 'revert'
+                  ? 'border-primary bg-primary/5 ring-1 ring-primary'
+                  : 'border-border hover:bg-muted/50'
+              }`}
+            >
               <RadioGroupItem
                 value="revert"
                 id="revert-items"
-                className="mt-1"
+                className="mt-0.5"
               />
-              <Label htmlFor="revert-items" className="font-normal">
-                <span className="font-medium">Revert items</span>
-                <br />
-                <span className="text-xs text-muted-foreground">
+              <span className="flex-1">
+                <span className="flex items-center gap-2">
+                  <span className="font-semibold">Revert items</span>
+                  <span className="inline-flex items-center rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-primary">
+                    Recommended
+                  </span>
+                </span>
+                <span className="mt-0.5 block text-xs text-muted-foreground">
                   Restock inventory for each order on this tab and cancel those
-                  orders.
+                  orders. Use this for accidental opens, voided sales, or any
+                  delete where the items did not actually leave the bar.
                 </span>
-              </Label>
-            </div>
-            <div className="flex items-start gap-2">
-              <RadioGroupItem value="keep" id="keep-items" className="mt-1" />
-              <Label htmlFor="keep-items" className="font-normal">
-                <span className="font-medium">Leave as-is</span>
-                <br />
-                <span className="text-xs text-muted-foreground">
-                  Orders keep their current status and data. Inventory is not
-                  adjusted.
+              </span>
+            </Label>
+            <Label
+              htmlFor="keep-items"
+              className={`flex items-start gap-3 rounded-md border p-3 cursor-pointer transition-colors font-normal ${
+                revertChoice === 'keep'
+                  ? 'border-destructive bg-destructive/5 ring-1 ring-destructive'
+                  : 'border-border hover:bg-muted/50'
+              }`}
+            >
+              <RadioGroupItem value="keep" id="keep-items" className="mt-0.5" />
+              <span className="flex-1">
+                <span className="font-semibold">Leave as-is</span>
+                <span className="mt-0.5 block text-xs text-muted-foreground">
+                  Orders keep their current status and inventory stays
+                  decremented. Only pick this if the items were actually
+                  served/consumed and you just want to delete the tab record.
                 </span>
-              </Label>
-            </div>
+              </span>
+            </Label>
           </RadioGroup>
         )}
 

--- a/services/inventory-service.ts
+++ b/services/inventory-service.ts
@@ -15,6 +15,30 @@ import type { InventoryKind } from '@/interfaces/inventory.interface';
  */
 class InventoryService {
   /**
+   * Apply a stock delta from an order operation (positive = restore on
+   * cancel, negative = deduction on sale). For trackByLocation items,
+   * mutate `locations[0]` so the model's pre-save hook (which recomputes
+   * `currentStock = sum(locations[].currentStock)` for location-tracked
+   * rows) reflects the change. Without this routing, direct assignments
+   * to `currentStock` on a location-tracked row are silently overwritten
+   * by the hook, leaving stock counts frozen at the last manual update.
+   */
+  private static applyOrderStockDelta(
+    inventory: InstanceType<typeof InventoryModel>,
+    delta: number
+  ): void {
+    if (inventory.trackByLocation && inventory.locations.length > 0) {
+      const loc = inventory.locations[0];
+      loc.currentStock = Math.max(0, loc.currentStock + delta);
+      loc.lastUpdated = new Date();
+      loc.updatedBy = new mongoose.Types.ObjectId('000000000000000000000000');
+      loc.updatedByName = 'System';
+    } else {
+      inventory.currentStock = Math.max(0, inventory.currentStock + delta);
+    }
+  }
+
+  /**
    * Deduct stock for completed order
    * Called when order status changes to 'completed'
    */
@@ -42,10 +66,7 @@ class InventoryService {
         });
 
         if (inventory) {
-          inventory.currentStock = Math.max(
-            0,
-            inventory.currentStock - actualQuantity
-          );
+          InventoryService.applyOrderStockDelta(inventory, -actualQuantity);
 
           let reason = 'Sale';
           let notes: string | undefined;
@@ -105,10 +126,7 @@ class InventoryService {
         if (!linkedInv) continue;
 
         const linkedAmount = actualQuantity * deductionPerUnit;
-        linkedInv.currentStock = Math.max(
-          0,
-          linkedInv.currentStock - linkedAmount
-        );
+        InventoryService.applyOrderStockDelta(linkedInv, -linkedAmount);
 
         await StockMovementModel.create({
           inventoryId: linkedInv._id,
@@ -177,7 +195,7 @@ class InventoryService {
         });
 
         if (inventory) {
-          inventory.currentStock += actualQuantity;
+          InventoryService.applyOrderStockDelta(inventory, actualQuantity);
 
           let notes: string | undefined;
           if (item.portionSize === 'half') {
@@ -228,7 +246,7 @@ class InventoryService {
         if (!linkedInv) continue;
 
         const linkedAmount = actualQuantity * deductionPerUnit;
-        linkedInv.currentStock += linkedAmount;
+        InventoryService.applyOrderStockDelta(linkedInv, linkedAmount);
 
         await StockMovementModel.create({
           inventoryId: linkedInv._id,

--- a/services/tab-service.ts
+++ b/services/tab-service.ts
@@ -910,90 +910,129 @@ export class TabService {
   }
 
   /**
-   * Delete a tab
-   * Requirements:
-   * - Tab must not be closed/paid (status must be 'open' or 'settling')
-   * - All orders on the tab must be cancelled first
+   * Delete a tab.
+   *
+   * Default path (admin): tab must not be closed+paid, and all linked
+   * orders must already be cancelled. Hard-deletes the tab and writes a
+   * `tab.delete` audit log.
+   *
+   * Super-admin path (`opts.superAdminOverride === true`): bypasses both
+   * guards. If `opts.revertItems === true`, each non-cancelled linked
+   * order is set to `cancelled` and — if inventory was deducted — its
+   * stock is restored via `InventoryService.restoreStockForOrder`. Each
+   * such order gets its own `order.cancel` audit log. The role gate for
+   * the override lives in the calling action (`deleteTabAction`).
    */
-  static async deleteTab(tabId: string, deletedBy: string): Promise<void> {
+  static async deleteTab(
+    tabId: string,
+    deletedBy: string,
+    opts?: { superAdminOverride?: boolean; revertItems?: boolean }
+  ): Promise<void> {
     await connectDB();
 
-    console.log('deleteTab called with:', { tabId, deletedBy });
+    const superAdminOverride = opts?.superAdminOverride === true;
+    const revertItems = opts?.revertItems === true;
 
     const tab = await TabModel.findById(tabId);
     if (!tab) {
       throw new Error('Tab not found');
     }
 
-    console.log('Tab found:', {
-      status: tab.status,
-      paymentStatus: tab.paymentStatus,
-      orderCount: tab.orders.length,
-    });
-
-    // Check if tab is already closed/paid
-    if (tab.status === 'closed' && tab.paymentStatus === 'paid') {
+    if (
+      !superAdminOverride &&
+      tab.status === 'closed' &&
+      tab.paymentStatus === 'paid'
+    ) {
       throw new Error(
         'Cannot delete a closed/paid tab. Only open or unpaid tabs can be deleted.'
       );
     }
 
-    // Get all orders on this tab
     const orders = await OrderModel.find({
       _id: { $in: tab.orders },
     });
 
-    console.log(
-      'Orders found:',
-      orders.map((o) => ({ id: o._id, status: o.status }))
-    );
-
-    // Check if any orders are not cancelled
     const nonCancelledOrders = orders.filter(
       (order) => order.status !== 'cancelled'
     );
-    if (nonCancelledOrders.length > 0) {
-      console.log(
-        'Non-cancelled orders found:',
-        nonCancelledOrders.map((o) => ({ id: o._id, status: o.status }))
-      );
+    if (!superAdminOverride && nonCancelledOrders.length > 0) {
       throw new Error(
         `Cannot delete tab. Please cancel all ${nonCancelledOrders.length} order(s) on this tab first.`
       );
     }
 
-    console.log('All orders are cancelled, proceeding with deletion');
+    const AuditLogService = (await import('./audit-log-service'))
+      .AuditLogService;
 
-    // Create audit log before deletion
-    try {
-      const AuditLogService = (await import('./audit-log-service'))
-        .AuditLogService;
-      console.log('Creating audit log with userId:', deletedBy);
-      await AuditLogService.createLog({
-        userId: deletedBy,
-        userEmail: tab.customerEmail || 'unknown',
-        userRole: 'admin',
-        action: 'tab.delete',
-        resource: 'tab',
-        resourceId: tabId,
-        details: {
-          tabNumber: tab.tabNumber,
-          tableNumber: tab.tableNumber,
-          orderCount: orders.length,
-          deletedBy,
-        },
-      });
-      console.log('Audit log created successfully');
-    } catch (auditError) {
-      console.error('Error creating audit log:', auditError);
-      throw new Error(
-        `Failed to create audit log: ${auditError instanceof Error ? auditError.message : 'Unknown error'}`
-      );
+    const revertedOrderIds: string[] = [];
+    let inventoryRestoredCount = 0;
+    if (superAdminOverride && revertItems && nonCancelledOrders.length > 0) {
+      const InventoryService = (await import('./inventory-service')).default;
+      for (const order of nonCancelledOrders) {
+        const orderId = order._id.toString();
+        const previousStatus = order.status;
+        const wasDeducted = order.inventoryDeducted === true;
+
+        if (wasDeducted) {
+          await InventoryService.restoreStockForOrder(orderId);
+          inventoryRestoredCount += 1;
+        }
+
+        await OrderModel.updateOne(
+          { _id: order._id },
+          {
+            $set: { status: 'cancelled' },
+            $push: {
+              statusHistory: {
+                status: 'cancelled',
+                timestamp: new Date(),
+                note: 'Tab deleted by super-admin (revert items)',
+              },
+            },
+          }
+        );
+        revertedOrderIds.push(orderId);
+
+        await AuditLogService.createLog({
+          userId: deletedBy,
+          userEmail: tab.customerEmail || 'unknown',
+          userRole: 'super-admin',
+          action: 'order.cancel',
+          resource: 'order',
+          resourceId: orderId,
+          details: {
+            previousStatus,
+            reason: 'Tab deleted by super-admin',
+            viaTabDelete: true,
+            inventoryRestored: wasDeducted,
+          },
+        });
+      }
     }
 
-    // Delete the tab
-    console.log('Deleting tab from database');
+    await AuditLogService.createLog({
+      userId: deletedBy,
+      userEmail: tab.customerEmail || 'unknown',
+      userRole: superAdminOverride ? 'super-admin' : 'admin',
+      action: 'tab.delete',
+      resource: 'tab',
+      resourceId: tabId,
+      details: {
+        tabNumber: tab.tabNumber,
+        tableNumber: tab.tableNumber,
+        orderCount: orders.length,
+        deletedBy,
+        ...(superAdminOverride
+          ? {
+              superAdminOverride: true,
+              revertItems,
+              ordersAffected: revertedOrderIds,
+              inventoryRestored: inventoryRestoredCount,
+            }
+          : {}),
+      },
+    });
+
     await TabModel.findByIdAndDelete(tabId);
-    console.log('Tab deleted successfully from database');
   }
 }


### PR DESCRIPTION
## Summary

Promotes three UAT-verified PRs from develop to main:

- **#113** — \`feat(tabs): super-admin can delete tabs with optional inventory revert\` — super-admin gets an enabled Delete button on tabs blocked by closed+paid or non-cancelled-order guards. At delete-time, picks **Revert items** (restock inventory + cancel linked orders) or **Leave as-is**. Audit logs per cancelled order + enriched \`tab.delete\` log.
- **#114** — \`fix(tabs): make Revert items the visually obvious default in delete dialog\` — UAT testing exposed that the two radio options had equal visual weight and a stray click silently flipped to Leave-as-is. Each option is now a bordered card with a coloured ring when selected (primary for Revert, destructive for Leave-as-is) and Revert gets a **Recommended** pill.
- **#115** — \`fix(inventory): route deduct/restore via locations[0] for trackByLocation rows\` — UAT testing exposed that \`InventoryService.deductStockForOrder\` and \`restoreStockForOrder\` were assigning directly to \`inventory.currentStock\`, which the model's pre-save hook silently overwrites for any row with \`trackByLocation: true\` (it recomputes \`currentStock = sum(locations[].currentStock)\`). New helper mutates \`locations[0]\` so the hook's recompute reflects the change. Behaviour change: sales of location-tracked items now actually move stock (previously a silent no-op masked by manual reconciliation).

All verified on UAT. Full suite 809 pass / 4 skipped; tsc clean.

## Test plan

- [ ] CI green on the release PR
- [ ] After merge: prod health check on \`wawagardenbar-app-production-45c8.up.railway.app\`
- [ ] Watch low-stock alerts on prod for the next day — sales of location-tracked items will start moving \`currentStock\` for the first time, which may surface drift that manual reconciliation was masking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)