### PR TITLE
chore(ci): clean gate JSON evidence (devaudit 0.1.10, #48) [Ref: REQ-046]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,9 +94,13 @@ jobs:
 
       - name: SAST Scan
         run: |
+          # --output writes the JSON report to the file directly; stderr
+          # (progress/metrics/version notices) goes to /dev/null. Using
+          # `> file 2>&1` instead merged semgrep's stderr into the JSON and
+          # produced an unparseable file (DevAudit #48).
           semgrep scan --config auto app/ lib/ \
             --severity ERROR --severity WARNING \
-            --json > sast-results.json 2>&1 || true
+            --json --output sast-results.json 2>/dev/null || true
           FINDINGS=$(python3 -c "
           import json
           with open('sast-results.json') as f:
@@ -115,7 +119,8 @@ jobs:
 
       - name: Dependency Audit
         run: |
-          npm audit --json > dependency-audit.json 2>&1 || true
+          # stderr → /dev/null so warnings can't corrupt the JSON (DevAudit #48)
+          npm audit --json > dependency-audit.json 2>/dev/null || true
           ACCEPTED=""
           UNACCEPTED=$(python3 -c "
           import json
@@ -152,9 +157,15 @@ jobs:
         run: npx wait-on http://localhost:3000 --timeout 120000
 
       - name: E2E Tests
-        run: |
-          PLAYWRIGHT_HTML_REPORTER_OPEN=never npx playwright test --project=chromium --reporter=json,html > e2e-results.json 2>/dev/null \
-            || PLAYWRIGHT_HTML_REPORTER_OPEN=never npx playwright test --project=chromium --reporter=html
+        env:
+          # PLAYWRIGHT_JSON_OUTPUT_NAME makes the json reporter write straight
+          # to the file. Capturing stdout (`> e2e-results.json`) instead mixed
+          # the html reporter's "To open report" line in after the JSON blob
+          # and produced an unparseable file (DevAudit #48). html report still
+          # lands in playwright-report/.
+          PLAYWRIGHT_HTML_REPORTER_OPEN: never
+          PLAYWRIGHT_JSON_OUTPUT_NAME: e2e-results.json
+        run: npx playwright test --project=chromium --reporter=json,html
 
       # ── Gate 5: Build ──
 
@@ -293,7 +304,7 @@ jobs:
           if [ ! -f ci-evidence/sast-results.json ]; then
             VENV="$HOME/.semgrep-venv"
             if [ -x "$VENV/bin/semgrep" ]; then
-              "$VENV/bin/semgrep" scan --config auto app/ lib/ --json > ci-evidence/sast-results.json 2>/dev/null || echo '{"results":[]}' > ci-evidence/sast-results.json
+              "$VENV/bin/semgrep" scan --config auto app/ lib/ --json --output ci-evidence/sast-results.json 2>/dev/null || echo '{"results":[]}' > ci-evidence/sast-results.json
             else
               echo '{"results":[]}' > ci-evidence/sast-results.json
             fi


### PR DESCRIPTION
Applies DevAudit-Installer v0.1.10 (#48) to WGB.

`ci.yml` regenerated so gate JSON is valid + viewable:
- semgrep → `--json --output sast-results.json 2>/dev/null` (was `> file 2>&1`)
- Playwright → `PLAYWRIGHT_JSON_OUTPUT_NAME=e2e-results.json` (was `--reporter=json,html > file`)
- npm audit → `2>/dev/null`

`Ref: REQ-046` so the develop CI run uploads clean `sast-results.json` + `e2e-results.json` to the REQ-046 release (which is still DRAFT). The earlier corrupted artifacts remain in the append-only store; the new clean ones are the viewable current evidence.