### PR TITLE
test(e2e): unblock #159 unit-conversion suite — 3 test-side fixes

### DIFF
--- a/e2e/kitchen/expense-link.spec.ts
+++ b/e2e/kitchen/expense-link.spec.ts
@@ -103,7 +103,11 @@ superAdminTest.describe(
           .click();
         await expect(dialog).toBeHidden({ timeout: 10000 });
 
-        // ── 3. Transfer pending group to confirmed expenses.
+        // ── 3. Approve, then Transfer pending group to confirmed expenses.
+        // `pending-expense-group-list.tsx` gates the Transfer button on
+        // `group.status === 'approved'` — submission lands the group in
+        // 'pending', so we have to Approve it first before Transfer
+        // renders. (Earlier #159 failure traced to this missing step.)
         await page.goto('/dashboard/finance/expenses/pending');
         await page.waitForLoadState('networkidle');
         // Find the row that contains our unique ingredient/description text.
@@ -111,11 +115,21 @@ superAdminTest.describe(
           .locator('tr,div', { hasText: ingredientName })
           .first();
         await expect(pendingRow).toBeVisible({ timeout: 5000 });
-        // Trigger the transfer for this group. UI exposes a "Transfer" action
-        // on the group; the bulk-select / single-action paths both work.
+        // Approve the group — the Approve button is in the group's action
+        // strip while status is 'pending'.
+        const approveButton = pendingRow
+          .getByRole('button', { name: /^Approve$/i })
+          .first();
+        await expect(approveButton).toBeVisible({ timeout: 5000 });
+        await approveButton.click();
+        await page.waitForLoadState('networkidle');
+        // Trigger the transfer for the now-approved group. UI exposes a
+        // "Transfer" action on the group; the bulk-select / single-action
+        // paths both work.
         const transferButton = page
           .getByRole('button', { name: /^Transfer/i })
           .first();
+        await expect(transferButton).toBeVisible({ timeout: 5000 });
         await transferButton.click();
         // Confirmation dialog.
         const confirmDialog = page.locator('[role="dialog"]');
@@ -182,13 +196,26 @@ superAdminTest.describe(
           .click();
         await expect(dialog).toBeHidden({ timeout: 10000 });
 
-        // Transfer.
+        // Approve, then Transfer. See the 5kg test above for the
+        // Approve-before-Transfer rationale (`pending-expense-group-list.tsx`
+        // gates Transfer on `group.status === 'approved'`).
         await page.goto('/dashboard/finance/expenses/pending');
         await page.waitForLoadState('networkidle');
-        await page
+        const pendingRow = page
+          .locator('tr,div', { hasText: ingredientName })
+          .first();
+        await expect(pendingRow).toBeVisible({ timeout: 5000 });
+        const approveButton = pendingRow
+          .getByRole('button', { name: /^Approve$/i })
+          .first();
+        await expect(approveButton).toBeVisible({ timeout: 5000 });
+        await approveButton.click();
+        await page.waitForLoadState('networkidle');
+        const transferButton = page
           .getByRole('button', { name: /^Transfer/i })
-          .first()
-          .click();
+          .first();
+        await expect(transferButton).toBeVisible({ timeout: 5000 });
+        await transferButton.click();
         const confirmDialog = page.locator('[role="dialog"]');
         await expect(confirmDialog).toBeVisible({ timeout: 5000 });
         await confirmDialog

--- a/e2e/kitchen/expense-link.spec.ts
+++ b/e2e/kitchen/expense-link.spec.ts
@@ -104,20 +104,24 @@ superAdminTest.describe(
         await expect(dialog).toBeHidden({ timeout: 10000 });
 
         // ── 3. Approve, then Transfer pending group to confirmed expenses.
-        // `pending-expense-group-list.tsx` gates the Transfer button on
+        // `pending-expense-group-list.tsx` (GroupRow) gates Approve on
+        // `group.status === 'pending'` and Transfer on
         // `group.status === 'approved'` — submission lands the group in
         // 'pending', so we have to Approve it first before Transfer
         // renders. (Earlier #159 failure traced to this missing step.)
+        //
+        // Note: we can't filter by ingredientName here — GroupRow's
+        // collapsed header shows only date / type / item-count; the item
+        // description (which carries the ingredient name) is hidden until
+        // the row is expanded. Each test creates one fresh pending group
+        // and the list is time-sorted newest-first, so `.first()` picks
+        // our group.
         await page.goto('/dashboard/finance/expenses/pending');
         await page.waitForLoadState('networkidle');
-        // Find the row that contains our unique ingredient/description text.
-        const pendingRow = page
-          .locator('tr,div', { hasText: ingredientName })
-          .first();
-        await expect(pendingRow).toBeVisible({ timeout: 5000 });
-        // Approve the group — the Approve button is in the group's action
-        // strip while status is 'pending'.
-        const approveButton = pendingRow
+        // Approve the (most recent) group — Approve button is only shown
+        // while status === 'pending' (and to super-admins; test runs
+        // as super-admin).
+        const approveButton = page
           .getByRole('button', { name: /^Approve$/i })
           .first();
         await expect(approveButton).toBeVisible({ timeout: 5000 });
@@ -196,16 +200,13 @@ superAdminTest.describe(
           .click();
         await expect(dialog).toBeHidden({ timeout: 10000 });
 
-        // Approve, then Transfer. See the 5kg test above for the
-        // Approve-before-Transfer rationale (`pending-expense-group-list.tsx`
-        // gates Transfer on `group.status === 'approved'`).
+        // Approve, then Transfer. Same locator strategy as the 5kg test
+        // above — pick the most recent (top-most) pending group by
+        // `.first()` rather than filtering on ingredientName (the
+        // GroupRow's collapsed header doesn't render item descriptions).
         await page.goto('/dashboard/finance/expenses/pending');
         await page.waitForLoadState('networkidle');
-        const pendingRow = page
-          .locator('tr,div', { hasText: ingredientName })
-          .first();
-        await expect(pendingRow).toBeVisible({ timeout: 5000 });
-        const approveButton = pendingRow
+        const approveButton = page
           .getByRole('button', { name: /^Approve$/i })
           .first();
         await expect(approveButton).toBeVisible({ timeout: 5000 });

--- a/e2e/kitchen/expense-link.spec.ts
+++ b/e2e/kitchen/expense-link.spec.ts
@@ -135,12 +135,18 @@ superAdminTest.describe(
           .first();
         await expect(transferButton).toBeVisible({ timeout: 5000 });
         await transferButton.click();
-        // Confirmation dialog.
+        // Confirmation dialog. The Confirm Transfer button is
+        // `disabled={!transferReference.trim()}` per
+        // `components/features/finance/transfer-confirmation-dialog.tsx`,
+        // so fill the required Transfer Reference (#transferRef) before
+        // clicking.
         const confirmDialog = page.locator('[role="dialog"]');
         await expect(confirmDialog).toBeVisible({ timeout: 5000 });
         await confirmDialog
-          .getByRole('button', { name: /confirm|transfer|continue/i })
-          .first()
+          .locator('#transferRef')
+          .fill(`E2E-TRF-${Date.now()}`);
+        await confirmDialog
+          .getByRole('button', { name: /^Confirm Transfer$/i })
           .click();
         await expect(confirmDialog).toBeHidden({ timeout: 10000 });
         await page.waitForLoadState('networkidle');
@@ -217,11 +223,15 @@ superAdminTest.describe(
           .first();
         await expect(transferButton).toBeVisible({ timeout: 5000 });
         await transferButton.click();
+        // Confirmation dialog — same Transfer Reference gate as the 5kg test
+        // above.
         const confirmDialog = page.locator('[role="dialog"]');
         await expect(confirmDialog).toBeVisible({ timeout: 5000 });
         await confirmDialog
-          .getByRole('button', { name: /confirm|transfer|continue/i })
-          .first()
+          .locator('#transferRef')
+          .fill(`E2E-TRF-${Date.now()}`);
+        await confirmDialog
+          .getByRole('button', { name: /^Confirm Transfer$/i })
           .click();
         await expect(confirmDialog).toBeHidden({ timeout: 10000 });
         await page.waitForLoadState('networkidle');

--- a/e2e/kitchen/helpers.ts
+++ b/e2e/kitchen/helpers.ts
@@ -75,8 +75,16 @@ export async function createKitchenIngredient(
 
   await selects.nth(1).click();
   const unitToPick = opts.unitLabel ?? 'Grams';
+  // ANCHOR the regex — default UoM registry orders `Kilograms (kg)`
+  // BEFORE `Grams (g)`, and an unanchored /Grams/i pattern matches
+  // "Kilograms" case-insensitively (since "kilograms" contains "grams").
+  // `.first()` then picked Kilograms, so every test calling this with
+  // `unitLabel: 'Grams'` silently created a **kg-unit** ingredient.
+  // That's the actual root cause of all 4 #159 failures — what looked
+  // like a kg→g conversion bug was test data being kg→kg (or g→kg).
+  // Anchor with `^` so `^Grams` doesn't match `Kilograms`.
   await page
-    .getByRole('option', { name: new RegExp(unitToPick, 'i') })
+    .getByRole('option', { name: new RegExp(`^${unitToPick}\\b`, 'i') })
     .first()
     .click();
 

--- a/e2e/kitchen/helpers.ts
+++ b/e2e/kitchen/helpers.ts
@@ -108,11 +108,25 @@ export async function readKitchenStock(
   await page.getByRole('tab', { name: /^Kitchen/ }).click();
   const row = page.locator('tr', { hasText: ingredientName }).first();
   if ((await row.count()) === 0) return null;
-  // The inventory table renders currentStock in a column; pick the first
-  // numeric-looking cell that follows the name cell. Robust enough for the
-  // current table shape; refine if the markup changes.
-  const text = await row.innerText();
-  const match = text.match(/\b(\d+(?:\.\d+)?)\b/);
+  // `InventoryTable` (components/features/admin/inventory-table.tsx) renders
+  // 8 columns: Name, Category, Current Stock, Locations, Min/Max, Stock
+  // Level, Status, Actions. Current Stock is the 3rd TD (0-indexed: 2),
+  // formatted as `{currentStock} {unit}` (e.g. `0 g`, `5000 g`).
+  //
+  // Earlier this helper read row.innerText() and ran
+  // /\b(\d+(?:\.\d+)?)\b/ over the whole row — but `uniqueLabel(prefix)`
+  // appends Date.now() to ingredient names (e.g.
+  // `E2E-D10-Goat-1780242429276`), and that timestamp is the FIRST
+  // numeric token in the row's text. The regex grabbed the timestamp
+  // instead of the stock cell, making every `expect(stock).toBe(0)`
+  // assertion fail with `Received: 1780242429276` (#159).
+  //
+  // Scope to the Current Stock cell directly, then parse the leading
+  // number. Min/Max styling (`0/0`) and the trailing unit code are
+  // handled by anchoring the regex to the start of the cell text.
+  const stockCell = row.locator('td').nth(2);
+  const text = (await stockCell.innerText()).trim();
+  const match = text.match(/^\s*(\d+(?:\.\d+)?)/);
   if (!match) return null;
   return Number(match[1]);
 }

--- a/e2e/kitchen/production-flow.spec.ts
+++ b/e2e/kitchen/production-flow.spec.ts
@@ -26,13 +26,39 @@ import {
   readKitchenStock,
 } from './helpers';
 
+/**
+ * Map a long unit label (the shape the kitchen-ingredient form uses,
+ * coming from `getUnitsOfMeasurement()` → `'Kilograms (kg)'`, `'Grams (g)'`)
+ * to the short code the recipe-builder Select renders.
+ *
+ * `recipe-builder.tsx:59` hardcodes `DEFAULT_UNIT_CHOICES = ['g', 'kg',
+ * 'ml', 'litres', 'eggs', 'pieces']`. The earlier helper passed the long
+ * label straight into a `getByRole('option', { name: /Kilograms/i })`
+ * lookup — no such option exists in the recipe-builder dropdown, so the
+ * click timed out and #159 failures #4/#5 surfaced.
+ *
+ * Accept either form at call sites (the long label keeps the call sites
+ * self-documenting); convert here.
+ */
+function toRecipeBuilderUnitCode(unitLabel: string): string {
+  const lower = unitLabel.trim().toLowerCase();
+  // Long → short.
+  if (/^kilograms?\b/.test(lower)) return 'kg';
+  if (/^grams?\b/.test(lower)) return 'g';
+  if (/^litres?\b/.test(lower)) return 'litres';
+  if (/^millilitres?\b/.test(lower)) return 'ml';
+  // Already a short code or one of the count-style codes the dropdown
+  // also renders verbatim (eggs, pieces).
+  return unitLabel;
+}
+
 async function authorRecipe(
   page: import('@playwright/test').Page,
   opts: {
     recipeName: string;
     ingredientName: string;
     quantity: number;
-    unitLabel: string; // e.g. 'Kilograms' to test cross-unit conversion
+    unitLabel: string; // 'Kilograms' / 'Grams' / 'kg' / 'g' / etc.
   }
 ) {
   await page.goto('/dashboard/kitchen/recipes/new');
@@ -51,8 +77,11 @@ async function authorRecipe(
     .click();
   await page.locator('input[type="number"]').nth(1).fill(String(opts.quantity));
   await combos.nth(2).click();
+  // Recipe-builder Select renders short codes — match exactly so `g`
+  // doesn't accidentally grab `Grams (g)` or `gel` first.
+  const unitCode = toRecipeBuilderUnitCode(opts.unitLabel);
   await page
-    .getByRole('option', { name: new RegExp(opts.unitLabel, 'i') })
+    .getByRole('option', { name: new RegExp(`^${unitCode}$`, 'i') })
     .first()
     .click();
   await page.getByRole('button', { name: /create recipe/i }).click();


### PR DESCRIPTION
Triage of #159 classified all 4 failures as **TEST-side bugs**. None of the 4 actually reaches the D10/D11 unit-conversion code — they all bail out earlier on test infrastructure issues.

## What the 4 failures actually were

| # | Test | Real cause | Product code affected? |
|---|---|---|---|
| 1 | `expense-link:40` 5kg → 5000g | `readKitchenStock` regex grabbed `Date.now()` from `uniqueLabel` suffix in name | No |
| 2 | `expense-link:139` identity 100g | `pending-expense-group-list.tsx:478` gates Transfer on `approved` — submission lands in 'pending' | No (intentional workflow gate) |
| 3 | `production-flow:71` 2kg → 2000g | `authorRecipe` looked for `/Kilograms/i` but `recipe-builder.tsx:59` renders short codes (`'g', 'kg'…`) | No |
| 4 | `production-flow:118` preflight | Same `/Kilograms/i` mismatch | No |

## Fixes (test-only — no app/lib/services touched)

1. **`helpers.ts:readKitchenStock`** — scope to `td:nth-child(3)` (the Current Stock column) instead of `row.innerText()`. Anchor regex to leading number.
2. **`production-flow.spec.ts:authorRecipe`** — add `toRecipeBuilderUnitCode` long→short mapper; anchor option lookup with `^code$` so `g` doesn't partial-match `Grams (g)`.
3. **`expense-link.spec.ts`** (both tests) — insert Approve step before Transfer.

## Verification

- `npx tsc --noEmit` → exit 0
- `npx eslint <changed>` → 0 errors
- Focused E2E on the 2 affected spec files dispatched: [run 26719376556](https://github.com/metasession-dev/wawagardenbar-app/actions/runs/26719376556) — link will update.

## Risk

LOW — Lightweight path (`test:` housekeeping per the change-workflows taxonomy). No REQ-XXX. If the unit-conversion code IS actually broken, the focused E2E will reveal it (the helpers now let the test reach the assertions); that would be a separate REQ-053 surface.

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)