### PR TITLE
ci: guard req_meta_args against silent set -e exit on empty CT

### DIFF
--- a/.github/workflows/compliance-evidence.yml
+++ b/.github/workflows/compliance-evidence.yml
@@ -149,6 +149,17 @@ jobs:
               | head -1 || true)
             [ -n "$TITLE" ] && printf -- '--release-title %q ' "$TITLE"
             [ -n "$CT" ] && printf -- '--change-type %q ' "$CT"
+            # The function's exit status is the exit of its last command. The
+            # last `[ -n … ] && printf` returns 1 whenever the bracket-test is
+            # false (e.g. CT="" — the common case under `actions/checkout@v4`'s
+            # default `fetch-depth: 1`, where `git log --grep` sees only the
+            # HEAD merge commit whose subject never carries `[REQ-XXX]`). Under
+            # the workflow's `set -e` mode, `VAR=$(req_meta_args …)` then exits
+            # the whole shell silently — the symptom on develop after 0.1.21:
+            # doc uploads succeed, ticket loop never starts, workflow dies with
+            # bare `exit 1`. Force a clean return so the conditional printfs
+            # remain advisory.
+            return 0
           }
 
           # Upload release tickets (pending only)


### PR DESCRIPTION
## Why

After the v0.1.21 sync (commit `c0cfbc8`), Compliance Evidence Upload has been failing silently on every develop push that has a pending release ticket (PRs #178, #179, #181 — and the re-run on PR #180's merge SHA, which blocks the REQ-050 release).

The new helper `req_meta_args` ends with two conditional `printf`s:

```bash
[ -n "$TITLE" ] && printf -- '--release-title %q ' "$TITLE"
[ -n "$CT" ] && printf -- '--change-type %q ' "$CT"
```

The function's exit status is the status of its last command. `CT` is empty in the common case — `actions/checkout@v4`'s default `fetch-depth: 1` gives `git log --grep '\[REQ-XXX\]\|Ref: REQ-XXX'` only the HEAD merge commit (`Merge pull request #N from …`), which never matches. So function returns 1.

Under the workflow's `set -e` (`bash -e {0}`), `TICKET_META_ARGS=$(req_meta_args …)` then exits the entire step silently — the symptom is doc uploads completing, no "Uploading: RELEASE-TICKET-…" line, then bare `exit 1`.

## Reproduction

```
$ bash -e -c 'f(){ x=""; [ -n "$x" ] && echo nope; }; v=$(f); echo "survived"'
# (no output — exits 1)
```

Locally verified against the actual workflow code path:

```
DEBUG: TITLE=[Release Ticket: REQ-050 — …]  CT=[]
Function return: 1
```

## Fix

`return 0` at the end of `req_meta_args`. The conditional `printf`s are stdout-shapers, not status signals.

## Upstream

This bug ships in DevAudit-Installer's v0.1.21 templates and will be re-introduced by the next `devaudit update`. Upstream issue to follow.

## Verification

Local simulation passes for all three relevant cases — CT empty, CT+TITLE both empty, and the full ticket-loop flow. Once this lands and Compliance Evidence runs green on the next develop push, the v2026.05.28 release record will be fully populated and the v0.1.21 release-approval gate on PR #180 can be approved in the DevAudit portal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)