### PR TITLE
docs(compliance): [REQ-056] re-attribute gate evidence to REQ-056 release

### DIFF
--- a/lib/whatsapp.ts
+++ b/lib/whatsapp.ts
@@ -203,7 +203,7 @@ export class WhatsAppService {
   /**
    * Send a free-form text message via WhatsApp.
    *
-   * REQ-056 — Used by the inbound router for STOP opt-out
+   * @requirement REQ-056 — Used by the inbound router for STOP opt-out
    * confirmations. Meta allows free-form replies inside the 24-hour
    * customer-service window that opens when a customer messages us, so
    * a STOP confirmation does not need a template approval. Same error


### PR DESCRIPTION
**Fixes a release-attribution miss on REQ-056.**

When PR #229 merged to develop, CI Quality Gates failed at the Dependency Audit gate (vitest GHSA UI-server CVE — npm advisory published between REQ-055's CI and REQ-056's, unrelated to REQ-056). Upload Evidence was skipped, so REQ-056's TS / SAST / dep-audit / test / build artefacts never reached the portal. PR #230 fixed the CVE but its merge commit had no `[REQ-056]` tag, so the subsequent CI run attributed to `v2026.06.01` (bare-date).

This PR's commit subject carries `[REQ-056]`, so:
- The develop-push merge commit's body will carry that bracket → `derive-release-version.sh` returns `REQ-056` (script step 3).
- `ci.yml` re-runs the gates under `--release REQ-056` and uploads them under that release.
- Portal's REQ-056 missing-gates panel fills in.

The actual file change is small — a JSDoc-convention nudge on `WhatsAppService.sendTextMessage`: `REQ-056 —` → `@requirement REQ-056 —`, matching the convention on the inbound service / model / templates module.

Same pattern as PR #163 (REQ-048 re-attribution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)