### PR TITLE
test(e2e): unblock 2 untracked regression failures from #190 (UoM + reconciliation)

### DIFF
--- a/e2e/reconciliation.spec.ts
+++ b/e2e/reconciliation.spec.ts
@@ -150,8 +150,12 @@ test.describe('REQ-014: Orders Page — Reconciliation', () => {
     await expect(payNowBtn).toBeVisible({ timeout: 5000 });
     await payNowBtn.click();
 
-    // Select Cash payment method
-    const cashBtn = page.locator('button').filter({ hasText: 'Cash' });
+    // Select Cash payment method. `filter({ hasText: 'Cash' })` over `button`
+    // now matches two elements (strict-mode violation), so we anchor on the
+    // accessible name being exactly "Cash" — the picker is a plain-labelled
+    // button; any other button containing the substring (e.g. a card with a
+    // longer label) won't match.
+    const cashBtn = page.getByRole('button', { name: /^Cash$/i });
     await expect(cashBtn).toBeVisible({ timeout: 5000 });
     await cashBtn.click();
 

--- a/e2e/settings/units-of-measurement.spec.ts
+++ b/e2e/settings/units-of-measurement.spec.ts
@@ -53,8 +53,12 @@ superAdminTest.describe('REQ-033: Units of Measurement registry', () => {
     'AC1: Settings shows the Units of Measurement section to super-admin',
     async ({ page }) => {
       await gotoSettings(page);
+      // The section title renders inside a shadcn `CardTitle`, which is a
+      // `<div>` (not a semantic heading), so `getByRole('heading')` never
+      // matches. Use the same `text=` locator `gotoSettings` already uses
+      // to scroll the section into view.
       await expect(
-        page.getByRole('heading', { name: /Units of Measurement/i })
+        page.locator('text=Units of Measurement').first()
       ).toBeVisible();
       // Default seeded units are visible
       await expect(page.locator('input[value="kg"]')).toBeVisible();


### PR DESCRIPTION
## Summary

Fixes 2 of the 4 untracked regression-pack failures tracked in #190 — both pure test-side bugs surfaced by run [26621177567](https://github.com/metasession-dev/wawagardenbar-app/actions/runs/26621177567) (2026-05-29 06:06 UTC).

| File:test | Failure | Fix |
|---|---|---|
| `e2e/settings/units-of-measurement.spec.ts:AC1` | `getByRole('heading', /Units of Measurement/i)` not found | shadcn's `CardTitle` is a `<div>`, not a heading element. Switched to `page.locator('text=Units of Measurement').first()` — the same pattern the spec's own `gotoSettings` helper already uses, so the two stay consistent. |
| `e2e/reconciliation.spec.ts:154` | `locator('button').filter({ hasText: 'Cash' })` matched 2 elements (strict-mode violation) | Anchored on the accessible name being exactly "Cash" via `getByRole('button', { name: /^Cash$/i })` — same class as the #160 selector failures. |

Both are 1-locator changes, no component or product change. ~10 LOC.

## Verification

Quality Gates (smoke) will run on the PR. The full regression suite re-runs nightly at 02:00 UTC on `main`; if you want immediate end-to-end verification I can trigger `gh workflow run e2e-regression.yml --ref test/e2e-untracked-fixes-uom-cash` once the PR's smoke is green.

## Remaining in #190

- `pending-expenses.spec.ts:multi-line expense group — appears on pending page` — dialog doesn't hide after submit; needs component-level triage (possibly Zod validation regression or close-handler removal).
- `pending-expenses.spec.ts:Pending Expenses button on expenses page` — click does not navigate despite the `<Link>` existing at the expected href; needs dev-server triage.

Bundling those into a follow-up PR after triage; they're more likely product bugs than test bugs.

Refs: #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)