### PR TITLE
compliance: [REQ-050] record Compliance Evidence Upload fix chain in verification

### DIFF
--- a/compliance/pending-releases/RELEASE-TICKET-REQ-050.md
+++ b/compliance/pending-releases/RELEASE-TICKET-REQ-050.md
@@ -42,6 +42,7 @@ Ships with `scripts/reconcile-track-by-location-stock.ts` to systematically reco
 - Semgrep (`--severity ERROR`) → 0 findings on REQ-050 code.
 - E2E: N/A by scope (service-layer fix; UI reflects state).
 - CI Pipeline ran on develop-push merging `4f0cbeb` — `derive-release-version.sh` returned `REQ-050` ✓; gate evidence uploaded at `environment=uat` under `--release REQ-050`.
+- Compliance Evidence Upload initially failed silently on the post-`4f0cbeb` develop pushes (the v0.1.21 sync introduced a `set -e` + bash-function-last-command bug in `req_meta_args`). Fixed via PR #182 (`return 0` guard in the helper); workflow now successfully uploads the REQ-050 release ticket + 7 evidence files to the `REQ-050` release record (verified end-to-end on `workflow_dispatch` run `26583892811`, 12 uploads in 9s). Upstream issue [DevAudit-Installer#77](https://github.com/metasession-dev/DevAudit-Installer/issues/77) tracks the permanent fix in the next sync.
 
 ## Operational repair (separate from this code release)
 


### PR DESCRIPTION
## Why

Two things in one commit:

1. **Honest audit-trail addition** — record in the REQ-050 release ticket's Verification section that the post-merge Compliance Evidence Upload runs initially failed silently (v0.1.21 `set -e` bug in `req_meta_args`), were fixed via #182, and that the REQ-050 release record is now fully populated (verified end-to-end on workflow_dispatch run `26583892811`, 12 uploads in 9s). Upstream permanent fix tracked at [DevAudit-Installer#77](https://github.com/metasession-dev/DevAudit-Installer/issues/77).

2. **Side-effect: retargets the DevAudit Release Approval gate on PR #180.** The merge-commit body of this PR will carry `[REQ-050]`, so `derive-release-version.sh` on develop's next HEAD will return `REQ-050` — the gate then checks the `REQ-050` release record (which has the full evidence pack) instead of `v2026.05.28` (the date-prefix housekeeping release created by #181 as the bootstrap-mode-false-pass workaround). v2026.05.28 was correctly refused for UAT-approve in the portal because it had no evidence attached.

## Diff

One line added to `compliance/pending-releases/RELEASE-TICKET-REQ-050.md` under `## Verification`.

## After-merge sequence

1. develop's HEAD subject body now has `[REQ-050]`.
2. DevAudit Release Approval re-runs on PR #180 → checks the `REQ-050` release.
3. Operator UAT-approves `REQ-050` in the portal (full evidence already attached: release ticket, ai-prompts, ai-use-note, implementation-plan, security-summary, test-execution-summary, test-plan, test-scope).
4. Gate passes → PR #180 merges → `post-deploy-prod.yml` runs → Phase 5 completes.

Ref: REQ-050

🤖 Generated with [Claude Code](https://claude.com/claude-code)