### PR TITLE
ci: checkout PR head SHA in release-approval gate so derive sees the integration-side commit

### DIFF
--- a/.github/workflows/check-release-approval.yml
+++ b/.github/workflows/check-release-approval.yml
@@ -33,7 +33,19 @@ jobs:
       PROJECT_SLUG: wgb
 
     steps:
+      # Checkout the PR's head SHA (e.g. develop's HEAD for a develop→main
+      # release PR) instead of the default `refs/pull/<N>/merge` synthetic
+      # merge commit. derive-release-version.sh runs `git log -1` against the
+      # checked-out HEAD; the synthetic merge commit GitHub auto-creates for a
+      # PR carries neither the source-branch's [REQ-XXX] subject nor the PR
+      # title in its body, so derive falls through to the date fallback —
+      # which then collides with whatever housekeeping date-prefix release
+      # exists (or doesn't) in the portal. Pointing at head.sha gives derive
+      # the actual integration-side HEAD whose body carries [REQ-XXX] from the
+      # merge of feat/REQ-XXX into the integration branch.
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Resolve DevAudit base URL
         run: |


### PR DESCRIPTION
## Why

The DevAudit Release Approval gate is failing on PR #180 with `Release v2026.05.28 status: draft` even though develop's HEAD has `[REQ-050]` in the merge-commit body and the `REQ-050` release record is fully populated and UAT-approved.

Root cause: `actions/checkout@v4` on `pull_request` events defaults to `refs/pull/<N>/merge` — GitHub's auto-generated synthetic merge of head into base. That commit carries neither the source-branch's `[REQ-XXX]` subject nor the PR title in its body. `derive-release-version.sh` runs `git log -1` against the checked-out HEAD, sees no match, and falls through to the date prefix. The gate then asks for approval of a date-prefix release that may be empty (or absent), which the portal correctly refuses.

## Fix

```yaml
- uses: actions/checkout@v4
  with:
    ref: ${{ github.event.pull_request.head.sha }}
```

For a develop→main release PR, `head.sha` is develop's HEAD — whose body does carry `[REQ-XXX]` (from the merge of `feat/REQ-XXX-…` into develop). derive then correctly returns the tracked-release identifier.

## After-merge expectation

On PR #180:
- Gate re-runs (PRs auto-re-run when develop's HEAD moves).
- Checks out develop @ `74843c4` (or whatever HEAD is after this merge).
- `git log -1 --format='%b'` includes `compliance: [REQ-050] record …` — derive returns `REQ-050`.
- Looks up `REQ-050` status → `uat_approved` (just approved by operator).
- ✅ Pass.

## Upstream

Same bug class as DevAudit-Installer#77 — local patch will be clobbered by next `devaudit update`. Upstream issue to follow.

Ref: REQ-050

🤖 Generated with [Claude Code](https://claude.com/claude-code)