### PR TITLE
test: fix regression-suite locators (route, strict-mode, CSS-parse) — partial #160 follow-up

### DIFF
--- a/e2e/authenticated.spec.ts
+++ b/e2e/authenticated.spec.ts
@@ -113,7 +113,11 @@ superAdminTest.describe('Section 11: Dashboard Overview', () => {
   superAdminTest('dashboard shows recent orders section', async ({ page }) => {
     await page.goto('/dashboard');
     await page.waitForLoadState('networkidle');
-    await expect(page.locator('text=Recent Orders')).toBeVisible();
+    // Scope to <main> — the dashboard layout has duplicate desktop+mobile nav
+    // so a bare text= matches twice (strict-mode violation).
+    await expect(
+      page.locator('main').getByText('Recent Orders').first()
+    ).toBeVisible();
   });
 });
 
@@ -271,9 +275,12 @@ superAdminTest.describe('Section 15: Financial Management', () => {
     async ({ page }) => {
       await page.goto('/dashboard/finance/expenses');
       await page.waitForLoadState('networkidle');
-      const pendingBtn = page.locator(
-        'a[href="/dashboard/finance/expenses/pending"]'
-      );
+      // Scope to <main> — the sidebar nav also links to the same href, so a
+      // bare attribute selector matches twice (strict-mode violation).
+      const pendingBtn = page
+        .locator('main')
+        .locator('a[href="/dashboard/finance/expenses/pending"]')
+        .first();
       await expect(pendingBtn).toBeVisible();
     }
   );
@@ -335,9 +342,9 @@ superAdminTest.describe('Section 16: Reports & Analytics', () => {
 // ===========================================================================
 adminTest.describe('Section 17: Kitchen Display System', () => {
   adminTest('kitchen display loads with dark theme', async ({ page }) => {
-    await page.goto('/dashboard/kitchen');
+    await page.goto('/dashboard/kitchen-display');
     await page.waitForLoadState('networkidle');
-    expect(page.url()).toContain('/dashboard/kitchen');
+    expect(page.url()).toContain('/dashboard/kitchen-display');
     await expect(
       page.locator('h1', { hasText: 'Kitchen Display' })
     ).toBeVisible();
@@ -347,14 +354,14 @@ adminTest.describe('Section 17: Kitchen Display System', () => {
   });
 
   adminTest('kitchen display shows active order count', async ({ page }) => {
-    await page.goto('/dashboard/kitchen');
+    await page.goto('/dashboard/kitchen-display');
     await page.waitForLoadState('networkidle');
     const body = await page.textContent('body');
     expect(body).toMatch(/Active Order/i);
   });
 
   adminTest('kitchen display has back button to orders', async ({ page }) => {
-    await page.goto('/dashboard/kitchen');
+    await page.goto('/dashboard/kitchen-display');
     await page.waitForLoadState('networkidle');
     await expect(
       page.getByRole('link', { name: 'Back to Dashboard' })

--- a/e2e/pending-expenses.spec.ts
+++ b/e2e/pending-expenses.spec.ts
@@ -248,8 +248,11 @@ adminTest.describe('REQ-026: Edit pending group', () => {
       }
       await page.locator('button[title="Edit"]').first().click();
       await expect(page.locator('[role="dialog"]')).toBeVisible();
+      // Playwright doesn't accept `[role="dialog"] text=…` (mixing CSS attr
+      // selector with the `text=` engine in one string). Split into a scoped
+      // locator + getByText.
       await expect(
-        page.locator('[role="dialog"] text=Edit Expense Group')
+        page.locator('[role="dialog"]').getByText('Edit Expense Group')
       ).toBeVisible();
     }
   );
@@ -463,7 +466,9 @@ adminTest.describe('REQ-026: Navigation', () => {
     async ({ page }) => {
       await page.goto('/dashboard/finance/expenses');
       await page.waitForLoadState('networkidle');
+      // Scope to <main> — sidebar nav also links to the same href.
       const pendingBtn = page
+        .locator('main')
         .locator('a[href="/dashboard/finance/expenses/pending"]')
         .first();
       await expect(pendingBtn).toBeVisible();


### PR DESCRIPTION
Housekeeping `test:` change — first concrete output from triaging PR #152's red E2E Regression run.

## What this fixes (7 confirmed test-bugs, 2 files)

- **`authenticated.spec.ts`** — 5 tests:
  - Section 11D `text=Recent Orders` & 15F `a[href=…]` → scoped to `<main>` (strict-mode: sidebar nav duplicates the matched element).
  - Section 17K kitchen-display tests (×3) — were navigating to `/dashboard/kitchen` (the kitchen-management hub per REQ-034) instead of **`/dashboard/kitchen-display`** (the actual display screen). Confirmed via `lib/permissions.ts:29` + `app/dashboard/kitchen-display/page.tsx` having the matching `bg-gray-900` / `Kitchen Display` h1 / `Back to Dashboard` link / `Active Order(s)` text.
- **`pending-expenses.spec.ts`** — 2 tests:
  - Line 252 — split `page.locator('[role="dialog"] text=Edit Expense Group')` — Playwright rejects mixing the CSS engine with the `text=` engine in one selector string.
  - Line 466 — scope pending-button locator to `<main>` (same strict-mode pattern).

Verified via `playwright test --list` — both files parse cleanly.

## What's not in this PR (tracked)

- **#158** — tip captures not reflected in Daily Report (3 tests, express/close-tab/admin-pay-tab — same symptom from independent flows, probably product/integration not selector).
- **#159** — inventory unit conversion D10/D11 re-surface (4 tests).
- **#160** — 14 remaining tests needing component-level verification before triage.

## SDLC
Housekeeping `test:` — no REQ-XXX, no RTM row, no evidence pack. PR → `develop` per the project's branch model. Lightweight path per the [change-workflows taxonomy](https://github.com/metasession-dev/DevAudit-Installer/blob/main/docs/change-workflows.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
