### PR TITLE
chore: devaudit update to 0.1.27 (test-summary as test_report)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,10 +434,16 @@ jobs:
               --category test_report ${FLAGS}
           fi
 
-          # Upload test summary report (test_report category)
+          # Upload test summary report — precise evidence_type=test_report
+          # (was compliance_document). The portal's Compliance Gates panel
+          # filters by evidence_type, so the markdown summary belongs in the
+          # Test Reports gate alongside playwright-report.zip + coverage
+          # summary. Markdown renders inline (MarkdownRenderer); auditor
+          # reads pass/fail counts + narrative without downloading the zip.
+          # devaudit#370 follow-up.
           if [ -f "compliance/test-summary-report.md" ]; then
             upload test-summary-report.md \
-              wgb _compliance-docs compliance_document compliance/test-summary-report.md \
+              wgb _compliance-docs test_report compliance/test-summary-report.md \
               --category test_report ${FLAGS}
           fi
 

--- a/.github/workflows/compliance-evidence.yml
+++ b/.github/workflows/compliance-evidence.yml
@@ -125,8 +125,9 @@ jobs:
           DERIVED_META=()
           [ -n "$DERIVED_CT" ] && DERIVED_META+=(--change-type "$DERIVED_CT")
 
-          # Upload compliance docs (planning category)
-          for DOC in compliance/RTM.md compliance/test-plan.md compliance/test-cases.md compliance/test-summary-report.md; do
+          # Upload planning docs (RTM / Test Plan / Test Cases) as
+          # compliance_document — they surface under the Documents tab.
+          for DOC in compliance/RTM.md compliance/test-plan.md compliance/test-cases.md; do
             if [ -f "$DOC" ]; then
               echo "Uploading: $(basename "$DOC")"
               bash scripts/upload-evidence.sh \
@@ -136,6 +137,19 @@ jobs:
                 || echo "Warning: Failed to upload $(basename "$DOC")"
             fi
           done
+
+          # Test summary report — precise evidence_type=test_report so it
+          # lands in the portal's Test Reports gate (rendered inline by the
+          # MarkdownRenderer). devaudit#370 follow-up; same change applied
+          # in ci.yml's gate-evidence upload step.
+          if [ -f "compliance/test-summary-report.md" ]; then
+            echo "Uploading: test-summary-report.md (test_report type)"
+            bash scripts/upload-evidence.sh \
+              wgb _compliance-docs test_report compliance/test-summary-report.md \
+              --category test_report ${FLAGS} --release "${DERIVED_RELEASE}" \
+              "${DERIVED_META[@]}" \
+              || echo "Warning: Failed to upload test-summary-report.md"
+          fi
 
           # Project-level governance docs (devaudit#370 Phase 3a). When the
           # operator commits any of these markdown files, upload with the


### PR DESCRIPTION
Sync from `@metasession.co/devaudit-cli@0.1.27`. Next CI run uploads `compliance/test-summary-report.md` as `evidence_type=test_report` so it surfaces inline in the portal's Test Reports gate. Refs DevAudit-Installer#91 + devaudit#370. 🤖 Generated with [Claude Code](https://claude.com/claude-code)