### PR TITLE
test(e2e): widen tabs-filter trigger locator past the activeFilterCount badge

### DIFF
--- a/e2e/reconciliation.spec.ts
+++ b/e2e/reconciliation.spec.ts
@@ -98,8 +98,17 @@ test.describe('REQ-014: Tabs Page — Reconciliation', () => {
     await page.goto('/dashboard/orders/tabs');
     await page.waitForLoadState('networkidle');
 
-    // Open the filter panel
-    await page.getByText('Filter Tabs', { exact: true }).first().click();
+    // Open the filter panel. The DashboardTabsFilter `CardTitle` is the
+    // collapsible trigger and renders an icon + 'Filter Tabs' + a count
+    // badge (the badge shows whenever activeFilterCount > 0, and the
+    // default state has statuses=['open'] so the count is 1 on first
+    // load). `getByText('Filter Tabs', { exact: true })` therefore can't
+    // match the title because the visible-text container also includes
+    // the badge. Use the role+name pattern instead.
+    await page
+      .getByRole('button', { name: /Filter Tabs/i })
+      .first()
+      .click();
 
     // Reconciliation label should be visible in the filter panel
     await expect(


### PR DESCRIPTION
## Why

`#160` entry — `reconciliation.spec.ts:tabs filter includes reconciliation options` — has been failing with 30s timeout on every run. Diagnosed without traces:

`DashboardTabsFilter`'s `CardTitle` is wrapped in a `CollapsibleTrigger` button. It renders:

```
<Filter icon> Filter Tabs <Badge>{activeFilterCount}</Badge>
```

`activeFilterCount` is `1` on first load because `DEFAULT_STATUSES = ['open']` seeds the persisted filter to non-empty. So the badge is always visible at page-open. The test's `getByText('Filter Tabs', { exact: true })` can't match because the visible-text container also includes the badge digit.

## Fix

Match the trigger by accessible name instead:

```ts
- await page.getByText('Filter Tabs', { exact: true }).first().click();
+ await page.getByRole('button', { name: /Filter Tabs/i }).first().click();
```

The icon and badge don't contribute to the accessible-name string, so this matches the CollapsibleTrigger reliably regardless of badge state.

## Verification

PR-triggered smoke (no E2E gate on PRs into develop). For full verification I'll trigger `gh workflow run e2e-regression.yml --ref test/e2e-tabs-filter-badge` after this — that run also exercises PR #192's new trace upload so any further failure in this test (or others) will yield spec-named traces.

## Remaining in #160 / #190 / #158 / #159

This is 1 of 12 remaining in #160. The rest mostly need traces to diagnose confidently (mystery-state failures where source-only reading doesn't yield a definitive test-vs-product classification). Once PR #192's traces upload on the next regression run, I'll triage another batch.

Refs: #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)