### PR TITLE
chore: devaudit update to 0.1.26 (precise evidence_type for SAST + dep-audit)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,17 +391,22 @@ jobs:
             npm audit --json > ci-evidence/dependency-audit.json 2>/dev/null || echo '{"vulnerabilities":{}}' > ci-evidence/dependency-audit.json
           fi
 
-          # Upload SAST results (security_scan category)
+          # Upload SAST results — precise evidence_type=sast_report (Phase 3a /
+          # devaudit#370). Pre-3a uploads used `audit_log` + category alone,
+          # which made the portal's SAST and Dependency Audit gates show
+          # identical content (devaudit#387). Tagging the precise type keeps
+          # the two panels distinct + matches the ISO 27001 A.8.28 clause.
           if [ -f ci-evidence/sast-results.json ]; then
             upload sast-results.json \
-              wgb _compliance-docs audit_log ci-evidence/sast-results.json \
+              wgb _compliance-docs sast_report ci-evidence/sast-results.json \
               --category security_scan ${FLAGS}
           fi
 
-          # Upload dependency audit (security_scan category)
+          # Upload dependency audit — precise evidence_type=dependency_audit
+          # (same rationale as SAST above).
           if [ -f ci-evidence/dependency-audit.json ]; then
             upload dependency-audit.json \
-              wgb _compliance-docs audit_log ci-evidence/dependency-audit.json \
+              wgb _compliance-docs dependency_audit ci-evidence/dependency-audit.json \
               --category security_scan ${FLAGS}
           fi
 

--- a/.github/workflows/compliance-evidence.yml
+++ b/.github/workflows/compliance-evidence.yml
@@ -137,6 +137,36 @@ jobs:
             fi
           done
 
+          # Project-level governance docs (devaudit#370 Phase 3a). When the
+          # operator commits any of these markdown files, upload with the
+          # precise evidence_type so the portal's framework-coverage matrix
+          # auto-closes the matching clauses (GDPR.Art-30 for ropa, GDPR.Art-35
+          # for dpia, EUAIA.Art-13 for ai_disclosure, SOC2.CC4.1 + ISO27001.A.12.1
+          # for periodic_review, etc.). Each path is optional — skipped silently
+          # when the file is absent.
+          upload_governance() {
+            local FILE="$1" TYPE="$2"
+            if [ ! -f "$FILE" ]; then return 0; fi
+            echo "Uploading governance: $(basename "$FILE") (type=${TYPE})"
+            bash scripts/upload-evidence.sh \
+              wgb _compliance-docs "$TYPE" "$FILE" \
+              --category planning ${FLAGS} --release "${DERIVED_RELEASE}" \
+              "${DERIVED_META[@]}" \
+              || echo "Warning: Failed to upload $(basename "$FILE")"
+          }
+          # Recognise governance docs at top-level OR under compliance/governance/
+          # (operator's choice — both layouts are common).
+          upload_governance compliance/ropa.md             ropa
+          upload_governance compliance/governance/ropa.md  ropa
+          upload_governance compliance/dpia.md             dpia
+          upload_governance compliance/governance/dpia.md  dpia
+          upload_governance compliance/ai-disclosure.md             ai_disclosure
+          upload_governance compliance/governance/ai-disclosure.md  ai_disclosure
+          upload_governance compliance/periodic-review.md             periodic_review
+          upload_governance compliance/governance/periodic-review.md  periodic_review
+          upload_governance compliance/incident-report.md             incident_report
+          upload_governance compliance/governance/incident-report.md  incident_report
+
           # Helper: emit a `--release-title …` `--change-type …` pair for a given
           # REQ, derived from its pending release-ticket H1 and the most recent
           # commit attributed to that REQ. Empty pair when neither is available.


### PR DESCRIPTION
Sync from `@metasession.co/devaudit-cli@0.1.26`. After merge, the next CI run uploads SAST + dep-audit with precise evidence types — REQ-051's gate panels finally populate from real types. Refs DevAudit-Installer#90 + devaudit#370. 🤖 Generated with [Claude Code](https://claude.com/claude-code)