### PR TITLE
fix(rewards): [REQ-046] D4 — persist periodType default so blank-cadence save works

### DIFF
--- a/__tests__/components/reward-rule-form-schema.test.ts
+++ b/__tests__/components/reward-rule-form-schema.test.ts
@@ -7,6 +7,13 @@
  * legacy one-award-per-post behaviour"). These tests lock in that blank cadence
  * parses cleanly while genuinely invalid values are still rejected, and that
  * the validation toast can name the nested sub-field.
+ *
+ * REQ-046 D4: the Period Type select shows "weekly" as a display fallback but
+ * never wrote it to form state, so an untouched select submitted
+ * periodType:undefined and the required enum blocked the same blank-cadence
+ * save. The schema now defaults periodType to 'weekly'; these tests lock in
+ * that an untouched select parses to 'weekly' while explicit/invalid values
+ * behave correctly.
  */
 import { describe, it, expect } from 'vitest';
 import {
@@ -88,6 +95,40 @@ describe('reward-rule-form formSchema — cadence fields (REQ-046 D3)', () => {
         ...baseSocialRule.socialConfig,
         windowDays: '2.5',
       },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('reward-rule-form formSchema — periodType default (REQ-046 D4)', () => {
+  it('defaults periodType to "weekly" when the select is untouched (undefined)', () => {
+    const result = formSchema.safeParse({
+      ...baseSocialRule,
+      socialConfig: {
+        platform: 'instagram' as const,
+        hashtag: '#wawa',
+        minViews: 0,
+        maxPostsPerPeriod: 5,
+        pointsAwarded: 100,
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.socialConfig?.periodType).toBe('weekly');
+  });
+
+  it('preserves an explicitly chosen periodType (does not clobber on edit)', () => {
+    const result = formSchema.safeParse({
+      ...baseSocialRule,
+      socialConfig: { ...baseSocialRule.socialConfig, periodType: 'monthly' as const },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.socialConfig?.periodType).toBe('monthly');
+  });
+
+  it('still rejects an invalid periodType value', () => {
+    const result = formSchema.safeParse({
+      ...baseSocialRule,
+      socialConfig: { ...baseSocialRule.socialConfig, periodType: 'daily' },
     });
     expect(result.success).toBe(false);
   });

--- a/compliance/evidence/REQ-046/defects.md
+++ b/compliance/evidence/REQ-046/defects.md
@@ -50,6 +50,21 @@
 
 ---
 
+## D4 — `socialConfig.periodType` not persisted; blank-cadence save still blocked
+
+**Reported by:** maintainer, UAT verification of the D3 fix (2026-05-25)
+**Symptom:** On `/dashboard/rewards/rules/new`, saving a `social_instagram` rule with the Cadence fields left blank (the D3 scenario) still fails with a red toast: *"Couldn't save: form has errors — Check the 'socialConfig.periodType' field."* The D3 fix correctly unblocked the cadence count fields and the nested-path toast works, but a different field — Period Type — now surfaces as the blocker.
+
+**Root cause:** The Period Type `<Select>` renders its value as `watch('socialConfig.periodType') || 'weekly'`, so the UI always *shows* "Weekly", but that fallback is display-only — it is never written into react-hook-form state. On a fresh rule an operator who accepts the shown default (never opens the select) submits `periodType: undefined`, which fails the required `z.enum(['weekly','monthly','campaign_duration'])`. This is the same class as D1 (`platform` shown but not in form state); D3's documented verification masked it by instructing the tester to set periodType manually. `periodType` is genuinely required per `ISocialRewardConfig` (it scopes the `maxPostsPerPeriod` repeat-award cap), so it must be persisted, not made optional.
+
+**Fix (this PR):**
+- Changed the schema field to `z.enum([...]).default('weekly')` in `reward-rule-form.tsx`, so the displayed default is the value persisted on submit (zodResolver applies it) while an edited rule still loads its stored value first.
+- Added a `periodType default (REQ-046 D4)` describe block to `__tests__/components/reward-rule-form-schema.test.ts` (3 cases): undefined → defaults to `weekly`; an explicit `monthly` is preserved (no clobber on edit); an invalid value is still rejected.
+
+**Severity:** MEDIUM (blocks the same blank-cadence flow D3 targeted; no data loss). Client-side only.
+
+---
+
 ## Verification on UAT after the fix lands
 
 1. Log in as super-admin → `/dashboard/rewards/rules/new`.
@@ -61,8 +76,10 @@
 7. Create a `triggerType: transaction` rule (no socialConfig). Save succeeds (regression).
 8. Negative case: try saving a `social_instagram` rule with hashtag blank. Expect a visible "Couldn't save: form has errors" toast (D1 surfacing fix), not silent no-op.
 9. **D3:** Set `triggerType: social_instagram`, fill the required fields, **leave all three Cadence fields blank**, click **Save**. Expect success (rule created with no cadence). Negative: enter `postsRequired: 0` → toast reads *"Check the 'socialConfig.postsRequired' field"* (nested path), not just `socialConfig`.
+10. **D4:** Repeat step 9 but **do not open the Period Type select** (accept the shown "Weekly"). Click **Save**. Expect success — the rule persists with `periodType: weekly`. Before the fix this failed with *"Check the 'socialConfig.periodType' field"*.
 
 ## Suite at fix-PR push
 
 - D1/D2 PR (#127): `npx vitest run` → 816 pass / 4 skipped (was 813; +3 on the action)
-- D3 PR (this branch): `npx tsc --noEmit` → clean; `npx vitest run` → 828 pass / 4 skipped (+7 new in `__tests__/components/reward-rule-form-schema.test.ts`)
+- D3 PR (#131): `npx tsc --noEmit` → clean; `npx vitest run` → 828 pass / 4 skipped (+7 new in `__tests__/components/reward-rule-form-schema.test.ts`)
+- D4 PR (this branch): +3 cases in `__tests__/components/reward-rule-form-schema.test.ts` (periodType default); CI is the verification source (no local node_modules).

--- a/components/features/admin/rewards/reward-rule-form.tsx
+++ b/components/features/admin/rewards/reward-rule-form.tsx
@@ -59,7 +59,13 @@ export const formSchema = z.object({
     hashtag: z.string().min(2, 'Hashtag required'),
     minViews: z.coerce.number().min(0),
     maxPostsPerPeriod: z.coerce.number().min(1),
-    periodType: z.enum(['weekly', 'monthly', 'campaign_duration']),
+    // REQ-046 D4: the Period Type <Select> renders "weekly" as a display
+    // fallback (value={watch(...) || 'weekly'}) but never writes it to
+    // react-hook-form state, so an untouched select submits periodType:
+    // undefined and the required enum aborts the save (same class as the D1
+    // platform bug above). Default to 'weekly' so the displayed value is the
+    // one persisted; an edited rule still loads its stored value first.
+    periodType: z.enum(['weekly', 'monthly', 'campaign_duration']).default('weekly'),
     pointsAwarded: z.coerce.number().min(1),
     postsRequired: optionalCount,
     windowDays: optionalCount,


### PR DESCRIPTION
## Symptom (UAT, 2026-05-25)

Saving a `social_instagram` reward rule with the **Cadence** fields left blank — the D3 scenario — still fails: *"Couldn't save: form has errors — Check the 'socialConfig.periodType' field."*

## Root cause

The Period Type `<Select>` renders its value as `watch('socialConfig.periodType') || 'weekly'`, so the UI always shows **Weekly**, but that fallback is display-only — it is never written to react-hook-form state. An operator who accepts the shown default (never opens the select) submits `periodType: undefined`, failing the required `z.enum`. Same class as the **D1** platform bug; D3's documented UAT steps masked it by instructing the tester to set Period Type manually.

`periodType` is genuinely **required** per `ISocialRewardConfig` (it scopes the `maxPostsPerPeriod` repeat-award cap), so the fix **persists the default** rather than making it optional.

## Fix

- `reward-rule-form.tsx`: `periodType: z.enum([...]).default('weekly')`. zodResolver applies the default on submit; an edited rule still loads its stored value first.
- `__tests__/components/reward-rule-form-schema.test.ts`: +3 cases (undefined → `weekly`; explicit `monthly` preserved; invalid rejected).
- Logged as **D4** in `compliance/evidence/REQ-046/defects.md` with a UAT re-verification step.

## Verification

CI is the verification source (no local node_modules). After merge + UAT redeploy: create a social rule, leave cadence blank, **do not open the Period Type select**, Save → expect success with `periodType: weekly`.

Ref: REQ-046

🤖 Generated with [Claude Code](https://claude.com/claude-code)