### PR TITLE
chore: promote REQ-046/047 ticket-status close-out fix to main

### DIFF
--- a/compliance/approved-releases/RELEASE-TICKET-REQ-046.md
+++ b/compliance/approved-releases/RELEASE-TICKET-REQ-046.md
@@ -1,13 +1,14 @@
 # Release Ticket: REQ-046 — IG-1 cadence schema + IG-6 admin form fields
 
-**Status:** TESTED - PENDING SIGN-OFF
-**Date:** 2026-05-25 (last updated 2026-05-26)
+**Status:** RELEASED
+**Date:** 2026-05-25 (released 2026-05-27)
 **Requirement ID:** REQ-046
 **Risk Level:** LOW
 **GitHub Issue:** [#117](https://github.com/metasession-dev/wawagardenbar-app/issues/117) (IG band, items IG-1 + IG-6)
 **Implementation PR:** [#124](https://github.com/metasession-dev/wawagardenbar-app/pull/124) (IG-1 schema + IG-6 form), followed by UAT defect fixes [#127](https://github.com/metasession-dev/wawagardenbar-app/pull/127) (D1+D2), [#131](https://github.com/metasession-dev/wawagardenbar-app/pull/131) (D3), [#133](https://github.com/metasession-dev/wawagardenbar-app/pull/133) (D4), [#134](https://github.com/metasession-dev/wawagardenbar-app/pull/134) (D5)
-**Release PR:** Will be linked when the develop → main PR is created
+**Release PR:** [#138](https://github.com/metasession-dev/wawagardenbar-app/pull/138) (develop → main, production deploy)
 **DevAudit Release:** `https://devaudit.metasession.co/projects/wgb/` (release version `REQ-046`)
+**Sign-off (dual-actor):** UAT approved + Production approved on the DevAudit portal (`released`); post-deploy production smoke evidence captured (`environment=production`). Close-out: ticket → `approved-releases/`, RTM row → `RELEASED`.
 
 ---
 

--- a/compliance/approved-releases/RELEASE-TICKET-REQ-047.md
+++ b/compliance/approved-releases/RELEASE-TICKET-REQ-047.md
@@ -1,11 +1,13 @@
 # Release Ticket: REQ-047 — Harden CORS origin reflection
 
-**Status:** TESTED - PENDING SIGN-OFF
-**Date:** 2026-05-25
+**Status:** RELEASED
+**Date:** 2026-05-25 (released 2026-05-27)
 **Requirement ID:** REQ-047
 **Risk Level:** LOW
 **GitHub Issue:** [#128](https://github.com/metasession-dev/wawagardenbar-app/issues/128)
+**Release PR:** [#138](https://github.com/metasession-dev/wawagardenbar-app/pull/138) (develop → main, production deploy)
 **DevAudit Release:** `https://devaudit.metasession.co/projects/wgb/` (release version `REQ-047`)
+**Sign-off (dual-actor):** UAT approved + Production approved on the DevAudit portal (`released`); post-deploy production smoke evidence captured (`environment=production`). Close-out: ticket → `approved-releases/`, RTM row → `RELEASED`.
 
 ---
 


### PR DESCRIPTION
Promotes #145 to `main` — the final piece of the REQ-046/047 close-out.

Carries the ticket-body fix: both `approved-releases/RELEASE-TICKET-REQ-046.md` and `-047.md` now read `**Status:** RELEASED` (with the #138 backlink + dual-actor sign-off), making the ticket bodies on `main` consistent with the RTM rows (which already say `RELEASED`).

Compliance-doc-only — no app code, no new requirement. Post-deploy finds no pending tickets, so it won't touch the released REQs.

Ref: REQ-046, REQ-047

🤖 Generated with [Claude Code](https://claude.com/claude-code)