### PR TITLE
ci(e2e-regression): disable release-pr auto-trigger during #117 work

### DIFF
--- a/.github/workflows/e2e-regression.yml
+++ b/.github/workflows/e2e-regression.yml
@@ -23,13 +23,15 @@ on:
         required: false
         type: string
         default: ''
-  pull_request:
-    branches: [main]
-  # Nightly cron DISABLED until #117 (WhatsApp + customer-facing
-  # backlog) is delivered. Operator policy during #117 work: only
-  # targeted runs (workflow_dispatch with `specs`) plus the full
-  # regression on the release PR to main (which is "delivery").
-  # Re-enable by uncommenting the schedule block below once #117 closes.
+  # Auto-triggers DISABLED during #117 (WhatsApp + customer-facing
+  # backlog). Operator policy: "delivery" = when #117 as a whole closes,
+  # not when each intermediate REQ-XXX inside #117 ships. Until then:
+  #   - workflow_dispatch with `specs` for targeted iteration (above)
+  #   - workflow_dispatch with empty `specs` for the one-time full pack
+  #     at #117 close (manual op)
+  # Re-enable both blocks below by uncommenting once #117 closes.
+  # pull_request:
+  #   branches: [main]
   # schedule:
   #   - cron: '0 2 * * *' # nightly 02:00 UTC
 


### PR DESCRIPTION
Tightens the operator policy set in PR #221.

Earlier interpretation: 'full regression on release PR to main = delivery gate'.
Clarified: "delivery" = when #117 as a whole closes, NOT each intermediate REQ-XXX inside.

Disables the `pull_request: branches: [main]` trigger; only `workflow_dispatch` remains. Per-REQ release PRs use targeted runs + admin-merge. At #117 close, manually dispatch with empty `specs` for the one-time full pack.

In-flight E2E on REQ-054 PR #223 is allowed to complete (no cancellation). Subsequent REQ-XXX releases within #117 will skip the auto-trigger.

Risk: LOW. Reversible by uncommenting 2 lines.

Refs #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)