### PR TITLE
ci(e2e-regression): disable nightly cron during #117 work

### DIFF
--- a/.github/workflows/e2e-regression.yml
+++ b/.github/workflows/e2e-regression.yml
@@ -25,8 +25,13 @@ on:
         default: ''
   pull_request:
     branches: [main]
-  schedule:
-    - cron: '0 2 * * *' # nightly 02:00 UTC
+  # Nightly cron DISABLED until #117 (WhatsApp + customer-facing
+  # backlog) is delivered. Operator policy during #117 work: only
+  # targeted runs (workflow_dispatch with `specs`) plus the full
+  # regression on the release PR to main (which is "delivery").
+  # Re-enable by uncommenting the schedule block below once #117 closes.
+  # schedule:
+  #   - cron: '0 2 * * *' # nightly 02:00 UTC
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Operator policy: while #117 (WhatsApp + customer-facing backlog) is in flight, the full Playwright regression pack only runs:

1. On the **release PR to main** ("delivery") — `pull_request: branches: [main]` trigger stays.
2. On **targeted `workflow_dispatch`** with non-empty `specs` input (developer-driven during fix-and-verify) — stays.

Disable the nightly cron that was running the full pack unconditionally at 02:00 UTC. Re-enable by uncommenting the schedule block once #117 closes; the block has a multi-line comment above it explaining the policy.

## What this doesn't change

- `ci.yml` Gate 4 `--project=smoke` keeps running on every develop push + PR (fast smoke gate, not the full regression pack).
- Release PR to main still fires the full regression as the delivery gate.
- `workflow_dispatch` is still available for ad-hoc full runs if needed (just leave `specs` empty); the policy is operator discipline, not a workflow lock.

## Risk

LOW — disabling an auto-trigger; no test code changes. Reversible by uncommenting 2 lines.

Refs #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)