### PR TITLE
ci(e2e): upload test-results/ alongside playwright-report/

### DIFF
--- a/.github/workflows/e2e-regression.yml
+++ b/.github/workflows/e2e-regression.yml
@@ -91,4 +91,13 @@ jobs:
           path: |
             e2e-regression-results.json
             playwright-report/
+            # Playwright writes per-test traces, videos, screenshots and
+            # error-context.md to test-results/<spec>-<title>[-retry<N>]/
+            # — spec-named, unlike playwright-report/data/<hash>.zip. Include
+            # them so failed-test triage doesn't need to walk the hash index
+            # in the HTML report: `npx playwright show-trace
+            # test-results/<spec-test>/trace.zip` resolves the failure in one
+            # step. Storage cost is a duplicate of the data already in
+            # playwright-report/data/, accepted for the debuggability win.
+            test-results/
           retention-days: 30


### PR DESCRIPTION
## Why

[#190](https://github.com/metasession-dev/wawagardenbar-app/issues/190) has 3 untracked regression failures (pending-expenses dialog close, pending-expenses Link nav, reconciliation tabs filter timeout) that aren't diagnosable from source alone — they need Playwright traces.

Traces **are** captured today (`trace: 'on-first-retry'` fires for all 3 since each retries) and end up inside the uploaded artifact at `playwright-report/data/<hash>.zip`. But the hash names mean triage requires walking the HTML report index just to find the file for a specific failed test.

Playwright also writes the same traces to `test-results/<spec>-<title>[-retryN]/trace.zip` during the run — spec-named, plus screenshots, videos, and the modern `error-context.md` summary. That folder isn't currently in the upload paths.

## Change

```yaml
path: |
  e2e-regression-results.json
  playwright-report/
+ test-results/   # spec-named traces, videos, screenshots, error-context.md
```

After this lands, triaging a failed regression test is:

```bash
gh run download <id> --name e2e-regression-report
npx playwright show-trace test-results/pending-expenses-REQ-026-…-retry1/trace.zip
```

## Cost

Storage roughly doubles the trace footprint — currently ~80 MB of trace zips inside `playwright-report/data/`, accepted for the debuggability win. Retention stays 30 days.

## Verification

The change is to artifact-upload paths only — no test or runtime behaviour changes. Nightly regression at 02:00 UTC will exercise the new artifact shape; if anything's off (path doesn't exist, etc.) it will manifest as a missing-file warning on the upload step, not a test failure.

Refs: #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)