### PR TITLE
test(e2e): unblock REQ-051 tip-cash residuals + #160 family — 3 fixes

### DIFF
--- a/e2e/finance/create-pending-from-expenses.spec.ts
+++ b/e2e/finance/create-pending-from-expenses.spec.ts
@@ -103,11 +103,20 @@ superAdminTest.describe(
 
         // The date field shows today (format: 'PPP' = "April 30th, 2026" style;
         // assert by month-name match instead of full string).
+        //
+        // Scope to the dialog: a page-wide `getByText('May')` hits 3
+        // elements in May (current-month strict-mode violation — the page
+        // can show "May" in the expense rows + a date picker dropdown +
+        // the dialog's own date display). Strict mode fails before the
+        // dialog match wins. Anchor inside `[role="dialog"]` so the
+        // dialog's currently-rendered date string is the only match.
         const monthShort = new Date().toLocaleDateString('en-US', {
           month: 'short',
         });
+        const dialog = page.locator('[role="dialog"]');
+        await expect(dialog).toBeVisible({ timeout: 5000 });
         await expect(
-          page.getByText(monthShort, { exact: false })
+          dialog.getByText(monthShort, { exact: false }).first()
         ).toBeVisible();
       }
     );

--- a/e2e/orders/admin-pay-tab-tip-method.spec.ts
+++ b/e2e/orders/admin-pay-tab-tip-method.spec.ts
@@ -120,16 +120,25 @@ test.describe.serial('REQ-036: card bill + cash tip on tab close', () => {
 
     // Tip method dropdown defaults to the bill type ('card').
     // Override to 'cash' to exercise AC1's independence.
+    //
+    // The previous locator was `[id="tab-close-tip"] ~ * button` (CSS
+    // general-sibling), but `#tab-close-tip` is the <Input> itself, and
+    // the Select trigger button is a sibling of the input's *parent* div
+    // in the TipInputRow grid (components/features/orders/tip-input-row.tsx).
+    // The locator matched 0 elements, the silent `if (isVisible)` fallback
+    // skipped the override, the tip recorded under the bill's method
+    // (card), and AC8 read 0 cash tips. Same root cause and fix as
+    // PR #206 for express-tip-capture (#201) — use a document-order
+    // XPath to find the first combobox after the input, and fail
+    // loudly if the override path is missing.
     const tipMethodTrigger = page
-      .locator('[id="tab-close-tip"] ~ * button')
-      .first();
-    if (await tipMethodTrigger.isVisible().catch(() => false)) {
-      await tipMethodTrigger.click();
-      const cashOption = page.getByRole('option', { name: /^Cash$/ });
-      if (await cashOption.isVisible().catch(() => false)) {
-        await cashOption.click();
-      }
-    }
+      .locator('#tab-close-tip')
+      .locator('xpath=following::button[@role="combobox"][1]');
+    await expect(tipMethodTrigger).toBeVisible({ timeout: 5000 });
+    await tipMethodTrigger.click();
+    const cashOption = page.getByRole('option', { name: /^Cash$/ });
+    await expect(cashOption).toBeVisible({ timeout: 5000 });
+    await cashOption.click();
 
     // Submit close-tab.
     await page.getByRole('button', { name: /Pay ₦.*Close Tab/i }).click();

--- a/e2e/orders/close-tab-tip-capture.spec.ts
+++ b/e2e/orders/close-tab-tip-capture.spec.ts
@@ -81,6 +81,14 @@ async function openTodayReport(page: Page) {
 
 test.describe.serial('REQ-035: close-tab tip capture', () => {
   let baselineCashTips = 0;
+  // Shared flag — AC2 silently `test.skip`s when UAT has no open tab to
+  // close. The Daily Report still renders a "Tips Received" heading
+  // regardless, so AC7's existing heading-based skip fallback can't tell
+  // the difference between "AC2 was skipped" and "AC2 ran but the tip
+  // didn't land". AC7 then assertion-failed with `Received: 0` because
+  // baseline stayed at the AC2-init value. Use a positive flag so AC7
+  // only asserts when AC2 actually closed a tab.
+  let tabClosedInThisRun = false;
   const TIP = 250;
 
   test.beforeEach(async ({ page }, testInfo) => {
@@ -128,20 +136,24 @@ test.describe.serial('REQ-035: close-tab tip capture', () => {
 
     // Toast / refresh.
     await page.waitForLoadState('networkidle');
+    // Mark the tab as actually closed only after the submit completes;
+    // AC7 reads this to decide whether to assert or skip.
+    tabClosedInThisRun = true;
   });
 
   test('AC7 — Daily Report Tips Received cash card increased', async ({
     page,
   }) => {
+    // If AC2 silent-skipped (no open tab on UAT), there's no tip to
+    // verify — skip rather than fail with `Received: 0`.
+    test.skip(
+      !tabClosedInThisRun,
+      'AC2 was skipped (no open tab to close) — nothing to assert in AC7'
+    );
+
     await openTodayReport(page);
     const heading = page.locator('h3').filter({ hasText: /Tips Received/i });
-    if (!(await heading.isVisible().catch(() => false))) {
-      test.skip(
-        true,
-        'Tips section absent — likely the prior test was skipped or no tip recorded'
-      );
-      return;
-    }
+    await expect(heading).toBeVisible({ timeout: 15000 });
     const { cash } = await readTipsBreakdown(page);
     expect(cash - baselineCashTips).toBeGreaterThanOrEqual(TIP);
   });


### PR DESCRIPTION
Three independent test-side bugs in the E2E regression suite carried as follow-ups from REQ-052's release PR #208.

## Fixes

### 1. `admin-pay-tab-tip-method.spec.ts` (AC1 + AC8) — REQ-051 tip-cash residual

Same root cause + fix as [#201 / PR #206](https://github.com/metasession-dev/wawagardenbar-app/pull/206) but for the close-tab dialog. Locator `[id="tab-close-tip"] ~ * button` was CSS general-sibling, but `#tab-close-tip` is the `<Input>` itself; the Select trigger is a sibling of the input's *parent* div in the `TipInputRow` grid. Locator matched 0, silent `if (isVisible)` fallback skipped the override, tip recorded under bill's method (card), AC8 read 0 cash tips. Switch to document-order XPath + fail loudly.

### 2. `close-tab-tip-capture.spec.ts` AC7 — REQ-051 tip-cash residual

AC2 silently `test.skip`s when UAT has no open tab to seed from. AC7's heading-based skip fallback couldn't distinguish that from "tip didn't land" and asserted with baseline=0 → `Received: 0`. Added `tabClosedInThisRun` positive flag set at end of AC2; AC7 skips when false.

### 3. `create-pending-from-expenses.spec.ts` AC4 — #160 family

`getByText('May')` strict-mode violation in May runs — 3 page-wide elements match. Scope to `[role="dialog"]` so the dialog's currently-rendered date string is the only candidate.

### 4. `inventory-crud.spec.ts:550` AC7 — #160 family (carried, no test edit)

Likely already fixed by [PR #211](https://github.com/metasession-dev/wawagardenbar-app/pull/211)'s `createKitchenIngredient` regex anchor (was creating kg-unit ingredients that polluted the Archive → Restore flow). Included in the focused run to confirm; if it still fails after PR #211, that becomes a separate cycle.

## Verification

- `npx tsc --noEmit` exit 0
- `npx eslint <changed>` 0 errors
- Focused E2E: [run 26720523286](https://github.com/metasession-dev/wawagardenbar-app/actions/runs/26720523286) on the 4 spec files

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)