### PR TITLE
test(e2e): fix express-tip method override locator + remove silent skip (#201)

### DIFF
--- a/e2e/orders/express-tip-capture.spec.ts
+++ b/e2e/orders/express-tip-capture.spec.ts
@@ -129,16 +129,24 @@ test.describe.serial('REQ-035: express order tip capture', () => {
     await tipInput.fill(String(TIP));
     // Tip method dropdown defaults to the bill method (POS / 'card');
     // override to 'cash' to exercise AC4.
+    //
+    // The previous locator was `[id="tip-amount"] ~ * button` (CSS general-
+    // sibling), but `#tip-amount` is the <Input> itself, and the Select
+    // trigger button is a sibling of the input's *parent* div in the
+    // TipInputRow grid (components/features/orders/tip-input-row.tsx). The
+    // locator matched 0 elements, `isVisible()` returned false, the
+    // `if`-fallback silently skipped the override, the tip recorded under
+    // the bill's method (card), and AC7 read 0 cash tips. Use a
+    // document-order XPath to find the first combobox after the input, and
+    // fail loudly if the override path is missing.
     const tipMethodTrigger = page
-      .locator('[id="tip-amount"] ~ * button')
-      .first();
-    if (await tipMethodTrigger.isVisible().catch(() => false)) {
-      await tipMethodTrigger.click();
-      const cashOption = page.getByRole('option', { name: /^Cash$/ });
-      if (await cashOption.isVisible().catch(() => false)) {
-        await cashOption.click();
-      }
-    }
+      .locator('#tip-amount')
+      .locator('xpath=following::button[@role="combobox"][1]');
+    await expect(tipMethodTrigger).toBeVisible({ timeout: 5000 });
+    await tipMethodTrigger.click();
+    const cashOption = page.getByRole('option', { name: /^Cash$/ });
+    await expect(cashOption).toBeVisible({ timeout: 5000 });
+    await cashOption.click();
 
     // Submit.
     const payBtn = page.getByRole('button', { name: /Pay ₦/i });


### PR DESCRIPTION
## Why

[#201](https://github.com/metasession-dev/wawagardenbar-app/issues/201) — `orders/express-tip-capture.spec.ts:AC7 — Daily Report Tips Received cash card increased by ₦500` failed deterministically because the AC1+AC4 prerequisite test's tip-method override never actually fired.

## Trace evidence

Fresh focused run [`26713876740`](https://github.com/metasession-dev/wawagardenbar-app/actions/runs/26713876740) snapshot for AC7 shows:

```
Tips Received ₦1,000.00 total
  POS / Card tips — 100.0% of total tips
```

All tips landed in the **CARD** bucket; 0 in cash. AC7 expects cash to grow by ₦500. Cash card not rendered → reads 0 → assertion fails.

## Root cause

The AC1+AC4 test's override step:

```ts
const tipMethodTrigger = page.locator('[id="tip-amount"] ~ * button').first();
if (await tipMethodTrigger.isVisible().catch(() => false)) {
  await tipMethodTrigger.click();
  const cashOption = page.getByRole('option', { name: /^Cash$/ });
  if (await cashOption.isVisible().catch(() => false)) {
    await cashOption.click();
  }
}
```

The CSS general-sibling `#tip-amount ~ * button` doesn't match because:

- `#tip-amount` is the `<Input>` itself.
- The Select trigger `<button role="combobox">` is a sibling of the input's **parent** `<div class="relative">` in the TipInputRow grid layout (`components/features/orders/tip-input-row.tsx`).

So the locator returns 0 matches → `isVisible()` is false → silent skip → the tip records under the bill's payment method (POS/card). The `effectiveTipMethod = paymentMethod` because `tipMethodOverridden` stays `false`.

## Fix

Use a document-order XPath to find the first combobox after the tip-amount input, and drop the silent `if`-fallback so a missing UI element fails loudly with a clear assertion message rather than producing wrong test outcomes:

```diff
- const tipMethodTrigger = page.locator('[id="tip-amount"] ~ * button').first();
- if (await tipMethodTrigger.isVisible().catch(() => false)) { ... }
+ const tipMethodTrigger = page
+   .locator('#tip-amount')
+   .locator('xpath=following::button[@role="combobox"][1]');
+ await expect(tipMethodTrigger).toBeVisible({ timeout: 5000 });
+ await tipMethodTrigger.click();
+ const cashOption = page.getByRole('option', { name: /^Cash$/ });
+ await expect(cashOption).toBeVisible({ timeout: 5000 });
+ await cashOption.click();
```

## Verification

Will dispatch focused regression on the spec after this PR opens. Expected: AC1+AC4 actually exercises the override → order persists with `tipPaymentMethod = 'cash'` → AC7's cash card moves by ₦500 → passes.

Refs: #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)