### PR TITLE
chore: track .claude/skills/ in git (parity with META-JOBS)

### DIFF
--- a/.claude/skills/e2e-test-engineer/SKILL.md
+++ b/.claude/skills/e2e-test-engineer/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: e2e-test-engineer
+description: Maintain or bootstrap a project's end-to-end and visual regression test pack. Use when the user wants to add, update, or retire e2e or visual tests for a feature, ticket, issue, or PR — OR when no e2e suite exists yet and one needs setting up using best practices for the detected stack. Covers deriving the scenarios a change needs, matching the project's conventions, removing obsolete tests (only after confirmation), running the suite, and filing defects for failures or missed acceptance criteria. Trigger on phrases like "add e2e tests for [ticket]", "update the test pack", "what tests do we need for this issue", "are any tests obsolete", "run the e2e tests and file issues", "add visual regression coverage", "set up e2e tests for this project", or "bootstrap an e2e suite". Framework-agnostic (Playwright, Cypress, Selenium, etc.) and tracker-agnostic (GitHub, Jira, Linear, etc.). Do NOT use for unit, component, or API-only tests, or performance tests.
+---
+
+# E2E Test Engineer
+
+Maintain or bootstrap a project's e2e and visual regression test suite. Given an issue (or ticket, or PR) plus the implementation, derive the scenarios the change actually needs, reconcile them with what's already there (adding what's missing, retiring what's obsolete), run the suite, and surface defects and missed acceptance criteria. When no suite exists yet, set one up using best practices for the detected tech stack before adding the change's tests as the first real tests in the new suite.
+
+## Scope
+
+**In scope**
+- End-to-end tests (UI-driven, user-flow level) in any framework.
+- Visual regression tests in any tool.
+- Maintaining an existing test pack — adding, updating, retiring tests.
+- Bootstrapping a new e2e suite when none exists, including framework selection, structure, configuration, a starter smoke test, and (optionally) CI integration.
+
+**Out of scope**
+- Unit, component, or API-only tests.
+- Performance, load, or accessibility audits, unless the project's e2e pack already includes them — in which case follow its lead.
+
+## The workflow
+
+Six phases. Don't skip them and don't reorder — each one feeds the next. Communicate progress as you go; long silent phases feel like the skill has stalled.
+
+### Phase 1 — Orient
+
+Three things must be in hand before designing tests: the **test stack**, the **change**, and the **issue tracker**. Discover them in parallel where possible.
+
+**Detect the test stack** from the repo:
+
+- *E2E framework signals* — `playwright.config.*`, `cypress.config.*`, `wdio.conf.*`, `nightwatch.conf.*`, `codecept.conf.*`, `testcafe.config.*`. Failing that, check `package.json` dependencies for `@playwright/test`, `cypress`, `webdriverio`, `puppeteer`, `selenium-webdriver`, or Python equivalents (`pytest-playwright`, `selenium`, `splinter`).
+- *Test location* — common patterns: `e2e/`, `tests/e2e/`, `cypress/e2e/`, `playwright/`, `test/e2e/`, `__tests__/e2e/`.
+- *Visual regression tool* — Playwright or Cypress built-in snapshots, `cypress-image-snapshot`, `cypress-visual-regression`, `percy`, `applitools-eyes-*`, `chromatic`, `backstop.json`, `loki`, `reg-suit`. If none of these are present, the project doesn't do visual regression and you should only add it if the issue explicitly asks for it.
+- *Run command* — search `package.json` scripts for `e2e`, `test:e2e`, `cy:run`, `pw:test`. Failing that, check `Makefile`, `justfile`, `tox.ini`, `pyproject.toml`, CI config. If still unclear, ask.
+
+**Detect the issue tracker** so you can read the input issue now and file defect issues later:
+
+- GitHub: git remote on `github.com` → use the `gh` CLI if installed, or a connected GitHub MCP.
+- GitLab: `glab` CLI or a GitLab MCP.
+- Jira: an Atlassian MCP, or `jira-cli` config.
+- Linear: a Linear MCP.
+- Azure DevOps: the `az boards` CLI or an ADO MCP.
+- None of the above: ask the user where the source issue lives and where defects should go. Final fallback is a paste-ready markdown report.
+
+**Take in the change.** The user typically gives you one of:
+
+- An issue/ticket ID or URL → fetch its full text, description, comments, and acceptance criteria.
+- A PR/MR URL or a branch name → fetch the description and the diff.
+- A pasted description → use what you've been given; ask for the diff or branch if not provided.
+
+Briefly summarise what you found (the stack, the tracker, the change in one or two sentences) and confirm before continuing. The user is far more responsive to corrections now than after you've written twelve test files.
+
+**If no e2e suite was found, go to Phase 1b before continuing.** Otherwise skip to Phase 2.
+
+### Phase 1b — Bootstrap (only when no suite exists)
+
+This phase runs only if Phase 1 found no e2e framework, no test directory, and no relevant dependencies. Don't run it just because the existing suite is small or messy — that's a maintenance problem, not a bootstrap one.
+
+The goal of bootstrap is a working, well-configured e2e suite with one passing smoke test, set up so that any tests added afterward (including the change's tests in Phase 5) feel native to the project. **Read `references/bootstrap.md`** before you start — it has the per-stack framework recommendations, official-installer commands, config best practices, and structure templates.
+
+The bootstrap workflow:
+
+1. **Gather extra context** beyond what Phase 1 found:
+   - Frontend framework (React, Vue, Angular, Svelte, Next.js, Nuxt, mobile, Electron, etc.) — from `package.json` deps or equivalent.
+   - Language — `tsconfig.json` for TypeScript, otherwise JS or whatever the project uses.
+   - Package manager — `pnpm-lock.yaml` → pnpm; `yarn.lock` → yarn; otherwise npm. Or pip/poetry/uv for Python; bundler for Ruby; etc.
+   - Dev server command and port — from `scripts` in `package.json` or the equivalent.
+   - CI system — `.github/workflows/`, `.gitlab-ci.yml`, `.circleci/`, `Jenkinsfile`, `azure-pipelines.yml`.
+   - Any existing unit/integration test framework — for matching style (assertions, file naming, runner conventions).
+
+2. **Propose a framework choice with a one-line rationale, and get explicit confirmation.** This is a long-lived decision; do not install anything without a clear "yes". Use `references/bootstrap.md` for the recommendation matrix. Briefly mention the runner-up so the user can override if their team has a preference you couldn't infer.
+
+3. **Decide whether to include visual regression now.** If the user asked for it, or the originating issue is visually significant, yes. If unsure, ask. Visual regression has its own tooling decision (built-in snapshots vs cloud service like Percy/Chromatic/Applitools) — `references/bootstrap.md` covers this.
+
+4. **Install with the official installer** wherever one exists (e.g. `npm init playwright@latest`, `npx cypress install`). Official installers set up sensible defaults the skill shouldn't try to second-guess.
+
+5. **Lay out the directory structure** for the project's expected scale: a top-level test directory (`e2e/` or whatever the framework's installer chose), with subfolders for specs, fixtures, page objects (or fixture-based equivalent), helpers, and visual specs if applicable. Write the structure as a short tree in your reply so the user can see what was created.
+
+6. **Configure for best practice** — base URL pointing at the project's dev server, retries on CI only, parallel workers, an HTML reporter, trace on first retry, `screenshot: 'only-on-failure'` (failure forensics — see *Evidence vs failure forensics* below for per-AC evidence capture), video retention on failure, and (if the framework supports it) auto-starting the dev server before the suite runs. Specifics per framework are in `references/bootstrap.md`.
+
+7. **Establish the abstraction pattern** — write one Page Object Model (or one fixture, depending on framework idioms) as a worked example so the change's tests in Phase 5 have a template to follow.
+
+8. **Write a smoke test** that proves the setup works end-to-end: load the home page, assert the title or a known stable element. Run it. It must pass before you continue.
+
+9. **Wire up runner scripts** — at minimum `test:e2e` (headless), `test:e2e:ui` or `:headed` (interactive), `test:e2e:debug`, and `test:e2e:update-snapshots` if visual regression is in.
+
+10. **Offer a CI job** — write the YAML (or equivalent) for the project's CI system, but **do not commit it without confirmation**. Show it inline first. On a **DevAudit** project, `.github/workflows/ci.yml` is generated and marked do-not-edit-manually — don't hand-edit it; instead drive the E2E gate from `sdlc-config.json`. If the suite must run against a **disposable local database** (the rule on any project with no separate test instance — never test against prod), set `e2e_setup_command` (e.g. `supabase start` + load schema + seed) and `e2e_env` (e.g. `E2E_LOCAL=1`, local coords, a dummy email key) so the gate severs production. See [Local-database E2E in CI](https://github.com/metasession-dev/DevAudit-Installer/blob/main/docs/e2e-local-db-ci.md), then `devaudit update` to regenerate.
+
+11. **Write a short README** in the test directory explaining structure, how to run, how to add new tests, and how to update visual baselines. Future contributors (and the skill itself, on next invocation) will thank you.
+
+After bootstrap, if there's a change to test, continue to Phase 2 as normal. If the user only wanted the suite set up with no specific change in mind, stop here with a final summary.
+
+### Phase 2 — Understand the change
+
+You cannot write the right tests without understanding what changed and why. Spend real time here.
+
+1. **Read the issue end-to-end.** Capture: the user-facing goal, the explicit acceptance criteria (number them), any negative criteria ("should not allow X"), edge cases the description mentions, and any references to existing behaviour that must stay intact.
+
+2. **Read the implementation.** From the diff or branch:
+   - Which files changed — routes, components, state, API contracts, styles?
+   - What's the user-facing entry point — what URL, what control, what flow leads here?
+   - What pre-conditions does the new behaviour assume — auth state, feature flag, seed data?
+   - What adjacent surfaces share code with the change and could regress as a side effect?
+
+3. **Read the surrounding app** enough to know how a real user reaches the changed area. Look at routing, navigation, and the one or two most adjacent features.
+
+4. **Write a short mental model** in your reply: *trigger → new behaviour → expected outcomes → likely side-effects*. If anything is ambiguous, ask the user before designing scenarios. Guesses here cascade into bad tests.
+
+### Phase 3 — Design scenarios
+
+The goal is the *minimum* set of scenarios that, if they all pass, would give a reasonable person high confidence the change works as intended and hasn't broken adjacent functionality. "Minimum" is load-bearing: e2e tests are slow to run and expensive to maintain, and a bloated suite gets ignored.
+
+Derive scenarios from these sources, in this order:
+
+1. **One scenario per acceptance criterion.** If an AC is compound ("user can filter by status AND see a count"), split it.
+
+2. **One negative scenario per error path the change introduces.** Invalid input, unauthorised access, network failure — only if the change has explicit handling for it.
+
+3. **Boundary scenarios** where the change has obvious boundaries: empty state, max length, zero results, single result, many results.
+
+4. **Adjacent regression scenarios** — pick the one or two nearby flows most likely to break because they share code with the change. Don't try to re-test the whole app from this seat.
+
+5. **Visual regression scenarios** (only if the project does visual regression): each visually-changed component or page state gets a snapshot at the breakpoints the project already covers. Add one or two adjacent surfaces that share styling.
+
+Resist padding. A new endpoint doesn't need a test that re-verifies login if login is already covered. Match the project's existing depth — if it covers one happy path per feature, don't add six.
+
+For each scenario, write a one-line description. Present the full grouped list to the user before writing any code: *"Here's the coverage I'd propose — anything to add or drop?"*
+
+### Phase 4 — Reconcile with existing tests
+
+For the area touched by the change, look at what's already there.
+
+1. **Overlap** — find existing tests that already cover scenarios from Phase 3. Don't duplicate; either reuse or note the overlap and drop the duplicate from your add list.
+
+2. **Obsolete** — a test is obsolete when:
+   - The behaviour it asserts has been intentionally removed or replaced.
+   - The selectors or routes it uses no longer exist and the new equivalents are covered elsewhere.
+   - It tests an old version of a flow that has been fully superseded.
+
+   A test is **not** obsolete just because it's failing. Failing tests are signals, not garbage. Be conservative — when in doubt, propose updating rather than deleting.
+
+3. **Needs updating** — existing tests where the scenario is still valid but selectors, routes, or assertions have shifted.
+
+Present three lists to the user:
+- **To add** — new scenarios not already covered.
+- **To update** — existing tests needing adjustment.
+- **To delete** — genuinely obsolete tests, each with a one-line rationale.
+
+**Do not delete anything without explicit confirmation.** Not even tests you're 95% sure about. The cost of asking is one sentence; the cost of deleting real coverage is real. Wait for a clear "yes, delete those" before removing anything.
+
+### Phase 5 — Implement
+
+Write the tests in the project's existing style.
+
+- **Match the structure.** Same directory, same file-naming pattern, same test-ID or tag convention.
+- **Reuse existing helpers.** Page Object Models, fixtures, custom commands, test-data factories — use them. Don't invent parallel infrastructure.
+- **Match the assertion style.** If the codebase uses `expect(locator).toBeVisible()`, don't switch to `assert.isTrue(...)`.
+- **Read 2–3 nearby tests before writing.** Fastest way to absorb conventions you wouldn't have noticed otherwise.
+
+For **visual regression** specifically:
+- New tests need baseline images. Generate them, but **do not auto-approve** — surface them for the user to verify before they're committed.
+- Use the project's existing breakpoints, viewports, and element-masking conventions.
+
+Do additions, updates, and (approved) deletions in the same change so the suite stays internally consistent.
+
+### Phase 6 — Execute and report
+
+Run the suite. Strategy:
+
+1. **Run the new and updated tests first** in isolation if the framework supports filtering. Fast feedback on whether your tests themselves work.
+2. **Then run the full suite** to catch regressions outside the changed area.
+3. **For visual regression**, run the project's normal comparison mode against existing baselines.
+
+Triage every failure into one of these buckets *before* taking any action:
+
+- **Flake** — non-deterministic; passes on rerun. Rerun once. If it passes, note it. If it keeps flaking, flag it but don't file a noisy bug.
+- **Test bug** — your test is wrong (bad selector, wrong assertion, timing). Fix the test; don't file anything.
+- **Application defect** — the app does the wrong thing. File it.
+- **Visual diff — intended** — the snapshot changed because the change intentionally changed the UI. Update the baseline and surface it for user approval.
+- **Visual diff — unintended** — a snapshot changed somewhere the change shouldn't have affected. File it as a regression.
+
+**Then check for missed requirements.** For each numbered acceptance criterion from Phase 2, confirm at least one *passing* test covers it. An AC with no passing test — because no test was written, or because the test fails — is a missed requirement. File it.
+
+### Filing defects
+
+Use whatever tracker integration you found in Phase 1: `gh issue create`, `glab issue create`, a Jira or Linear MCP tool, `az boards work-item create`. If nothing is available, produce a markdown report with each defect formatted ready to paste.
+
+Each filed issue needs:
+
+- **Title** — short, specific, describes the symptom not the cause. *"Filter by status shows zero results when status=pending"*, not *"Filter broken"*.
+- **Steps to reproduce** — numbered, minimal, exact.
+- **Expected vs actual** — on separate lines, no ambiguity.
+- **Environment** — branch, commit SHA, test command, browser/viewport if relevant.
+- **Evidence** — link or path to the failing test, error output, screenshot, trace.
+- **Link back** to the originating issue/PR.
+- **Severity** — your honest call: blocker, major, minor. Don't inflate.
+
+Show the user the full set of issues you're about to file. Get confirmation. Then file them.
+
+### Final report
+
+Wrap up with a summary the user can drop into the PR or ticket:
+
+- Tests added — count, with a list.
+- Tests updated — count.
+- Tests deleted — count, with rationale.
+- Suite result — passing, failing, flaky.
+- Defects filed — count, with links.
+- Missed requirements — count, with links.
+
+---
+
+## Evidence vs failure forensics
+
+Playwright's auto-screenshot (`screenshot: 'only-on-failure'`) is for **failure forensics** — "what state was the page in when this test broke?" For a passing test it captures the post-test screen, which is useless as compliance evidence.
+
+To prove an AC was actually verified, call `evidenceShot()` **at the assertion that proves it**, before any further interaction:
+
+```ts
+import { evidenceShot } from './helpers/evidence';
+
+test('AC1: edit dialog opens with fields pre-filled', async ({ page }) => {
+  await openEditDialog(page, item.id);
+  await expect(dialog.locator('#name')).toHaveValue(item.name);
+  await evidenceShot(page, 'REQ-037', 'AC1-edit-dialog-prefilled');
+  // ...rest of test
+});
+```
+
+**Discipline:**
+
+- Call `evidenceShot` **immediately after** the AC-proving assertion, before navigating, closing dialogs, or any further interaction.
+- Slug as `AC<n>-<what-this-proves>` — the filename documents the claim.
+- One screenshot per AC, not per test.
+- Failure forensics stays untouched (`screenshot: 'only-on-failure'` + `trace: 'on-first-retry'`).
+
+The helper is shipped automatically into `e2e/helpers/evidence.ts` by the SDLC sync (node-stack consumers). Output lands at `compliance/evidence/<REQ-ID>/screenshots/<slug>.png` — commit these PNGs as part of the evidence pack so reviewers can corroborate the test-plan AC mapping.
+
+The canonical helper source lives at `references/evidence.ts` in this skill.
+
+---
+
+## Principles
+
+**Match the project's existing depth.** If it tests one happy path per feature, don't add six scenarios per AC. If it tests exhaustively, match that. Right coverage is coverage consistent with what's already there.
+
+**E2E is expensive.** Every test you add costs CI time and maintenance forever. Add what's needed for confidence in the change; resist adding more. The goal is a suite that stays trusted, not a suite that's maximal.
+
+**Don't invent infrastructure.** If the project uses POMs, use POMs. If it uses fixtures, use fixtures. If something is genuinely missing that you need, ask the user before adding it.
+
+**Confirm before destructive or public actions.** Deleting tests, approving new visual baselines, filing defects in a tracker — all need explicit user sign-off. The cost of confirming is a sentence; the cost of getting it wrong is real.
+
+**Ambiguity is a question, not a guess.** If an AC is unclear or the implementation does something the issue doesn't describe, ask. Tests built on guesses about intent are worse than no tests — they encode and propagate the misunderstanding.

--- a/.claude/skills/e2e-test-engineer/references/bootstrap.md
+++ b/.claude/skills/e2e-test-engineer/references/bootstrap.md
@@ -1,0 +1,244 @@
+# Bootstrap Reference
+
+Detailed guidance for setting up an e2e suite from scratch. Read this when Phase 1b of `SKILL.md` is in play.
+
+## Contents
+1. Framework selection matrix (by tech stack)
+2. Visual regression tool selection
+3. Official installer commands
+4. Best-practice configuration
+5. Directory structure templates
+6. CI snippets
+7. Anti-patterns to avoid
+
+---
+
+## 1. Framework selection matrix
+
+Recommend a primary, mention the runner-up, get user confirmation before installing. These recommendations reflect current best practice for new projects; if the team has a strong preference, follow it.
+
+### Web apps — JavaScript / TypeScript
+
+| Stack | Primary | Runner-up | Rationale |
+|---|---|---|---|
+| React / Next.js / Remix | **Playwright** | Cypress | Fast, parallel by default, multi-browser, first-party TS, built-in visual regression, excellent trace viewer. |
+| Vue / Nuxt | **Playwright** | Cypress | Same reasons. |
+| Angular | **Playwright** | Cypress | Playwright has overtaken Cypress as the Angular community default; Cypress still common in established Angular shops. |
+| Svelte / SvelteKit | **Playwright** | — | SvelteKit's official template ships Playwright. |
+| Static sites / SSG | **Playwright** | Cypress | Either works; Playwright is simpler to set up. |
+| Legacy multi-browser-grid needs | **WebdriverIO** | Selenium | Needed when integrating with existing Sauce Labs / BrowserStack grids or non-Chromium-family browsers beyond what Playwright covers. |
+| Anything requiring real IE11 (rare) | **Selenium** | — | Only Selenium still targets IE. |
+
+### Mobile
+
+| Stack | Primary | Runner-up | Rationale |
+|---|---|---|---|
+| React Native | **Detox** | Appium | Native, fast, integrates with RN test infra. |
+| Native iOS / Android cross-platform | **Appium** | Maestro | Industry standard; Maestro is gaining popularity for simpler flows. |
+| Mobile web | **Playwright** (mobile emulation) | Appium (for real-device need) | Playwright covers viewport + UA emulation; Appium for real-device touch interactions. |
+
+### Desktop
+
+| Stack | Primary | Runner-up | Rationale |
+|---|---|---|---|
+| Electron | **Playwright** | WebdriverIO + Electron service | Playwright has first-party Electron support. |
+| Tauri | **WebdriverIO** + Tauri driver | — | Official path. |
+
+### Backend-rendered / non-JS web apps
+
+| Stack | Primary | Runner-up | Rationale |
+|---|---|---|---|
+| Python (Django, Flask, FastAPI with templates) | **pytest-playwright** | Selenium + pytest | Same Playwright engine, idiomatic for Python test suites. |
+| Ruby on Rails | **Capybara + Cuprite** | Capybara + Selenium | Cuprite uses CDP, faster than Selenium. |
+| Java (Spring etc.) | **Playwright for Java** | Selenium + JUnit/TestNG | Playwright Java is mature; Selenium still dominant in enterprise Java. |
+| .NET | **Playwright for .NET** | Selenium + NUnit/xUnit | Playwright .NET is well-supported. |
+| PHP (Laravel, Symfony) | **Playwright via PHP** or **Pest browser plugin** | Codeception | Pest's browser plugin is gaining ground for Laravel. |
+
+### When to question the default
+
+- **Team already uses Cypress productively elsewhere** — stick with Cypress for consistency.
+- **Heavy iframe / cross-origin needs** — Cypress historically struggled here; Playwright handles it. (Cypress has improved but Playwright is smoother.)
+- **Component testing matters too** — Cypress has a unified e2e + component runner; with Playwright you'd add a separate component test setup.
+
+---
+
+## 2. Visual regression tool selection
+
+Only add visual regression if the user asked for it or the originating issue is visually significant. Default off for greenfield bootstrap unless explicitly requested.
+
+| Need | Recommendation | Notes |
+|---|---|---|
+| Default for Playwright | **`toHaveScreenshot()` built-in** | Zero extra deps; baselines stored in repo. Configure `threshold` and `maxDiffPixels`. |
+| Default for Cypress | **`cypress-image-snapshot`** | Or `cypress-visual-regression`. Both store baselines in repo. |
+| Default for WebdriverIO | **`@wdio/visual-service`** | Maintained, image-comparison-based. |
+| Default for BackstopJS-style standalone | **BackstopJS** | Use only if not integrating with an e2e framework above. |
+| Cross-team approval workflow needed | **Percy** or **Chromatic** | Cloud, web-based diff review. Chromatic is Storybook-friendly. Percy is generic. |
+| Heavy use of AI-assisted diffing / dynamic content | **Applitools** | Commercial, ML-based comparison, handles dynamic content gracefully. Higher cost. |
+
+Baseline strategy on first bootstrap: generate baselines locally, then have the user verify each one before committing. Never auto-approve baselines in CI on first run.
+
+---
+
+## 3. Official installer commands
+
+Always prefer the official installer — it gives the framework's authors' recommended defaults, which the skill should not override without reason.
+
+```bash
+# Playwright (Node)
+npm init playwright@latest
+# Picks language, test dir, GitHub Actions, browsers.
+
+# Playwright (Python)
+pip install pytest-playwright
+playwright install
+
+# Cypress
+npm install --save-dev cypress
+npx cypress open  # first run sets up structure
+
+# WebdriverIO
+npm init wdio@latest .
+
+# Detox (React Native)
+npm install --save-dev detox
+detox init
+
+# Appium
+npm install --save-dev appium @wdio/cli
+# Then use wdio installer
+
+# Selenium (Java, Maven)
+# Add selenium-java + junit-jupiter to pom.xml; no CLI installer.
+```
+
+Match the package manager: `npm` → `npm install`, `pnpm` → `pnpm add`, `yarn` → `yarn add`.
+
+---
+
+## 4. Best-practice configuration
+
+### Playwright (`playwright.config.ts`)
+
+Key settings to set up beyond the installer defaults:
+
+- `baseURL` — pointing at the project's dev server (`http://localhost:3000`, `5173`, `4200`, etc. depending on framework).
+- `retries: process.env.CI ? 2 : 0` — flake tolerance in CI only.
+- `workers: process.env.CI ? 2 : undefined` — explicit CI worker count.
+- `reporter: [['html'], ['list']]` — and add `['junit', ...]` if CI needs JUnit XML.
+- `use.trace: 'on-first-retry'` — full trace on flake.
+- `use.screenshot: 'only-on-failure'`.
+- `use.video: 'retain-on-failure'`.
+- `webServer` — auto-start the dev server before tests; saves CI config complexity.
+- `projects` — at least Chromium; add Firefox/WebKit if cross-browser matters; add a mobile viewport project if relevant.
+- `expect.toHaveScreenshot` — set `threshold` (default 0.2 is usually too lax for UI work; try 0.1) and `maxDiffPixels` for noise tolerance.
+
+### Cypress (`cypress.config.ts`)
+
+- `baseUrl`.
+- `viewportWidth`, `viewportHeight` — set explicitly so visual diffs are stable.
+- `retries: { runMode: 2, openMode: 0 }`.
+- `video: false` (or `true` with `videoCompression`) — videos are large; opt in deliberately.
+- `screenshotOnRunFailure: true`.
+- For visual regression with `cypress-image-snapshot`: configure `failureThreshold` and `failureThresholdType: 'percent'`.
+
+### Universal
+
+- Pin framework versions in `package.json` (no `^` for the test runner) — flake from runner updates is real.
+- Add the test browsers to `.gitignore` if downloaded outside `node_modules`.
+- Add baseline images to git if visual regression is set up.
+
+---
+
+## 5. Directory structure templates
+
+### Playwright (TypeScript)
+
+```
+e2e/
+├── tests/
+│   ├── auth/
+│   │   └── login.spec.ts
+│   └── home.smoke.spec.ts
+├── pages/
+│   └── login.page.ts
+├── fixtures/
+│   ├── auth.fixture.ts
+│   └── test-data.ts
+├── helpers/
+│   └── api-setup.ts
+└── visual/
+    └── home.visual.spec.ts
+playwright.config.ts
+```
+
+Playwright idiom is fixtures over POMs. POMs work; fixtures are more native. Use whichever the user prefers, but be consistent.
+
+### Cypress
+
+```
+cypress/
+├── e2e/
+│   ├── auth/
+│   │   └── login.cy.ts
+│   └── home.smoke.cy.ts
+├── support/
+│   ├── commands.ts        # custom commands
+│   ├── e2e.ts             # global setup
+│   └── pages/
+│       └── login.page.ts
+├── fixtures/
+│   └── users.json
+└── snapshots/             # visual baselines if using image-snapshot
+cypress.config.ts
+```
+
+Cypress idiom is custom commands (`cy.login(...)`) over POMs, but POMs are fine and increasingly common.
+
+---
+
+## 6. CI snippets
+
+Offer these as suggestions, get user confirmation before writing or committing.
+
+### GitHub Actions — Playwright
+
+```yaml
+name: E2E
+on: [push, pull_request]
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 'lts/*' }
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - run: npm run test:e2e
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14
+```
+
+### GitHub Actions — Cypress
+
+Use the official `cypress-io/github-action` — handles caching and parallelisation. Equivalent shape; see Cypress docs for current syntax (it changes more often than other CI integrations).
+
+### GitLab CI / CircleCI / Jenkins
+
+Each framework's docs have reference pipelines; link the user to them rather than hand-writing from scratch. The shape is always: install deps → install browsers → start dev server (or rely on `webServer` config) → run tests → upload artifacts.
+
+---
+
+## 7. Anti-patterns to avoid
+
+- **Don't write your own framework wrapper.** Use the framework's idioms directly. Wrappers ossify and the framework upgrades pass them by.
+- **Don't add every browser.** Start with one (Chromium); add others when the user has a real reason (cross-browser bugs reported, multi-browser SLA).
+- **Don't enable video by default.** It's expensive in CI; opt in for the suites that need it.
+- **Don't auto-approve visual baselines.** Bake in a manual approval step on first generation and on diff.
+- **Don't put real credentials in fixtures.** Use environment variables, dotfiles (`.env.test`, gitignored), or per-environment auth state files.
+- **Don't ignore the trace viewer / debug tools.** Playwright's trace viewer and Cypress's time-travel debugger are the reason these tools exist; lean on them for triage.
+- **Don't skip the smoke test on bootstrap.** A passing smoke test is the proof the setup is real. Without it you're handing the user broken infrastructure.

--- a/.claude/skills/e2e-test-engineer/references/evidence.ts
+++ b/.claude/skills/e2e-test-engineer/references/evidence.ts
@@ -1,0 +1,40 @@
+import path from 'path';
+import { type Page } from '@playwright/test';
+
+const SLUG_RE = /^[A-Za-z0-9_-]+$/;
+
+/**
+ * Write a per-assertion screenshot into the requirement's evidence pack.
+ *
+ * Call this AT the assertion that proves the AC, before any further
+ * interaction or navigation. The PNG is committed as part of the
+ * evidence pack and used by reviewers to corroborate the test-plan
+ * AC mapping.
+ *
+ * Output path: `compliance/evidence/<reqId>/screenshots/<slug>.png`
+ *
+ * @example
+ *   await expect(dialog.locator('#name')).toHaveValue(item.name);
+ *   await evidenceShot(page, 'REQ-037', 'AC1-edit-dialog-prefilled');
+ */
+export async function evidenceShot(
+  page: Page,
+  reqId: string,
+  slug: string,
+  opts: { fullPage?: boolean } = {},
+): Promise<void> {
+  if (!SLUG_RE.test(reqId)) {
+    throw new Error(`evidenceShot: invalid reqId "${reqId}" (must match ${SLUG_RE})`);
+  }
+  if (!SLUG_RE.test(slug)) {
+    throw new Error(`evidenceShot: invalid slug "${slug}" (must match ${SLUG_RE})`);
+  }
+  const out = path.join(
+    process.cwd(),
+    'compliance/evidence',
+    reqId,
+    'screenshots',
+    `${slug}.png`,
+  );
+  await page.screenshot({ path: out, fullPage: opts.fullPage ?? true });
+}

--- a/.claude/skills/sdlc-implementer/SKILL.md
+++ b/.claude/skills/sdlc-implementer/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: sdlc-implementer
+description: Take a GitHub issue end-to-end through the Metasession SDLC. Opens with a Workflow Triage step (Phase 0) that classifies the change and routes it — tracked work continues into the full cycle; housekeeping/trivial/doc-only is driven to merge down a lightweight path (same step-by-step guidance, no tracked ceremony). Use when the user wants to implement a single GitHub issue as a complete SDLC cycle — Phase 1 (classify risk, write implementation plan, update RTM) through Phase 4 (open PR, request UAT review on the portal), then halt; and Phase 5 (merge, post-deploy smoke evidence, mark Released, or change-request loop) on resume. Trigger phrases — "implement issue #N under the SDLC", "run the SDLC for issue #N", "automate REQ-XXX from issue to release", "do the SDLC stages for [issue]". Resume phrase — "resume REQ-XXX". MUST delegate end-to-end and visual-regression test work to the e2e-test-engineer skill in Phase 2; never authors e2e tests directly. Do NOT use for partial work — for stage-1 planning only, run the manual walkthrough; for test work alone, invoke e2e-test-engineer directly.
+tags: [sdlc, orchestration, compliance, automation]
+---
+
+# SDLC implementer
+
+Take a single GitHub issue end-to-end through the Metasession SDLC. The skill **triages first** (Phase 0): it classifies the change, announces the path it will take, and routes — only a **tracked** change continues into the full cycle, while housekeeping, trivial, and compliance-doc-only work is driven down its lighter path **to completion** (the skill still guides every step to merge; it just skips the tracked ceremony). For a tracked change, one command runs Phase 1 through Phase 4 unattended (with a plan-approval pause for HIGH/CRITICAL risk); the human enters the loop at the UAT review gate on the portal. On resume, the skill runs Phase 5 — merge, post-deploy smoke evidence, mark the release Released, or address change-requests and re-submit for UAT re-review.
+
+This skill is a single entry point that **routes**, not one that always runs heavy. The change-type taxonomy it routes against is the canonical table in [`change-workflows.md`](https://github.com/metasession-dev/DevAudit-Installer/blob/main/docs/change-workflows.md) (six change-types → commit-type → requirement? → path).
+
+This is an **orchestration skill**. It drives Claude Code's native tools (`gh`, shell, the `devaudit` CLI, the portal API) through the framework's existing stage docs, and it **MUST invoke the [`e2e-test-engineer`](../e2e-test-engineer/SKILL.md) skill** for any end-to-end or visual-regression test work in Phase 2. It does not author e2e tests directly.
+
+## Scope
+
+**In scope**
+
+- Pickup-time **workflow triage** (Phase 0): read the issue + labels, classify the change-type, announce the path, and route — tracked work into Stages 1–5; housekeeping / trivial / compliance-doc-only **driven to merge down the Lightweight path** (same guidance, no tracked ceremony).
+- Taking one GitHub issue from triage to merged-and-deployed, under the project's existing SDLC framework.
+- Risk classification per [`Test_Policy.md`](../../Test_Policy.md) §Risk-Based Testing.
+- Authoring `compliance/plans/REQ-XXX/implementation-plan.md` per the stage-1 template.
+- Updating `compliance/RTM.md`.
+- Implementation, unit/integration tests, quality gates.
+- Evidence capture and upload to the portal via `devaudit push`.
+- PR opening, UAT review request, change-request loop, merge, post-deploy verification, release finalisation.
+
+**Out of scope**
+
+- Issues that decompose into multiple requirements — refuse at Phase 1 and ask the user to split.
+- Stage-1 planning in isolation — run the manual walkthrough instead.
+- E2E or visual-regression test work in isolation — invoke `e2e-test-engineer` directly.
+- Cross-issue refactors that touch multiple REQ-XXX scopes — these are out of the one-issue contract.
+- Onboarding a new consumer — that's `devaudit install`, a different command entirely.
+
+## Sub-skill invocation contract
+
+The orchestrator MUST invoke `e2e-test-engineer` for end-to-end and visual-regression test work in Phase 2. This is a hard contract:
+
+- Never author e2e tests directly.
+- Never transcribe `e2e-test-engineer`'s six-phase workflow into this skill's body.
+- Call via the standard Claude Code Skill mechanism (`Skill(name: "e2e-test-engineer", …)`).
+
+Unit-test and integration-test work stays with this skill until a counterpart unit-test skill ships. The full sub-skill call graph lives at [`references/call-graph.md`](./references/call-graph.md).
+
+## The workflow
+
+A triage step (Phase 0) routes the issue, then up to five phases for tracked work. Phase 0 plus Phases 1–4 run in one Claude Code session; Phase 5 is invoked separately by the user after UAT. The off-ramps from Phase 0 (housekeeping / trivial / doc-only) don't enter Phase 1 — they run the **Lightweight path** (below), which the skill drives to merge.
+
+### Phase 0 — Workflow triage (classify → announce → confirm → route)
+
+Runs **first**, before any `REQ-XXX` is assigned. It decides which of the six change-types in [`change-workflows.md`](https://github.com/metasession-dev/DevAudit-Installer/blob/main/docs/change-workflows.md) applies and what will — and won't — run. This is what stops every issue defaulting to maximum ceremony.
+
+1. **Fetch.** `gh issue view <N> --json labels,title,body` and read all comments. Read the **labels** as well as the title and body.
+2. **Classify the change-workflow**, inference-first (labels are optional input). Precedence, highest first:
+   1. An explicit `type:*` / `risk:*` label → **authoritative**.
+   2. A conventional-commit prefix in the issue title — `feat` / `fix` / `refactor` / `perf` → **tracked**; `chore` / `ci` / `build` / `test` / `docs` / `compliance` → **housekeeping / doc-only**.
+   3. The issue template — Requirement → tracked; Bug → fix (tracked); Task → housekeeping.
+   4. Body heuristics — acceptance criteria, or risk signals (auth, payments, RBAC, data egress, AI decisioning) → tracked, and raise the risk class.
+
+   Map the result to one of the six paths in `change-workflows.md`.
+3. **Announce a "Workflow Decision" block** (template below): change-type, commit-type, whether a `REQ-XXX` is needed, risk class, which stages/gates run, which approvals the **operator** must perform (UAT four-eyes, Production approval), and what is **skipped**.
+4. **Pause policy — pause-when-it-matters.** Pause for explicit confirmation on **tracked / heavier** paths, or when classification is **ambiguous**; **announce-and-auto-proceed** on trivial / housekeeping. The operator can always reclassify ("treat this as housekeeping" / "this is HIGH risk").
+5. **Route — and stay on to completion.** A route is a choice of *which workflow to drive*, never a hand-off that abandons the operator. Whatever the path, the skill keeps guiding step by step until no further action is required (typically: merged).
+   - **tracked** (feature / bug fix / refactor / perf) → continue into Phase 1 below (full Stages 1–5).
+   - **housekeeping / trivial** → drive the **Lightweight path** below to completion. No `REQ-XXX`, no RTM row, no evidence pack, no portal release approvals — but the skill still branches, runs the gates, opens the PR, and walks the operator through review → merge.
+   - **compliance-doc-only** → drive the same Lightweight path as a docs push (or PR, per the project's flow) referencing the **existing** `REQ-XXX`: no new requirement and no quality-gate ceremony, but driven through to merge.
+6. **Write labels back.** Apply the inferred `type:*` / `risk:*` labels so the issue ends up labelled — `gh label create <label> --force` to ensure the label exists (idempotent; no failure if a label-seeding step never ran), then `gh issue edit <N> --add-label <label>`. Future triage is then a glance.
+
+**"Workflow Decision" announcement template**
+
+> **Workflow decision — #N**
+> - **Change type:** \<Feature | Bug fix | Refactor/Perf | Housekeeping | Trivial | Compliance-doc-only\>
+> - **Commit type:** \<feat | fix | refactor | chore | docs | …\>
+> - **Requirement:** \<REQ-XXX assigned | none\>
+> - **Risk:** \<LOW | MEDIUM | HIGH | CRITICAL\>
+> - **Path:** \<Full SDLC Stages 1–5 | Lightweight (gates → chore PR) | Doc-only push\>
+> - **Gates/evidence:** \<…\>
+> - **Your approvals:** \<UAT four-eyes + Production approval | PR review only\>
+> - **Skipped:** \<…\>
+> Proceed? *(or reclassify)*
+
+Only the **tracked** route continues into Phase 1; the others run the Lightweight path below. The off-ramps are deliberate — dragging housekeeping through tracked-change machinery it doesn't need is exactly the failure mode this step exists to prevent — but they are still **driven to completion**, never dumped as a checklist for the operator to run alone.
+
+### Lightweight path (housekeeping / trivial / compliance-doc-only)
+
+Reached from Phase 0 for non-tracked change-types. The skill drives this end-to-end; the only difference from the tracked cycle is the absence of *ceremony*, not the absence of *guidance*. It pauses only where a human is genuinely required (PR review, merge).
+
+1. **Branch off `develop`** with a housekeeping prefix — `chore/…`, `docs/…`, `ci/…`, `build/…`, `test/…`, or `compliance/…` for a doc-only change against an existing REQ.
+2. **Make the change**, single-purpose. If it turns out to touch runtime behaviour in `app/` / `lib/`, stop and reclassify as tracked — the commit-type rule is the backstop.
+3. **Run all gates locally** (`npm run lint`, `npx tsc --noEmit`, the test suite, `semgrep`, `npm audit` — or the stack-adapter equivalents). Trivial ≠ unverified; never `--no-verify`.
+4. **Commit** with a housekeeping type and **no** `REQ-XXX` — `docs:` / `chore:` / `ci:` / `build:` / `test:` / `revert:` are exempt from the `[REQ-XXX]` rule; a `compliance:` doc-only change references the existing REQ. `Co-Authored-By: Claude` if AI-assisted.
+5. **Push and open the PR.** CI runs the same quality gates; `compliance-validation.yml` finds no `REQ-XXX` and skips artifact validation.
+6. **Report honest status** — wait for CI, name any failing check, fix and re-push. Never announce "ready" while a required check is red.
+7. **Guide review → merge.** A human still reviews the PR (separation of duties). There is **no** portal release approval, no UAT four-eyes, no Production gate, and no close-out. Merge once CI is green and the reviewer approves.
+8. **Done.** A housekeeping push produces at most a bare-date release (`vYYYY.MM.DD`) with no approval gate; a doc-only push attaches its docs to the existing `REQ-XXX` release. No further action required — report completion and stop.
+
+### Phase 1 — Plan (SDLC stage 1)
+
+Reached only on the **tracked** route from Phase 0 (the issue is already fetched and classified).
+
+1. **Confirm the issue scope.** Re-read the `gh issue view <N>` output from Phase 0 — title, body, all comments — with implementation in mind.
+2. **Classify risk** per `Test_Policy.md` §Risk-Based Testing. Emit a one-paragraph rationale citing the signals you used (auth surface, financial calc, data egress, RBAC, AI decisioning, etc.).
+3. **Assign REQ-XXX.** Inspect `compliance/RTM.md` for existing entries; take the next free number. If the issue references an existing REQ, use that instead.
+4. **Detect over-scoping.** If the issue spans clearly distinct deliverables (e.g. "build SAML SSO + reorganise the admin dashboard + migrate from Postgres 14 to 16"), halt with a clear message asking the user to split the issue into separate ones. Do not proceed past Phase 1.
+5. **Write the implementation plan.** Create `compliance/plans/REQ-XXX/implementation-plan.md` per the stage-1 template (sections: context, acceptance criteria, technical approach, security considerations, dependencies, test scope). For HIGH/CRITICAL also include: threat model (against STRIDE categories applicable to the touched surfaces), four-eyes attestation slot, rollback plan.
+6. **Update `compliance/RTM.md`** with the new entry: REQ-XXX, title, risk class, linked issue, linked test cases (placeholder).
+7. **Post plan summary as an issue comment.** Format: TL;DR; Risk class + signals; Acceptance criteria; Technical approach (one paragraph); Dependencies; Test scope.
+8. **Checkpoint** — pause for human approval **iff** risk class is HIGH or CRITICAL. LOW and MEDIUM pass through to Phase 2 automatically. The checkpoint can be forced on for all classes via the `--require-plan-approval` flag (or `DEVAUDIT_REQUIRE_PLAN_APPROVAL=1` env var) for orgs that want it always-on.
+
+### Phase 2 — Implement and test (SDLC stage 2)
+
+1. **Branch off `develop`.** `git checkout -b feat/REQ-XXX-<slug>`. The slug is a kebab-case fragment of the issue title (max 6 words).
+2. **Write failing tests first** per [`Test_Architecture.md`](../../Test_Architecture.md). Depth scales with risk class:
+   - LOW — unit tests on the changed function(s); no e2e required unless the change touches a user-facing flow.
+   - MEDIUM — unit + integration; e2e for any UI-facing change.
+   - HIGH — unit + integration + e2e for every user-visible path + at least one negative/abuse test.
+   - CRITICAL — HIGH plus targeted security tests (authz bypass attempts, input fuzzing where applicable).
+3. **For any e2e or visual-regression test work in this step, invoke `e2e-test-engineer`** — do not author e2e tests directly. The orchestrator passes the implementation plan + the diff so far to the e2e-test-engineer skill, which derives scenarios, reconciles with the existing pack, and runs the suite.
+4. **Implement against the plan.** Reference `compliance/plans/REQ-XXX/implementation-plan.md` as you go. Any deviation from the plan must be noted in the plan itself under a `## Plan deviation` section — never silently diverge.
+5. **Run all gates locally** before pushing:
+   - `npm run lint` (or stack-adapter equivalent)
+   - `npx tsc --noEmit` (or stack-adapter equivalent)
+   - `npx vitest run` (unit/integration)
+   - `npx playwright test` (e2e — delegated to `e2e-test-engineer`)
+   - `semgrep scan --config auto`
+   - `npm audit --audit-level=high` (or stack-adapter equivalent)
+6. **On gate failure**, iterate up to N=3 attempts. Each iteration: read the failure output, propose a fix, apply, re-run. On exhausted attempts, halt with the full failure output and surface to the human — never use `--no-verify`, `eslint-disable`, `@ts-expect-error`, `xfail`, or any other bypass.
+7. **Commit** using Conventional Commits with `Ref: REQ-XXX` trailer and `Co-Authored-By: Claude` trailer. One commit per logical step; never amend a commit that's already been pushed.
+8. **Push** to the feature branch. No PR yet — that happens in Phase 4.
+
+### Phase 3 — Compile evidence (SDLC stage 3)
+
+1. **Re-run the full test pack** with artefact capture:
+   - `npm run test:e2e -- --reporter=html` (produces `playwright-report/`)
+   - `npx vitest run --coverage` (produces `coverage/`)
+2. **Organise artefacts** under `compliance/evidence/REQ-XXX/` with date-prefixed naming:
+   ```
+   compliance/evidence/REQ-XXX/
+   ├── YYYY-MM-DD_e2e-results.json
+   ├── YYYY-MM-DD_playwright-report/
+   ├── YYYY-MM-DD_unit-coverage/
+   └── YYYY-MM-DD_screenshots/*.png
+   ```
+3. **Upload each artefact to the portal**:
+   ```bash
+   devaudit push <project-slug> REQ-XXX <evidence-type> <file> \
+     --release "v$(date +%Y.%m.%d)" --create-release-if-missing \
+     --environment uat --category testing \
+     --git-sha "$(git rev-parse HEAD)" \
+     --branch "$(git rev-parse --abbrev-ref HEAD)"
+   ```
+   Evidence types: `screenshot`, `e2e_result`, `test_report`, `audit_log`, `compliance_document`, `manual_upload`.
+4. **Verify uploads landed.** `gh api` or `curl` against `https://devaudit.metasession.co/projects/<slug>/requirements/REQ-XXX/evidence` should show every artefact.
+5. **Update `compliance/RTM.md`** with portal links for each evidence row.
+
+### Phase 4 — Submit for UAT review (SDLC stage 4)
+
+1. **Open the PR.** `gh pr create --base main --head <branch>`. PR body per the SDLC PR template (see [`.github/pull_request_template.md`](../../../../../.github/pull_request_template.md)):
+   - Closes #N
+   - REQ-XXX
+   - Risk: <class>
+   - Evidence: `https://devaudit.metasession.co/projects/<slug>/requirements/REQ-XXX`
+   - For HIGH/CRITICAL: Four-eyes attestation: `@<reviewer-username>`
+   - For HIGH/CRITICAL: Rollback plan: reference to `compliance/plans/REQ-XXX/implementation-plan.md` §Rollback
+   - Test plan
+   - SDLC checklist
+2. **Verify the UAT reviewer ≠ skill-trigger user** for HIGH/CRITICAL. If they match, halt with a configuration error: "HIGH/CRITICAL risk requires an independent UAT reviewer; the configured reviewer matches the trigger user — fix the four-eyes attestation slot in the implementation plan and re-run."
+3. **Apply labels** — `awaiting-uat-review`, `risk:<class>`.
+4. **Comment on the issue**: "Implementation complete. PR #M opened. Evidence on portal: <link>. UAT review requested. Resume with `resume REQ-XXX` once UAT approval is granted on the portal."
+5. **Hard stop.** Phase 4 ends here. Do not proceed to merge; the human's next action is reviewing on the portal.
+
+### Phase 5 — Finalise or change-request loop (SDLC stage 5)
+
+Invoked separately by the user after UAT activity on the portal. Trigger: "resume REQ-XXX", "REQ-XXX UAT done", or just re-firing the skill on the same issue.
+
+1. **Read portal state.** `curl` `https://devaudit.metasession.co/api/projects/<slug>/releases/<version>` and inspect the approval status.
+
+2. **Branch on state:**
+
+   - **UAT approved** → run stage 5:
+     - `gh pr merge <M> --merge` (merge commit; `--squash` and `--rebase` are blocked by branch protection on SDLC repos and would break the audit trail).
+     - Watch `post-deploy-prod.yml` via `gh run watch` — block until the workflow reaches a terminal state.
+     - Verify production smoke evidence uploaded (`--environment production`) at `https://devaudit.metasession.co/projects/<slug>/releases/<version>`.
+     - Mark release as `Released` via portal API: `PATCH /releases/<version>` with `{"status": "released"}`.
+     - Comment on the issue: "Released. Production smoke evidence: <link>."
+     - Close the issue.
+     - If production smoke fails: do NOT mark as Released. File an `[INCIDENT]` defect issue, page the on-call per the project's incident playbook, follow the rollback plan from the implementation plan.
+
+   - **Changes requested** → run change-request loop:
+     - Fetch change-request comments from the PR (`gh pr view <M> --comments`) and from the portal release page.
+     - Add a new `## Change-request iteration N` section to `compliance/plans/REQ-XXX/implementation-plan.md` describing what changed and why.
+     - Re-run Phase 2 (implement + test) for the requested changes — same delegation to `e2e-test-engineer` for any e2e work.
+     - Re-run Phase 3 (evidence) for the new/changed artefacts only; existing evidence stays.
+     - Push to the same branch (no force-push). The PR auto-updates.
+     - Re-request UAT review on the portal: `POST /api/projects/<slug>/releases/<version>/approval-requests`.
+     - Comment on the issue: "Change requests addressed in commits <SHAs>. UAT re-review requested."
+     - Hard stop again. The portal's release-approval state has reset; UAT must explicitly re-approve.
+
+   - **Still pending UAT (no approval, no change-request)** → report "UAT review still pending on the portal at <link>" and stop. Do not act.
+
+## Compliance constraints
+
+Hard rules — the skill's SKILL.md fails review if any of these are violated. Audited against ISO 29119, ISO 27001, SOC 2, GDPR, and the EU AI Act; details in [`references/compliance-constraints.md`](./references/compliance-constraints.md).
+
+1. **Never skip the UAT review gate** for any risk class. The portal enforces this server-side via `check-release-approval.yml`; do not attempt to merge with that check still red.
+2. **For HIGH/CRITICAL, the skill MUST NOT act as the UAT approver.** Check at Phase 4 that the configured UAT reviewer differs from the skill-trigger user; halt with a configuration error otherwise. (SOC 2 CC8 — segregation of duties.)
+3. **Plan checkpoint mandatory for HIGH/CRITICAL.** LOW/MEDIUM pass through Phase 1 automatically; HIGH/CRITICAL pause for human plan approval before code is written.
+4. **Change-request loop triggers full UAT re-review.** The portal's release-approval state resets when new commits land on the PR — respect it. Surface a "UAT re-review needed" comment; never rely on prior approval covering subsequent changes.
+5. **AI involvement disclosed on every commit** via `Co-Authored-By: Claude`. (ISO 27001 disclosure norms + EU AI Act Art. 13 transparency.)
+6. **All portal mutations through audit-logged APIs.** Use `devaudit push` and the standard portal-API endpoints — never a private back-channel.
+
+Plus one process risk surfaced explicitly in the principles below (rubber-stamping at UAT). Not enforceable architecturally — the UAT reviewer is the load-bearing human.
+
+## Principles
+
+**The UAT reviewer is the load-bearing human.** This skill makes it easy to produce many releases per day. The control regime depends on the UAT reviewer actually reading what they're approving. If the human approves without reviewing, the controls are formally satisfied but substantively broken — auditors will notice. Where possible, the UAT reviewer should be a different human from the skill-trigger user (mandatory for HIGH/CRITICAL).
+
+**Never bypass a gate to ship faster.** No `--no-verify`. No `eslint-disable`. No `@ts-expect-error`. No `xfail`. No "we'll fix it in the next PR." If a gate is structurally wrong for this change, halt and surface the blocker — fix the gate, not the bypass.
+
+**The implementation plan is the source of truth, not a one-shot artefact.** When implementation deviates from the plan (and it will), update the plan in place under a `## Plan deviation` section. The plan documents intent + reality; the RTM, the evidence, and the PR all reference it.
+
+**Never close the issue until Phase 5 completes.** An issue closed at Phase 4 (PR opened) loses its tie to the release outcome. Closure is the signal that the change is Released; don't generate that signal prematurely.
+
+**Never mark a release as Released without verifying production smoke evidence on the portal.** "The post-deploy workflow ran" is not the same as "production smoke evidence is on the portal." Verify the artefact landed before flipping the status.
+
+**Confirm before destructive operations.** Force-pushing, branch deletion, tag deletion, `git reset --hard`, modifying CI/CD pipelines — all need explicit user sign-off when they arise mid-skill. The cost of confirming is a sentence; the cost of getting it wrong is real.
+
+**Issue too big? Refuse at Phase 1.** If the issue spans multiple distinct deliverables, the right answer is "split this issue" — not "sub-divide into multiple REQs silently". Halt at Phase 1 with the proposed split for the user to confirm.
+
+**Ambiguity is a question, not a guess.** If the issue is unclear about scope, acceptance criteria, or which subsystem is affected, ask. Implementing on guesses is worse than no implementation — it encodes the misunderstanding into evidence and the audit trail.
+
+## References
+
+- [`change-workflows.md`](https://github.com/metasession-dev/DevAudit-Installer/blob/main/docs/change-workflows.md) — the canonical change-type taxonomy and the pickup-time **Workflow triage** decision Phase 0 runs against.
+- [`references/compliance-constraints.md`](./references/compliance-constraints.md) — the six architectural constraints + the process risk, audited per framework.
+- [`references/call-graph.md`](./references/call-graph.md) — sub-skill invocation map; what `sdlc-implementer` calls and when.
+- [`references/change-request-loop.md`](./references/change-request-loop.md) — Phase 5 change-request flow in detail, including portal-state semantics.
+- [`../e2e-test-engineer/SKILL.md`](../e2e-test-engineer/SKILL.md) — the test-work sub-skill this orchestrator delegates to.
+- [`SKILLS.md`](../../../../SKILLS.md) — skill contract and conventions for the framework.
+- Portal: `docs/implementing-an-sdlc-issue.md` — the user-facing walkthrough this skill automates. (Lives in the portal repo, currently private; the synced framework copy at `sdlc/files/_common/implementing-an-sdlc-issue.md` is the consumer-visible equivalent.)
+- Portal: `docs/standards-coverage.md` — which SDLC artefacts satisfy which compliance clauses. (Same: portal repo, currently private.)
+- [`metasession-dev/DevAudit-Installer#29`](https://github.com/metasession-dev/DevAudit-Installer/issues/29) — the umbrella issue tracking this skill's delivery.

--- a/.claude/skills/sdlc-implementer/references/call-graph.md
+++ b/.claude/skills/sdlc-implementer/references/call-graph.md
@@ -1,0 +1,64 @@
+# Sub-skill call graph
+
+The `sdlc-implementer` skill is an orchestrator. It calls into other shipped skills rather than re-implementing their procedures. This document is the authoritative map of when and why each sub-skill is invoked.
+
+## Skills `sdlc-implementer` invokes today
+
+### `e2e-test-engineer` — Phase 2 (Implement and test)
+
+**When**: Any time Phase 2's test-writing step needs end-to-end or visual-regression tests. The risk-class depth table (LOW / MEDIUM / HIGH / CRITICAL) determines whether e2e tests are needed; whenever they are, `e2e-test-engineer` writes them.
+
+**Invocation**: `Skill(name: "e2e-test-engineer", input: { issue: "#N", req: "REQ-XXX", plan_path: "compliance/plans/REQ-XXX/implementation-plan.md", diff: <branch diff> })`.
+
+**Hard contract** (per [`SKILL.md`](../SKILL.md) §Sub-skill invocation contract):
+
+- The orchestrator never authors e2e tests directly.
+- The orchestrator never transcribes `e2e-test-engineer`'s six-phase workflow into its own body.
+- SKILL.md review for `sdlc-implementer` fails if e2e test-authoring logic is inlined.
+
+**Why hard-contract**: `e2e-test-engineer` exists, works, and has been smoke-tested. Re-implementing its scenario-derivation logic inside an orchestrator would (a) drift over time, (b) double the maintenance burden, (c) miss the orchestrator-skill-pattern intended for the framework.
+
+**What `sdlc-implementer` retains responsibility for in Phase 2**:
+
+- Branching off `develop`.
+- Risk-class-based depth selection (deciding _whether_ e2e is needed at all).
+- Unit + integration test writing (these stay with the orchestrator until a counterpart unit-test skill ships).
+- Running all gates (the orchestrator owns the gate execution; `e2e-test-engineer` may have already run the e2e portion).
+- Iterating on gate failures up to N=3 attempts.
+- Committing.
+- Pushing.
+
+## Skills `sdlc-implementer` does NOT invoke
+
+These were previously planned as atomic skills but were deprioritised. The orchestrator handles their slice directly, without calling out:
+
+| Deprecated atomic skill        | What the orchestrator does instead                                                                                                       |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `risk-classifier`              | Phase 1 step 2 — orchestrator reads `Test_Policy.md` directly and classifies risk, emitting the signals it used.                          |
+| `commit-message-author`        | Phase 2 step 7 — orchestrator generates the Conventional Commits message from the staged diff + branch name + RTM entry.                  |
+| `compliance-evidence-author`   | Phase 3 — orchestrator drives the test pack, organises artefacts, uploads via `devaudit push`, updates the RTM.                           |
+| `sast-triager`                 | Phase 2 step 5 — `semgrep` runs as one of the gates; the orchestrator surfaces findings to the human at Phase 1 plan or halts in Phase 2. |
+| `release-ticket-author`        | Phase 4 step 1 — orchestrator drafts the PR body directly from the SDLC PR template + plan.                                               |
+
+If any of these surface in production as repeated pain (per [`SKILLS.md` §When to make a skill vs. when to keep something in a stage doc](../../../../SKILLS.md#when-to-make-a-skill-vs-when-to-keep-something-in-a-stage-doc)), they may be lifted into atomic skills later. The orchestrator would then delegate to them — same pattern as it does today for `e2e-test-engineer`.
+
+## Skills the orchestrator may invoke once they exist
+
+Future expansion. Not committed; listed so the call graph is forward-readable.
+
+- **`unit-test-engineer`** (planned via real-need driver) — would take over Phase 2's unit/integration test writing. The orchestrator's Phase 2 step 2 would invoke this skill the same way it invokes `e2e-test-engineer` today.
+- **`incident-responder`** (planned via real-need driver) — would handle the "production smoke failed in Phase 5" branch. Today the orchestrator falls back to filing an `[INCIDENT]` issue + paging on-call per the project's playbook.
+
+When/if these ship, the call graph in this file gets updated alongside the orchestrator's SKILL.md.
+
+## Skills that invoke `sdlc-implementer`
+
+None. The orchestrator is a top-level entry point — it's invoked directly by the user ("implement issue #N under the SDLC") and runs the framework's stages. It is not designed to be a sub-skill of another orchestrator.
+
+## Invocation discipline
+
+Three rules every orchestrator → sub-skill call should follow:
+
+1. **Pass the minimum context the sub-skill needs.** `e2e-test-engineer` needs the implementation plan + diff; it does not need the orchestrator's full state. Over-passing context bloats the sub-skill's working memory and slows it down.
+2. **Trust the sub-skill's return contract.** If `e2e-test-engineer` says it added 3 tests and they all pass, the orchestrator does not re-verify the assertion. The sub-skill is the authority for its slice.
+3. **Surface sub-skill failures to the human at the orchestrator level.** If `e2e-test-engineer` halts because the project's test framework can't be detected, that's an orchestrator-level halt — the user sees one clear "I couldn't proceed because…" message, not a stack of nested skill output.

--- a/.claude/skills/sdlc-implementer/references/change-request-loop.md
+++ b/.claude/skills/sdlc-implementer/references/change-request-loop.md
@@ -1,0 +1,192 @@
+# Phase 5 — change-request loop in detail
+
+When UAT review at Phase 4 ends in "changes requested" instead of "approved", `sdlc-implementer` enters the change-request loop. This document is the long-form spec for that loop, the portal-state semantics it relies on, and the discipline that keeps re-iterations compliant.
+
+The happy path (UAT approved → Phase 5 merge + finalise) is covered in [`SKILL.md` §Phase 5 — Finalise or change-request loop](../SKILL.md#phase-5--finalise-or-change-request-loop). This file goes deeper on the change-request branch.
+
+## Portal-state semantics
+
+The portal's release-approval state machine for a release tied to REQ-XXX:
+
+```
+draft
+  └─→ uat_review (CI registers the release on develop push)
+        ├─→ uat_approved (reviewer clicks Approve on the portal)
+        ├─→ uat_changes_requested (reviewer clicks Request Changes, leaves comments)
+        └─→ uat_rejected (rare — reviewer marks the release fundamentally broken)
+              ↑
+              └─ on new commits to the linked PR branch, state resets to uat_review
+```
+
+Critical: **state resets to `uat_review` on new commits**. This is server-side, not skill-side — the portal watches the branch SHA and clears the approval state when the SHA advances after a `changes_requested` event. The skill must not work around this.
+
+## The change-request loop
+
+When the user runs `> Resume REQ-XXX` and the portal state is `uat_changes_requested`, the skill executes:
+
+### Step 1 — Fetch the change-request comments
+
+Two sources to read:
+
+1. **PR comments** — `gh pr view <M> --comments --json comments,reviews --jq '.comments[].body, .reviews[].body'`. Includes line-level review comments and top-level discussion.
+2. **Portal release-page comments** — `curl https://devaudit.metasession.co/api/projects/<slug>/releases/<version>/comments`. Includes any comments the UAT reviewer left on the release card itself.
+
+Both sources matter: PR comments are usually code-level; portal comments are usually about-the-release-as-a-whole.
+
+### Step 2 — Categorise the requested changes
+
+For each requested change, mark it as one of:
+
+- **Must address** — the reviewer is asking for a specific code/test/doc change.
+- **Question** — the reviewer is asking for clarification, not asking for a code change.
+- **Out of scope** — the reviewer is asking for something this REQ doesn't intend to deliver.
+
+For Questions: post a reply on the PR or portal explaining; do NOT change code.
+For Out-of-scope items: post a reply proposing a follow-up issue; do NOT silently expand REQ-XXX.
+For Must-address items: collect into a delta-plan section.
+
+### Step 3 — Add a delta-plan section to the implementation plan
+
+Append a new section to `compliance/plans/REQ-XXX/implementation-plan.md`:
+
+```markdown
+## Change-request iteration N
+
+**Reviewer**: @<username>
+**Requested**: <YYYY-MM-DD>
+**Iteration**: N
+
+### Requested changes
+
+- [ ] <bullet per Must-address item, with link to the comment that prompted it>
+
+### Approach
+
+<one-paragraph technical approach for addressing the items>
+
+### Test scope delta
+
+<which existing tests need updates, which new tests are needed, whether the change touches any new acceptance criteria>
+
+### Plan deviations
+
+<if the change reveals the original plan was wrong about something, note it here>
+```
+
+This section is append-only — never rewrite a prior iteration's delta-plan section.
+
+### Step 4 — Re-run Phase 2 (Implement and test)
+
+For the Must-address items only:
+
+- Make the code changes
+- Update existing tests or add new ones — **delegating any e2e/visual-regression test work to `e2e-test-engineer`** (the sub-skill invocation contract still applies in iteration N).
+- Re-run all gates locally; gate-failure iteration cap (N=3 attempts) applies per gate.
+- Commit with `Ref: REQ-XXX` + `Co-Authored-By: Claude` + a body that calls out the change-request iteration:
+
+```
+fix(REQ-XXX): address UAT iteration N — <one-line summary>
+
+Iteration N change-request items:
+- <bullet, link to comment>
+- <bullet, link to comment>
+
+Ref: REQ-XXX
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+### Step 5 — Re-run Phase 3 (Compile evidence) — partial
+
+Re-run the test suite that the change affected. Capture new artefacts:
+
+- New e2e results
+- New unit coverage (if unit tests changed)
+- New screenshots (if UI behaviour changed)
+
+Upload via `devaudit push` **with `--iteration N`** so the portal records this evidence as iteration-tagged:
+
+```bash
+devaudit push <slug> REQ-XXX <type> <file> \
+  --release "<version>" \
+  --environment uat --category testing \
+  --iteration N \
+  --git-sha "$(git rev-parse HEAD)"
+```
+
+(If the `--iteration` flag doesn't exist on the consumer's `devaudit` CLI version, fall back to encoding the iteration into the filename: `compliance/evidence/REQ-XXX/YYYY-MM-DD_iter-N_<artefact>`. The portal renders it the same way.)
+
+**Existing evidence stays.** Iteration N adds; it does not replace. The audit trail wants to see what each iteration's evidence looked like.
+
+### Step 6 — Push to the same branch
+
+`git push` — no `--force`. The PR auto-updates.
+
+The portal's release-approval state automatically resets to `uat_review` on the new SHA. Do not call the portal API to re-trigger this; the state machine handles it.
+
+### Step 7 — Re-request UAT review explicitly
+
+Even though state has reset, the reviewer needs notification. Two actions:
+
+1. **Portal API**: `POST https://devaudit.metasession.co/api/projects/<slug>/releases/<version>/approval-requests` with `{"iteration": N, "summary": "Change-request iteration N addressed"}`. This notifies the reviewer on their portal dashboard.
+2. **PR comment**: post a summary comment on the PR linking to the new commits and the iteration-N evidence on the portal:
+
+```
+Change-request iteration N addressed in <SHA>..<SHA>.
+
+Items addressed:
+- <bullet, link to original comment>
+- <bullet, link to original comment>
+
+Updated evidence: https://devaudit.metasession.co/projects/<slug>/requirements/REQ-XXX (filter by iteration N)
+
+@<reviewer-username> — UAT re-review requested.
+```
+
+### Step 8 — Hard stop
+
+The skill halts. The human's next move is reviewing the iteration N changes on the portal. The skill does NOT advance to merge.
+
+## Iteration discipline
+
+A few rules that keep iteration N+1 distinguishable from iteration N:
+
+- **One iteration per UAT cycle**, not one per commit. If the reviewer asks for three changes, address all three in iteration N, push once, request re-review once. Don't fire iteration boundaries per commit.
+- **Cap at 5 iterations** as a heuristic. If a REQ goes through 5+ iterations without converging, the original plan was probably wrong — halt and ask the user whether to abandon the REQ, split it, or restart from a fresh plan.
+- **Never rewrite the original plan's body** in response to iteration feedback. Use the delta-plan sections; the original plan stays as a historical record of what was first proposed.
+- **Iteration commits are still SDLC-conformant.** Conventional Commits format, `Ref: REQ-XXX`, `Co-Authored-By: Claude`, all gates green locally. No exceptions because "it's just a fix to the previous iteration."
+
+## If the change-request is fundamentally a different REQ
+
+Sometimes a reviewer's change-request is so large it constitutes a new requirement, not an iteration on this one. Examples:
+
+- Reviewer asks for an entire new acceptance criterion that wasn't in the original issue.
+- Reviewer asks for a refactor of a subsystem the REQ doesn't touch.
+- Reviewer asks for backwards-compatibility for a deprecated path the REQ removes.
+
+In these cases:
+
+1. Halt with a clear message: "This change-request expands scope beyond REQ-XXX as originally planned. Recommend filing a separate issue for <subject> and addressing only the in-scope items in iteration N of this REQ."
+2. Wait for the user to confirm the split.
+3. Address only the in-scope items in iteration N; the user opens the separate issue, which becomes a new `sdlc-implementer` invocation.
+
+The principle: REQ-XXX has a defined scope at Phase 1. Iterations refine within scope. Iterations are not scope-creep windows.
+
+## If the change-request is a rejection
+
+If the portal state is `uat_rejected` (not `uat_changes_requested`), the reviewer has marked the release fundamentally broken. The skill should:
+
+1. Halt the change-request loop. Do not attempt to address.
+2. Post on the issue: "UAT rejected this release. Awaiting user direction — options are to (a) close the PR and re-plan from scratch, (b) escalate the rejection to a different reviewer, or (c) appeal the rejection with new context."
+3. Wait for the user to decide. The skill does not unilaterally reopen, force-merge, or escalate.
+
+## Summary
+
+The change-request loop preserves the controls a one-shot approval cycle would skip. Every iteration:
+
+- Documents what the reviewer asked for.
+- Documents what was changed and why.
+- Captures fresh evidence tagged by iteration.
+- Triggers an explicit UAT re-review on the portal.
+- Maintains the full audit trail.
+
+By doing so, even REQs that take five iterations to land have the same compliance posture as REQs that pass UAT on the first try.

--- a/.claude/skills/sdlc-implementer/references/compliance-constraints.md
+++ b/.claude/skills/sdlc-implementer/references/compliance-constraints.md
@@ -1,0 +1,81 @@
+# Compliance constraints (per framework)
+
+The `sdlc-implementer` skill was audited against the five compliance frameworks DevAudit is designed to support. No framework breaks structurally; six architectural constraints + one process risk preserve the controls each framework expects. This document is the long-form audit.
+
+The constraints are enforced in `SKILL.md` and in the smoke pass. Where applicable, the portal itself enforces them server-side as a defence-in-depth measure.
+
+## The six architectural constraints
+
+### 1. Never skip the UAT review gate
+
+| | |
+|---|---|
+| **What** | The skill must not attempt to merge a PR while the `DevAudit Release Approval` check is red. |
+| **Why (framework)** | ISO 27001 A.8.32 (Change management); SOC 2 CC8 (Change management); EU AI Act Art. 14 (Human oversight). The UAT gate is the load-bearing human-oversight checkpoint. |
+| **Enforcement** | Portal-side via `check-release-approval.yml` workflow status check + branch protection. Skill-side: never call `gh pr merge` until the check is green. |
+| **Failure mode if violated** | Merge bypasses human review entirely. Auditor's question "did a human approve this change?" cannot be answered with evidence. |
+
+### 2. For HIGH/CRITICAL, never act as the UAT approver
+
+| | |
+|---|---|
+| **What** | The skill must verify at Phase 4 that the configured UAT reviewer (in `compliance/plans/REQ-XXX/implementation-plan.md` §Four-eyes attestation slot) differs from the skill-trigger user. If they match, halt. |
+| **Why (framework)** | SOC 2 CC8.1 — segregation of duties; ISO 27001 A.5.15 (Access control — duty segregation). The change-author cannot also be the change-approver for higher-risk work. |
+| **Enforcement** | Portal-side: the release-approval API rejects self-approval for MEDIUM/HIGH/CRITICAL risk classes. Skill-side: refuses to open the PR if the configured reviewer matches the trigger user. |
+| **Failure mode if violated** | One human approves their own work. The four-eyes principle is paper-only. |
+
+### 3. Plan checkpoint mandatory for HIGH/CRITICAL
+
+| | |
+|---|---|
+| **What** | At Phase 1 step 8, the skill pauses for human approval of the plan **iff** risk class is HIGH or CRITICAL. LOW/MEDIUM pass through automatically. Can be forced on for all classes via `--require-plan-approval` flag or `DEVAUDIT_REQUIRE_PLAN_APPROVAL=1` env var. |
+| **Why (framework)** | EU AI Act Art. 14 (Human oversight for high-risk AI systems); SOC 2 CC3 (Risk assessment requires human judgement); ISO 29119 §6 (Test management — planning is a documented human step). For HIGH/CRITICAL work the plan IS the design — human review must precede code. |
+| **Enforcement** | Skill-side. Phase 1 explicitly halts and waits for the human's "go" before Phase 2. |
+| **Failure mode if violated** | Code is written + tests are designed + evidence is captured for a HIGH/CRITICAL change without a single human-checkpointed plan. Auditor cannot evidence the design step. |
+
+### 4. Change-request loop triggers full UAT re-review
+
+| | |
+|---|---|
+| **What** | When new commits land on a PR after a UAT change-request, the portal's release-approval state resets. The skill respects the reset, surfaces a "UAT re-review needed" comment, and never assumes the prior approval still covers the new changes. |
+| **Why (framework)** | ISO 27001 A.14.2.4 (Restrictions on changes to software packages — each change goes through controls); SOC 2 CC8.1 (Each change requires approval). Treating "approval given once, all subsequent commits inherit it" would make UAT a one-shot rubber-stamp. |
+| **Enforcement** | Portal-side: the release-approval state machine resets on new commits to the linked branch. Skill-side: re-requests review explicitly via the portal API after each change-request iteration. |
+| **Failure mode if violated** | Drive-by changes ship under cover of an old approval. The audit trail shows "approved once" — but the approved diff is not the diff that shipped. |
+
+### 5. AI involvement disclosed on every commit
+
+| | |
+|---|---|
+| **What** | Every commit the skill creates carries a `Co-Authored-By: Claude <noreply@anthropic.com>` trailer (or equivalent for the specific Claude model in use). |
+| **Why (framework)** | ISO 27001 — transparency norms; EU AI Act Art. 13 (Transparency and provision of information to deployers); GDPR Art. 22 (data subjects' right to know about automated decisions, where applicable). When an auditor traces a commit, the AI involvement must be visible. |
+| **Enforcement** | Skill-side. Every `git commit` call includes the trailer. CI's `compliance-validation.yml` workflow can be configured to grep for `Co-Authored-By` on PRs labelled with the AI-touched marker; this is optional but recommended. |
+| **Failure mode if violated** | AI-generated code is indistinguishable from human-authored code in the audit trail. Future-proofing against tightening AI-disclosure regulations breaks. |
+
+### 6. All portal mutations through audit-logged APIs
+
+| | |
+|---|---|
+| **What** | The skill calls `devaudit push` and the standard portal HTTP APIs — never a database back-channel, never a service-role-key-equivalent that bypasses the audit log. |
+| **Why (framework)** | ISO 27001 A.12.4 (Logging and monitoring); SOC 2 CC4 + CC7 (Monitoring activities + system operations). Every action that affects compliance state must produce an audit-log entry attributable to a human identity (the user whose PAT is in `DEVAUDIT_USER_TOKEN`). |
+| **Enforcement** | Skill-side. All portal interaction goes through `devaudit push` or `curl`/`gh api` against the documented REST endpoints. |
+| **Failure mode if violated** | Compliance-affecting actions land on the portal with no audit-log trail. Auditor's "who did this?" question is unanswerable. |
+
+## The one process risk
+
+### 7. Rubber-stamping at UAT
+
+| | |
+|---|---|
+| **What** | If the UAT reviewer approves without actually reading the change, the controls are formally satisfied but substantively hollow. |
+| **Why (framework)** | SOC 2 CC4.1 (Monitoring activities — the entity should detect this via its own QA sampling). Not enforced by any control mechanism; relies on human discipline. |
+| **Enforcement** | Not architectural. Mitigations: the SKILL.md's Principles section names the UAT reviewer as "the load-bearing human"; the portal's UAT-review UI intentionally adds friction (no one-click approve from email); org policy should random-sample approvals for QA. |
+| **Failure mode if violated** | Auditors detect approval velocity that doesn't match human reading time. Spot-checks reveal approvals on changes the approver couldn't articulate. Trust erodes. |
+
+## What's NOT a compliance break
+
+Audited and cleared:
+
+- **Audit log attribution** (ISO 27001 A.12.4): Actions flow through the user's tokens (`DEVAUDIT_USER_TOKEN`, `GH_TOKEN`); commits carry `Co-Authored-By`; UAT approval is a genuine human act recorded on the portal. The auditor's question "did this human review this?" is answered by the UAT-approval event on the portal, not by the commit signature.
+- **GDPR Art. 22** (Automated decisions about data subjects): Doesn't apply. The skill makes technical decisions, not decisions about people. If the issue being implemented IS Art. 22 work (an algorithm that decides about data subjects), the implementation plan captures DPA/DPIA requirements at Phase 1 — same as today.
+- **EU AI Act high-risk classification of the skill itself**: The skill is a productivity tool, not high-risk under Annex III. Art. 14 (Human oversight) is satisfied by the HIGH/CRITICAL plan checkpoint + the always-on UAT gate.
+- **ISO 29119 test adequacy**: Human at UAT reviews test scope. Same caveat as #7 above — depends on UAT reviewer paying attention.

--- a/.gitignore
+++ b/.gitignore
@@ -49,5 +49,7 @@ next-env.d.ts
 # Database backups
 /backups
 
-# Claude Code local state
-.claude/
+# Claude Code local state — ignore everything except the synced SDLC skills,
+# which are version-controlled (refreshed by `devaudit update`).
+.claude/*
+!.claude/skills/


### PR DESCRIPTION
The synced SDLC skills (`sdlc-implementer`, `e2e-test-engineer`) were gitignored here, so the Phase-0 workflow-triage update from `devaudit update` landed only on disk. This version-controls them like META-JOBS does.

- `.gitignore` scoped to `.claude/*` + `!.claude/skills/` — local Claude Code state stays ignored, the synced skills are tracked.
- Commits the current 0.1.19 skills (incl. the Phase-0 triage in `sdlc-implementer`).

They remain refreshed by `devaudit update`; committing them just makes a fresh clone (and any reviewer) see the same skill the operator runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)