### PR TITLE
ci: derive release-approval lookup prefix from PR title (REQ-XXX) instead of hardcoded date

### DIFF
--- a/.github/workflows/check-release-approval.yml
+++ b/.github/workflows/check-release-approval.yml
@@ -150,8 +150,34 @@ jobs:
         id: release
         if: env.BOOTSTRAP_MODE != 'true'
         run: |
-          DATE_PREFIX="v$(date +%Y.%m.%d)"
-          RESOLVE_URL="${BASE}/api/ci/releases/resolve?projectSlug=${PROJECT_SLUG}&versionPrefix=${DATE_PREFIX}"
+          # Pick the release prefix the portal should look up. Priority:
+          #
+          #   1. `[REQ-XXX]` in the PR title — for a tracked-release PR
+          #      (e.g. "release: [REQ-050] expense-restock stock-leak …"),
+          #      look up the `REQ-XXX` release record directly. This is the
+          #      release that compliance-evidence.yml populates per-REQ; it
+          #      is the same identifier `derive-release-version.sh` returns
+          #      for develop pushes carrying the `[REQ-XXX]` tag.
+          #   2. Date prefix `v$(date +%Y.%m.%d)` — fallback for untracked /
+          #      housekeeping release PRs without a `[REQ-XXX]` title.
+          #
+          # The previous behaviour hardcoded the date prefix, which collided
+          # with the per-REQ release shape: the date-prefix release was
+          # empty (its requirement matrix never got populated, because
+          # uploads went to `REQ-XXX`), so the portal correctly refused to
+          # UAT-approve it, and the gate stayed red even after the actual
+          # tracked release (`REQ-XXX`) was approved. Reading from the PR
+          # title aligns the gate with the release that operators actually
+          # work in. Upstream issue to follow on DevAudit-Installer.
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          if echo "$PR_TITLE" | grep -qE '\[REQ-[0-9]+\]'; then
+            LOOKUP_PREFIX=$(echo "$PR_TITLE" | grep -oE '\[REQ-[0-9]+\]' | head -1 | grep -oE 'REQ-[0-9]+')
+            echo "Resolved release prefix from PR title: ${LOOKUP_PREFIX}"
+          else
+            LOOKUP_PREFIX="v$(date +%Y.%m.%d)"
+            echo "No [REQ-XXX] in PR title; falling back to date prefix: ${LOOKUP_PREFIX}"
+          fi
+          RESOLVE_URL="${BASE}/api/ci/releases/resolve?projectSlug=${PROJECT_SLUG}&versionPrefix=${LOOKUP_PREFIX}"
           # Retry: register-release in ci.yml may still be racing with us.
           MAX_ATTEMPTS=6
           WAIT_SECONDS=10
@@ -163,13 +189,13 @@ jobs:
               break
             fi
             if [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]; then
-              echo "Attempt ${ATTEMPT}/${MAX_ATTEMPTS}: no release for ${DATE_PREFIX} yet — waiting ${WAIT_SECONDS}s..."
+              echo "Attempt ${ATTEMPT}/${MAX_ATTEMPTS}: no release for ${LOOKUP_PREFIX} yet — waiting ${WAIT_SECONDS}s..."
               sleep $WAIT_SECONDS
             fi
           done
           VERSION=$(echo "$RESP" | jq -r '.latest.version // empty')
           if [ -z "$VERSION" ]; then
-            echo "::error::No release found for ${DATE_PREFIX} after ${MAX_ATTEMPTS} attempts. Push to develop first to create the release."
+            echo "::error::No release found for ${LOOKUP_PREFIX} after ${MAX_ATTEMPTS} attempts. Push to develop first to create the release."
             exit 1
           fi
           RELEASE_ID=$(echo "$RESP" | jq -r '.latest.id')


### PR DESCRIPTION
## Why

The DevAudit Release Approval gate hardcoded `DATE_PREFIX="v$(date +%Y.%m.%d)"` and resolved that exact prefix against the portal. `compliance-evidence.yml` however uploads per-requirement evidence under `--release REQ-XXX` — so the date-prefix release record is **empty** (no release ticket, no security summary, no requirement-scoped evidence). The portal correctly refuses to UAT-approve it, leaving the gate red even after the actual tracked release (`REQ-XXX`) has been approved.

On PR #180, REQ-050 is `uat_approved` in the portal and has the full evidence pack, but the gate keeps asking for `v2026.05.28` approval — which is structurally impossible because `v2026.05.28` has no release ticket, no security summary, and zero requirement-scoped evidence (those all went to release `REQ-050`).

## Fix

Pick the lookup prefix from the PR title:

```bash
PR_TITLE="${{ github.event.pull_request.title }}"
if echo "$PR_TITLE" | grep -qE '\[REQ-[0-9]+\]'; then
  LOOKUP_PREFIX=$(…extract REQ-XXX…)
else
  LOOKUP_PREFIX="v$(date +%Y.%m.%d)"
fi
```

PR #180's title is `release: [REQ-050] expense-restock stock-leak fix for trackByLocation inventory (#175)` — so on re-run the gate looks up `REQ-050`, finds `uat_approved`, ✅ passes.

Backwards-compatible: untracked / housekeeping release PRs without a `[REQ-XXX]` title still fall through to the date prefix (existing behaviour).

## Upstream

Sibling of [DevAudit-Installer#77](https://github.com/metasession-dev/DevAudit-Installer/issues/77). Will be re-raised upstream so the next `devaudit update` retains the fix.

Ref: REQ-050

🤖 Generated with [Claude Code](https://claude.com/claude-code)