### PR TITLE
docs(compliance): [REQ-048] re-attribute gate evidence to REQ-048 release

### DIFF
--- a/lib/scheduled-jobs.ts
+++ b/lib/scheduled-jobs.ts
@@ -1,10 +1,11 @@
 /**
- * In-process scheduled jobs for the persistent Railway server (REQ-048 / #117 P0 #3).
+ * @requirement REQ-048 — In-process reward-expiry scheduler (#117 P0 #3)
  *
- * The app runs as a long-lived custom Node server (`server.ts`), not serverless,
- * so a simple in-process scheduler is the lightest mechanism — no external cron
- * service, no new dependency. This module is the registry future scheduled jobs
- * hook into (e.g. the Instagram campaign poller, #117 IG-5).
+ * In-process scheduled jobs for the persistent Railway server. The app runs as
+ * a long-lived custom Node server (`server.ts`), not serverless, so a simple
+ * in-process scheduler is the lightest mechanism — no external cron service,
+ * no new dependency. This module is the registry future scheduled jobs hook
+ * into (e.g. the Instagram campaign poller, #117 IG-5).
  *
  * Single-instance assumption: if multiple Railway replicas run, each runs these
  * jobs — so every job here MUST be idempotent and duplicate runs harmless.


### PR DESCRIPTION
**Fixes a release-attribution miss on REQ-048.**

When PR #156 merged to develop, `derive-release-version.sh` fell through to the date fallback (returned `v2026.05.28`) because the merge-commit title used parens `(REQ-048, ...)` instead of brackets `[REQ-048]` — so step 3 of the script (\"bracketed [REQ-XXX] in body\") didn't match. Result: the CI Quality Gates run uploaded SAST / Dependency Audit / E2E / Test Reports to the `v2026.05.28` release, not REQ-048.

Portal reports REQ-048 as **Missing compliance gates: SAST Scan, Dependency Audit, E2E Tests, Test Reports**.

This PR's commit subject contains \`[REQ-048]\`, so:
- The develop-push merge commit's body will carry that bracket → \`derive-release-version.sh\` returns \`REQ-048\` (script step 3).
- \`ci.yml\` re-runs the gates under \`--release REQ-048\` and uploads them under that release.
- Portal's REQ-048 row should fill in.

The actual file change is small — converting an inline `(REQ-048 / #117 P0 #3)` mention in `lib/scheduled-jobs.ts` to the proper `@requirement REQ-048` JSDoc convention (matches `tab-service.ts:2`, `upload-evidence.sh:2`, etc.). Useful regardless of the attribution fix.

**Lesson:** PR titles for tracked work need `[REQ-XXX]` brackets so the merge-commit body inherits the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)