### PR TITLE
chore(compliance): enable UAT-env verification for all releases

### DIFF
--- a/SDLC/3-compile-evidence.md
+++ b/SDLC/3-compile-evidence.md
@@ -399,7 +399,7 @@ If it fails — typically a stale `devaudit.base_url`, a revoked `DEVAUDIT_API_K
 **Skip this step entirely if any of these are true:**
 
 - Project's `sdlc-config.json` has `uat.enabled: false` — meaning the project has no deployed UAT environment configured (internal services, retroactive-compliance pickups, etc.).
-- Requirement's risk class is **not** listed in project's `uat.required_risk_classes` (defaults: `payment`, `destructive_migration`, `realtime`, `physical_ux`). Text-only fixes, internal refactors, low-risk UI tweaks carry none of these and skip UAT-env verification.
+- Requirement's risk class is **not** listed in project's `uat.required_risk_classes` (defaults: `payment`, `destructive_migration`, `realtime`, `physical_ux`). Text-only fixes, internal refactors, low-risk UI tweaks carry none of these and skip UAT-env verification. **Wildcard:** if `required_risk_classes` contains `"*"`, every requirement requires UAT-env verification regardless of risk class — use this for projects that deploy `develop` to a UAT environment and exercise every release there before promotion.
 
 When skipped, proceed directly to Step 11.
 

--- a/compliance/evidence/REQ-047/security-summary.md
+++ b/compliance/evidence/REQ-047/security-summary.md
@@ -26,3 +26,15 @@
 - semgrep: `cors-misconfiguration` cleared → **0 findings** (baseline 0) on the develop CI run.
 - No new findings introduced.
 - Credentials are now only ever paired with an explicitly configured origin.
+
+## UAT Verification — 2026-05-25
+
+Exercised against the deployed UAT environment (Stage 3 Step 10; `uat.required_risk_classes: ["*"]`).
+
+- UAT Health check: PASS — `GET /api/public/health` → 200.
+- UAT Smoke test: PASS — `GET /` → 200, `GET /api/public/health` → 200.
+- Feature verification: PASS — CORS origin reflection confirmed on the live deployment via `OPTIONS /api/public/health` preflights:
+  - Non-allow-listed `Origin: https://evil.example.com` → **no** `Access-Control-Allow-Origin` header returned (arbitrary origin not reflected).
+  - Configured `Origin: https://wawagardenbar-app-uat.up.railway.app` → echoed back exactly with `Vary: Origin`.
+  - `Access-Control-Allow-Credentials: true` is therefore only ever paired with an explicitly configured origin — confirming the `lib/cors.ts` hardening holds in the deployed environment, not just unit tests.
+- UAT URL: https://wawagardenbar-app-uat.up.railway.app/

--- a/sdlc-config.json
+++ b/sdlc-config.json
@@ -34,12 +34,10 @@
     "scripts/check-requirement-jsdoc.sh"
   ],
   "uat": {
-    "enabled": false,
-    "url": "",
+    "enabled": true,
+    "url": "https://wawagardenbar-app-uat.up.railway.app/",
     "required_risk_classes": [
-      "payment",
-      "destructive_migration",
-      "realtime"
+      "*"
     ]
   },
   "approval": {


### PR DESCRIPTION
## Summary

WGB deploys `develop` to https://wawagardenbar-app-uat.up.railway.app/ and manually exercises **every** release there before the PR to `main`, but `sdlc-config.json` had `uat.enabled=false` — so Stage 3 Step 10 (UAT-environment verification) was skipped and no `uat-checklist` evidence was ever captured for testing the team actually performs (raised in DevAudit-Installer#52).

## Changes

- `sdlc-config.json` `uat` block:
  - `enabled: true`
  - `url: https://wawagardenbar-app-uat.up.railway.app/`
  - `required_risk_classes: ["*"]` — require UAT-env verification for **every** requirement, matching WGB's practice of UATing every release.
- `SDLC/3-compile-evidence.md` — pulls in the matching Step 10 `"*"` wildcard clause so it is honoured now; reconciles with upstream on the next `devaudit update`.

The `"*"` wildcard is defined canonically in DevAudit-Installer#53.

## Notes

Config/doc-only (both paths are in `paths_ignore`), so the quality-gate CI does not run. Going forward, releases should record a `uat-checklist` artifact per Step 10.

Ref: DevAudit-Installer#52

🤖 Generated with [Claude Code](https://claude.com/claude-code)