### PR TITLE
test(e2e): fix readTotalRevenueText helper selectors to match rendered DOM (#200)

### DIFF
--- a/e2e/kitchen/daily-report-regression.spec.ts
+++ b/e2e/kitchen/daily-report-regression.spec.ts
@@ -40,25 +40,35 @@ async function gotoDailyReport(page: Page): Promise<void> {
 }
 
 async function readTotalRevenueText(page: Page): Promise<string> {
-  // The Total Revenue row in components/features/reports/profit-section.tsx
-  // renders as a flex row of two spans:
+  // The DFR's Total Revenue card is rendered by
+  // components/features/admin/profitability-overview-cards.tsx as a shadcn
+  // Card with the label in CardHeader and the value in a sibling CardContent:
   //
-  //   <div class="flex justify-between items-center py-2">
-  //     <span class="font-semibold">Total Revenue</span>
-  //     <span class="text-lg font-bold text-primary">{formatCurrency(...)}</span>
-  //   </div>
+  //   <Card>
+  //     <CardHeader>
+  //       <CardTitle className="text-sm font-medium">Total Revenue</CardTitle>
+  //       <DollarSign />
+  //     </CardHeader>
+  //     <CardContent>
+  //       <div className="text-2xl font-bold">₦{value.toLocaleString()}</div>
+  //       <p className="text-xs">N order(s)</p>
+  //     </CardContent>
+  //   </Card>
   //
-  // The previous helper looked for the label as a `div`/`h3` and the value as
-  // a `div.text-2xl.font-bold` — neither matches the actual markup, so the
-  // helper returned ₦0.00 / failed visibility every time. Find the label by
-  // exact text (excluding the colon-suffixed 'Total Revenue:' label in
-  // revenue-section.tsx) and read its sibling span.
-  const label = page
+  // shadcn's CardTitle is a `<div>` (see PR #191 for the precedent — same
+  // gotcha hit the UoM test). The previous helper's CSS:has selector matched
+  // the CardHeader and then looked for `div.text-2xl.font-bold` INSIDE the
+  // header — but the value div lives in the sibling CardContent. Walk up to
+  // the Card root (two ancestors: CardTitle → CardHeader → Card) and pick
+  // the value from there. Filter out the 'Total Revenue:' label in
+  // revenue-section.tsx (different component, different layout).
+  const title = page
     .getByText(/^\s*Total Revenue\s*$/)
     .filter({ hasNotText: ':' })
     .first();
-  await expect(label).toBeVisible({ timeout: 10000 });
-  const value = label.locator('xpath=following-sibling::span[1]');
+  await expect(title).toBeVisible({ timeout: 10000 });
+  const card = title.locator('xpath=ancestor::div[2]');
+  const value = card.locator('div.text-2xl.font-bold').first();
   await expect(value).toBeVisible();
   return (await value.innerText()).trim();
 }

--- a/e2e/kitchen/daily-report-regression.spec.ts
+++ b/e2e/kitchen/daily-report-regression.spec.ts
@@ -40,21 +40,25 @@ async function gotoDailyReport(page: Page): Promise<void> {
 }
 
 async function readTotalRevenueText(page: Page): Promise<string> {
-  const card = page.locator(
-    'div:has(> :is(div, h3):text-matches("^\\s*Total Revenue\\s*$", "i"))'
-  );
-  // Fallback to a less-strict locator if the project's Card markup changes.
-  const fallback = page.locator(
-    'div', // Card root
-    { has: page.getByText(/^\s*Total Revenue\s*$/i) }
-  );
-  const target = (await card.count()) > 0 ? card : fallback;
-  await expect(target.first()).toBeVisible({ timeout: 10000 });
-  // Total Revenue value is the only `text-2xl font-bold` child of the card.
-  const value = target
-    .first()
-    .locator('div.text-2xl.font-bold, div.font-bold')
+  // The Total Revenue row in components/features/reports/profit-section.tsx
+  // renders as a flex row of two spans:
+  //
+  //   <div class="flex justify-between items-center py-2">
+  //     <span class="font-semibold">Total Revenue</span>
+  //     <span class="text-lg font-bold text-primary">{formatCurrency(...)}</span>
+  //   </div>
+  //
+  // The previous helper looked for the label as a `div`/`h3` and the value as
+  // a `div.text-2xl.font-bold` — neither matches the actual markup, so the
+  // helper returned ₦0.00 / failed visibility every time. Find the label by
+  // exact text (excluding the colon-suffixed 'Total Revenue:' label in
+  // revenue-section.tsx) and read its sibling span.
+  const label = page
+    .getByText(/^\s*Total Revenue\s*$/)
+    .filter({ hasNotText: ':' })
     .first();
+  await expect(label).toBeVisible({ timeout: 10000 });
+  const value = label.locator('xpath=following-sibling::span[1]');
   await expect(value).toBeVisible();
   return (await value.innerText()).trim();
 }


### PR DESCRIPTION
## Why

[#200](https://github.com/metasession-dev/wawagardenbar-app/issues/200) — two tests in `kitchen/daily-report-regression.spec.ts` (`DFR renders with a Total Revenue card and a currency-formatted value` + `AC14 — production batch invariant`) share the `readTotalRevenueText` helper. The helper's two CSS:has selectors didn't match the rendered DOM.

## Diagnosis

`components/features/reports/profit-section.tsx:30-34` renders:

```jsx
<div className="flex justify-between items-center py-2">
  <span className="font-semibold">Total Revenue</span>
  <span className="text-lg font-bold text-primary">{formatCurrency(...)}</span>
</div>
```

The old helper looked for:
- Label as direct child `div` or `h3` — actual markup is `<span>`.
- Value as `div.text-2xl.font-bold` or `div.font-bold` — actual value class is `text-lg font-bold text-primary` inside a `<span>`.

Result: deterministic *element not found* with 5s timeout.

## Fix

Anchor on the label span by exact text (excluding the colon-suffixed *Total Revenue:* label in `revenue-section.tsx:139`), then read the **following-sibling `<span>`** for the value. Robust to class-name churn since it follows the flex-row sibling relationship rather than specific Tailwind classes.

```diff
- const card = page.locator('div:has(> :is(div, h3):text-matches("^\\s*Total Revenue\\s*$", "i"))');
- const fallback = page.locator('div', { has: page.getByText(/^\s*Total Revenue\s*$/i) });
- const target = (await card.count()) > 0 ? card : fallback;
- await expect(target.first()).toBeVisible({ timeout: 10000 });
- const value = target.first().locator('div.text-2xl.font-bold, div.font-bold').first();
+ const label = page.getByText(/^\s*Total Revenue\s*$/).filter({ hasNotText: ':' }).first();
+ await expect(label).toBeVisible({ timeout: 10000 });
+ const value = label.locator('xpath=following-sibling::span[1]');
```

## Verification

Will dispatch focused regression on `kitchen/daily-report-regression.spec.ts` after this PR opens. Expected: AC14 + DFR Total Revenue card both pass.

Refs: #160, #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)