### PR TITLE
fix(rewards): [REQ-046] D3 — blank IG cadence fields now save

### DIFF
--- a/__tests__/components/reward-rule-form-schema.test.ts
+++ b/__tests__/components/reward-rule-form-schema.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Client-side form-schema coverage for the IG cadence fields (REQ-046).
+ *
+ * REQ-046 D3: a blank cadence `<input>` submits "" which `z.coerce.number()`
+ * turns into 0, so the original `.min(1).optional()` rejected a *blank* field
+ * even though the UI invites operators to leave it blank ("Leave blank for the
+ * legacy one-award-per-post behaviour"). These tests lock in that blank cadence
+ * parses cleanly while genuinely invalid values are still rejected, and that
+ * the validation toast can name the nested sub-field.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  formSchema,
+  firstErrorPath,
+} from '@/components/features/admin/rewards/reward-rule-form';
+
+const baseSocialRule = {
+  name: 'IG engagement',
+  description: 'Earn points for Instagram posts',
+  isActive: true,
+  spendThreshold: 0,
+  triggerType: 'social_instagram' as const,
+  rewardType: 'loyalty-points' as const,
+  rewardValue: 100,
+  probability: 100,
+  validityDays: 30,
+  socialConfig: {
+    platform: 'instagram' as const,
+    hashtag: '#wawa',
+    minViews: 0,
+    maxPostsPerPeriod: 5,
+    periodType: 'weekly' as const,
+    pointsAwarded: 100,
+  },
+};
+
+describe('reward-rule-form formSchema — cadence fields (REQ-046 D3)', () => {
+  it('accepts a social rule with cadence fields left blank ("")', () => {
+    const result = formSchema.safeParse({
+      ...baseSocialRule,
+      socialConfig: {
+        ...baseSocialRule.socialConfig,
+        postsRequired: '',
+        windowDays: '',
+        requireMention: true,
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // blank → omitted (undefined), not 0
+      expect(result.data.socialConfig?.postsRequired).toBeUndefined();
+      expect(result.data.socialConfig?.windowDays).toBeUndefined();
+    }
+  });
+
+  it('accepts a valid "3 posts in 7 days" cadence and coerces to numbers', () => {
+    const result = formSchema.safeParse({
+      ...baseSocialRule,
+      socialConfig: {
+        ...baseSocialRule.socialConfig,
+        postsRequired: '3',
+        windowDays: '7',
+        requireMention: false,
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.socialConfig?.postsRequired).toBe(3);
+      expect(result.data.socialConfig?.windowDays).toBe(7);
+    }
+  });
+
+  it('still rejects a cadence value below 1', () => {
+    const result = formSchema.safeParse({
+      ...baseSocialRule,
+      socialConfig: {
+        ...baseSocialRule.socialConfig,
+        postsRequired: '0',
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('still rejects a non-integer cadence value', () => {
+    const result = formSchema.safeParse({
+      ...baseSocialRule,
+      socialConfig: {
+        ...baseSocialRule.socialConfig,
+        windowDays: '2.5',
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('firstErrorPath — nested error reporting (REQ-046 D3)', () => {
+  it('returns the dotted path of a nested leaf error', () => {
+    const errors = {
+      socialConfig: {
+        postsRequired: { type: 'min', message: 'Number must be >= 1' },
+      },
+    };
+    expect(firstErrorPath(errors)).toBe('socialConfig.postsRequired');
+  });
+
+  it('returns a top-level field name when the error is not nested', () => {
+    const errors = { name: { type: 'too_small', message: 'too short' } };
+    expect(firstErrorPath(errors)).toBe('name');
+  });
+
+  it('returns undefined when there are no errors', () => {
+    expect(firstErrorPath({})).toBeUndefined();
+  });
+});

--- a/compliance/evidence/REQ-046/defects.md
+++ b/compliance/evidence/REQ-046/defects.md
@@ -34,6 +34,22 @@
 
 ---
 
+## D3 — Blank cadence fields rejected; toast names only `socialConfig`
+
+**Reported by:** maintainer, UAT smoke (2026-05-25)
+**Symptom:** On `/dashboard/rewards/rules/new`, saving a `social_instagram` rule with the **Cadence (optional)** fields left blank fails with a red toast: *"Couldn't save: form has errors — Check the 'socialConfig' field."* The Cadence subsection's own help text tells operators to leave the fields blank for legacy one-award-per-post behaviour, so the rule is unsaveable by following the on-screen guidance.
+
+**Root cause:** An empty number `<input>` submits `""` (not `undefined`). `z.coerce.number()` coerces `""` → `0` (`Number("") === 0`), so the original `postsRequired`/`windowDays` definition `z.coerce.number().int().min(1).optional()` fails `.min(1)` on the `0` — the `.optional()` branch only engages for `undefined`, never `""`. Confirmed empirically (`safeParse` of a blank-cadence social rule fails on `postsRequired` and `windowDays`). Separately, the D1 `onInvalid` toast read `Object.keys(validationErrors)[0]`, which for a nested error is the parent key `socialConfig`, hiding the real sub-field.
+
+**Fix (this PR):**
+- Added an `optionalCount` preprocessor in `reward-rule-form.tsx` that maps `"" | null | undefined → undefined` before `z.coerce.number().int().min(1).optional()`, and used it for `postsRequired` + `windowDays`. Blank now parses as omitted (not `0`); genuinely invalid values (`0`, negative, non-integer) are still rejected.
+- Replaced the toast's top-level key lookup with a recursive `firstErrorPath()` helper that returns the dotted leaf path (e.g. `socialConfig.postsRequired`).
+- Exported `formSchema` + `firstErrorPath` and added `__tests__/components/reward-rule-form-schema.test.ts` (7 cases): blank cadence parses + is omitted; valid `3/7` coerces to numbers; `0` and `2.5` rejected; nested-error path resolution.
+
+**Severity:** MEDIUM (blocks the headline REQ-046 cadence feature when used as documented; no data loss). Client-side only — server schema already accepts `undefined` for the optional fields.
+
+---
+
 ## Verification on UAT after the fix lands
 
 1. Log in as super-admin → `/dashboard/rewards/rules/new`.
@@ -44,8 +60,9 @@
 6. Edit, change postsRequired to 5, save, re-open. Persistence verified.
 7. Create a `triggerType: transaction` rule (no socialConfig). Save succeeds (regression).
 8. Negative case: try saving a `social_instagram` rule with hashtag blank. Expect a visible "Couldn't save: form has errors" toast (D1 surfacing fix), not silent no-op.
+9. **D3:** Set `triggerType: social_instagram`, fill the required fields, **leave all three Cadence fields blank**, click **Save**. Expect success (rule created with no cadence). Negative: enter `postsRequired: 0` → toast reads *"Check the 'socialConfig.postsRequired' field"* (nested path), not just `socialConfig`.
 
 ## Suite at fix-PR push
 
-- `npx tsc --noEmit` → clean
-- `npx vitest run` → 816 pass / 4 skipped (was 813; +3 new on the action)
+- D1/D2 PR (#127): `npx vitest run` → 816 pass / 4 skipped (was 813; +3 on the action)
+- D3 PR (this branch): `npx tsc --noEmit` → clean; `npx vitest run` → 828 pass / 4 skipped (+7 new in `__tests__/components/reward-rule-form-schema.test.ts`)

--- a/compliance/evidence/REQ-046/test-execution-summary.md
+++ b/compliance/evidence/REQ-046/test-execution-summary.md
@@ -50,12 +50,13 @@ Pending — to be executed by maintainer after PR #124 merges to develop and dep
 
 ## Defects logged
 
-Two defects found during UAT smoke on 2026-05-25 (both fixed in the follow-up PR; see `defects.md`):
+Three defects found during UAT smoke on 2026-05-25 (all fixed; see `defects.md`):
 
 - **D1** — `socialConfig.platform` not populated on a fresh `social_instagram` rule; client-side Zod failed on the platform enum and react-hook-form silently aborted submit ("nothing happens on Save"). MEDIUM. Fixed via a `useEffect` in `reward-rule-form.tsx` + a visible `onInvalid` toast for future failures.
 - **D2** — Server-side `rewardRuleSchema` (in `app/actions/admin/reward-rules-actions.ts`) silently stripped `triggerType` and `socialConfig`. Pre-existing — affected `createRewardRuleAction` and `updateRewardRuleAction`. MEDIUM. Fixed by extending both Zod schemas with the social-rule fields; 3 new vitest cases lock in the regression.
+- **D3** — Blank Cadence fields (`postsRequired`/`windowDays`) rejected on save because `z.coerce.number()` turns `""` into `0` and `.min(1)` fails, despite the UI inviting operators to leave them blank; toast named only `socialConfig`. MEDIUM. Fixed with an `optionalCount` preprocessor (`"" → undefined`) and a recursive `firstErrorPath()` for the toast; 7 new vitest cases in `__tests__/components/reward-rule-form-schema.test.ts`.
 
-Post-fix suite: 816 pass / 4 skipped (delta +3 from 813).
+Post-fix suite (D3 branch off develop): 828 pass / 4 skipped, including the 7 new D3 cases. `npx tsc --noEmit` clean.
 
 ## Conclusion
 

--- a/components/features/admin/rewards/reward-rule-form.tsx
+++ b/components/features/admin/rewards/reward-rule-form.tsx
@@ -32,9 +32,23 @@ import { useToast } from '@/hooks/use-toast';
 import { IRewardRule } from '@/interfaces';
 
 /**
+ * Optional positive-integer field for cadence inputs.
+ *
+ * REQ-046 D3 fix: an empty number `<input>` submits "" (not undefined), and
+ * `z.coerce.number()` coerces "" → 0, so a plain `.min(1).optional()` rejects a
+ * *blank* cadence field even though the UI invites operators to leave it blank.
+ * Preprocess empty/null → undefined first so the `.optional()` branch engages
+ * and the field is omitted from the payload.
+ */
+const optionalCount = z.preprocess(
+  (v) => (v === '' || v === null || v === undefined ? undefined : v),
+  z.coerce.number().int().min(1).optional()
+);
+
+/**
  * Form validation schema
  */
-const formSchema = z.object({
+export const formSchema = z.object({
   name: z.string().min(3, 'Name must be at least 3 characters').max(100),
   description: z.string().min(10, 'Description must be at least 10 characters').max(500),
   isActive: z.boolean(),
@@ -47,8 +61,8 @@ const formSchema = z.object({
     maxPostsPerPeriod: z.coerce.number().min(1),
     periodType: z.enum(['weekly', 'monthly', 'campaign_duration']),
     pointsAwarded: z.coerce.number().min(1),
-    postsRequired: z.coerce.number().int().min(1).optional(),
-    windowDays: z.coerce.number().int().min(1).optional(),
+    postsRequired: optionalCount,
+    windowDays: optionalCount,
     requireMention: z.boolean().optional(),
   }).optional(),
   rewardType: z.enum(['discount-percentage', 'discount-fixed', 'free-item', 'loyalty-points']),
@@ -66,6 +80,26 @@ const formSchema = z.object({
 });
 
 type FormData = z.infer<typeof formSchema>;
+
+/**
+ * Walk a react-hook-form error tree and return the dotted path of the first
+ * leaf error (e.g. "socialConfig.postsRequired"). RHF nests errors to mirror
+ * the form shape; a leaf is the node carrying a string `message`.
+ */
+export function firstErrorPath(
+  errors: Record<string, unknown>,
+  prefix = ''
+): string | undefined {
+  for (const key of Object.keys(errors)) {
+    const node = errors[key] as Record<string, unknown> | undefined;
+    if (!node || typeof node !== 'object') continue;
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (typeof node.message === 'string') return path;
+    const nested = firstErrorPath(node, path);
+    if (nested) return nested;
+  }
+  return undefined;
+}
 
 /**
  * Reward type options with metadata
@@ -280,11 +314,12 @@ export function RewardRuleForm({
         // operators see *why* Save isn't progressing instead of nothing
         // happening at all. react-hook-form silently swallows them by
         // default.
-        const firstField = Object.keys(validationErrors)[0];
-        const detail =
-          firstField && typeof firstField === 'string'
-            ? `Check the "${firstField}" field`
-            : 'Some fields are invalid';
+        // REQ-046 D3 follow-up: drill into nested errors (e.g. socialConfig.*)
+        // so the toast names the actual sub-field, not just the parent object.
+        const firstField = firstErrorPath(validationErrors);
+        const detail = firstField
+          ? `Check the "${firstField}" field`
+          : 'Some fields are invalid';
         toast({
           title: "Couldn't save: form has errors",
           description: detail,


### PR DESCRIPTION
## What

Third defect fix on REQ-046 (IG cadence). On `/dashboard/rewards/rules/new`, saving a `social_instagram` rule with the **Cadence (optional)** fields left blank failed with *"Couldn't save: form has errors — Check the 'socialConfig' field"* — despite the UI telling operators to leave them blank.

## Root cause

An empty number `<input>` submits `""`, and `z.coerce.number()` coerces `""` → `0` (`Number("") === 0`), so `postsRequired`/`windowDays` failed `.min(1)`. `.optional()` only fires for `undefined`, never `""`. Confirmed empirically. The error toast also showed only the parent key (`socialConfig`) because it read `Object.keys(validationErrors)[0]`.

## Fix (client-side only — `components/features/admin/rewards/reward-rule-form.tsx`)

- `optionalCount` preprocessor maps `"" | null | undefined → undefined` before `z.coerce.number().int().min(1).optional()`, applied to `postsRequired` + `windowDays`. Blank now parses as omitted; `0` / negatives / non-integers still rejected. Server schema already accepts `undefined`, so no server change.
- Recursive `firstErrorPath()` so the toast names the nested sub-field (e.g. `socialConfig.postsRequired`).
- Exported `formSchema` + `firstErrorPath`; added `__tests__/components/reward-rule-form-schema.test.ts` (7 cases).

## Verification

- `npx tsc --noEmit` clean
- `npx vitest run` → **828 pass / 4 skipped** (incl. 7 new)
- Logged as **D3** in `compliance/evidence/REQ-046/defects.md` + updated `test-execution-summary.md`

Ref: REQ-046

🤖 Generated with [Claude Code](https://claude.com/claude-code)