### PR TITLE
compliance: [REQ-056] evidence compiled - awaiting review

### DIFF
--- a/compliance/evidence/REQ-056/ai-prompts.md
+++ b/compliance/evidence/REQ-056/ai-prompts.md
@@ -1,0 +1,56 @@
+# REQ-056 — AI prompts log
+
+**Date:** 2026-06-01
+
+## Session prompts (user → AI)
+
+1. `plan WA-3 as REQ-056`
+   - AI surfaced the implementation plan with 8 ACs (model, state classifier, intent classifier, routing matrix, STOP compliance, auto-create User, safety try/catch, handleWebhook wire-up), STRIDE table, threat model, rollback. Risk: MEDIUM-HIGH. Plan approval requested per `feedback_sdlc_impl_plan_review`.
+
+2. `Approve as scoped`
+   - Plan approval at the MEDIUM-HIGH-risk gate. AI proceeded with TDD-first implementation.
+
+3. _(operator merged PR #229 → develop; AI observed CI failure on Dependency Audit gate from a vitest GHSA CVE published in npm advisory DB between REQ-055's CI and REQ-056's.)_
+
+4. _(operator merged PR #230 vitest 4.1 bump; CI passed but attributed to v2026.06.01 because chore commit had no `[REQ-056]` tag.)_
+
+5. `#231 merged`
+   - Confirmation that the attribution PR landed; CI ran with `--release REQ-056`, evidence uploaded to portal under REQ-056.
+
+6. `file a follow-up DevAudit-Installer issue`
+   - AI filed DevAudit-Installer #95 (resolver step-4-bis — scan RTM.md for IN PROGRESS rows as zero-ceremony attribution fallback).
+
+7. `file the second issue too` (Upload Evidence on Quality Gates failure)
+   - AI filed DevAudit-Installer #96 (ci.yml: upload-evidence on failure with status=failed).
+
+8. `yes` (open the release PR)
+   - AI opened release PR #232 develop → main with `[REQ-056]` title.
+
+9. `Release ticket not yet uploaded. Wait for the developer to complete SDLC step 3 (compile-evidence) — the next CI run after compliance/pending-releases/RELEASE-TICKET-REQ-XXX.md is pushed to develop will produce a reviewable release.`
+   - Operator caught the missing Phase 3 release ticket. AI re-read `SDLC/3-compile-evidence.md` step 8/9, surveyed REQ-055's evidence pack as the template, and assembled the full Phase 3 bundle (release ticket + 7 evidence markdowns).
+
+## Internal AI prompts (orchestrator → sub-skills)
+
+No sub-skills were invoked for REQ-056. The work is server-side webhook routing + a new audit-log model + thin wire-ups; no e2e author work needed (per the `project_e2e_targeted_until_117` policy AND per the scope justification — orchestrator unit boundary covers the surface). `sdlc-implementer` ran end-to-end; `e2e-test-engineer` was not invoked.
+
+## Decision points
+
+- **Auto-create User on `new` state** — mirrors `app/actions/auth/send-pin.ts` pattern. Alternative: log the inbound but DON'T create a User row until the customer explicitly signs up. Chosen because the consent-gate downstream (REQ-054's `NotificationService.send`) needs a User to read `whatsappTransactional` from; without auto-create, the welcome template send would fail with no user. Auto-create + `phoneVerified: false` keeps the door open for the customer to later complete signup via PIN flow.
+- **STOP regex strictness** — `^\s*(stop|unsubscribe|opt[-\s]?out)\s*$` is whole-message match, no partial matches. Trade-off: false negatives on "please stop the messages" — those route to `support_text` (staff queue) where a human can apply the opt-out. False positives are zero. Conservative is correct here: accidentally opting people out is worse than missing chatty STOPs.
+- **Free-form text-send method on WhatsAppService** — Meta's 24h customer-service window allows free-form replies (no template approval needed) inside the window opened by an inbound. Adding `sendTextMessage` to `WhatsAppService` keeps the channel boundary unified. Alternative was a separate `WhatsAppFreeFormService` class — rejected as needless abstraction.
+- **Lazy import in `handleWebhook` inbound branch** — same pattern REQ-055 used for the status branch. Avoids the lib→services→lib circular that a top-of-file import would create (`lib/whatsapp` imports `services/whatsapp-inbound-service` which imports `services/notification-service` which imports `lib/whatsapp` via `WhatsAppService.sendMessage`).
+- **IncomingMessage persists body content** — different posture from REQ-055's NotificationLog which is metadata-only. Justified because the router needs to log what was said for STOP audit + support-queue items. Flagged in `security-summary.md` as the TTL/redaction concern for a future REQ.
+- **Routing matrix `active + chat_with_staff → queued_for_staff`** — doesn't send a template. Active customers expect a human response, not an auto-reply. The `actionTaken: 'queued_for_staff'` row is the placeholder until a real SupportTicket model (P3 #17) lands.
+- **Welcome templates fire through `NotificationService.send`** — gated by REQ-053's `whatsappTransactional` consent (default true) and falls through to email when Meta restriction blocks template sends. The IncomingMessage row records `actionTaken: 'sent_welcome_new_user'` based on intent, not delivery — accepted for v1 because tracking actual delivery requires Meta's status-event webhook flow (REQ-055) reconciling against this row, which is a future REQ.
+- **`MetaInboundMessage` exported as a public interface** — required for test helpers to type-check. Internal interfaces remain internal (e.g. `ClassifyResult`).
+- **Audit-trail Phase 3 catch** — Phase 3 step 8/9 (release ticket in `compliance/pending-releases/` + 7 evidence markdowns) was originally skipped; AI jumped from Phase 2 (implement+test) directly to Phase 4 (open release PR). Operator caught the gap on the portal — the release ticket was missing, so the release wasn't reviewable. Corrected by this evidence-pack PR.
+
+## Audit cross-refs
+
+- Parent backlog: #117 (`WA-3`).
+- Direct dependencies: REQ-053 (consent fields on User), REQ-054 (`NotificationService.send` for welcome templates), REQ-055 (lazy-import pattern + `handleWebhook` status-branch precedent).
+- Cross-reference: existing `app/api/webhooks/whatsapp/route.ts` (untouched by REQ-056; verified by reading) provides the signature-verification surface.
+- Cycle artefacts: PR #229 (integration), PR #230 (unrelated vitest CVE bump), PR #231 (re-attribution), PR #232 (release develop → main).
+- Upstream follow-ups filed this cycle: DevAudit-Installer #95 (resolver step-4-bis), DevAudit-Installer #96 (ci.yml upload-on-failure).
+- Project memory honoured: `feedback_sdlc_impl_plan_review`, `feedback_tests_before_push`, `feedback_wait_for_ci`, `feedback_single_pr_default`, `project_e2e_targeted_until_117`, `feedback_no_delete_develop_on_release_merge`, `feedback_pr_title_req_brackets`.
+- Unblocks future work: full SupportTicket model + admin queue UI (P3 #17), order-cancellation intent, balance-inquiry intent, TTL/retention policy for IncomingMessage.

--- a/compliance/evidence/REQ-056/ai-use-note.md
+++ b/compliance/evidence/REQ-056/ai-use-note.md
@@ -1,0 +1,41 @@
+# REQ-056 — AI use note
+
+**Date:** 2026-06-01
+**Tool:** Claude Code (Opus 4.7) via project orchestrator.
+
+## What the AI did
+
+- Surveyed REQ-055's status-branch wire-up in `lib/whatsapp.ts:handleWebhook` and the inbound-branch TODO that REQ-055 deliberately left for REQ-056. Confirmed the webhook route at `app/api/webhooks/whatsapp/route.ts` + signature verification + GET-handshake are pre-existing — REQ-056's scope is the inbound-branch payload routing, not the webhook surface itself.
+- Authored `compliance/plans/REQ-056/implementation-plan.md` with 8 ACs, technical approach (state classifier, intent classifier, router matrix, IncomingMessage audit model, free-form text-send method on WhatsAppService, lazy-import wiring), STRIDE table, threat model (STOP regex strictness, NoSQL injection, auto-create-then-opt-out race, persistence-down posture), rollback. Risk classification: MEDIUM-HIGH (customer-facing surface, compliance-sensitive STOP, auto-modifies + auto-creates User records). Presented for plan review per `feedback_sdlc_impl_plan_review` MEDIUM/HIGH-risk gate; operator approved as scoped.
+- After plan approval: wrote four TDD red baselines —
+  - `__tests__/models/incoming-message-model.test.ts` (5 cases) — schema defaults, validators, enums on `classifiedState` + `classifiedIntent`, guest `userId: null` accepted.
+  - `__tests__/services/whatsapp-inbound-service.classify.test.ts` (13 cases) — state classifier covering all 4 states + deleted-account exclusion; intent classifier covering STOP regex variants, `"💬 Chat with Staff"` text body + Meta `interactive.button_reply` payload + the support-text fallback.
+  - `__tests__/services/whatsapp-inbound-service.routing.test.ts` (10 cases) — full state × intent matrix at significant cells, STOP compliance (`UserModel.updateOne` clears both whatsapp flags), AC6 auto-create payload, AC7 safety (`IncomingMessage.create` rejection swallowed, `NotificationService.send` rejection swallowed).
+  - `__tests__/lib/whatsapp.inbound-integration.test.ts` (2 cases) — inbound-payload delegates to `WhatsAppInboundService.handle` once per message; status-payload doesn't call inbound (REQ-055 path stays untouched).
+- 30/30 red confirmed → implemented `models/incoming-message-model.ts` (Mongoose schema + 3 indexes + unique `messageId` for Meta-retry dedup), `lib/whatsapp-inbound-templates.ts` (state → template name lookup), `services/whatsapp-inbound-service.ts` (classifiers + `handle()` orchestrator), and the `sendTextMessage` method on `WhatsAppService` for the 24h-window free-form STOP confirmation.
+- One iteration during TDD: the `MetaInboundMessage` payload type wasn't exported, so the routing test helpers couldn't type-check. Exported the interface from the service; helpers typed cleanly; full suite green.
+- Ran the full gate set: `tsc --noEmit` clean, full vitest 966 / 4 skip / 0 fail (+30 new), eslint scoped (0 errors; 6 intentional `no-console` warnings on `lib/whatsapp.ts` v1 observability), semgrep ERROR-severity 0 findings on 4 files, npm audit 0 high/critical (after the unrelated PR #230 vitest GHSA bump).
+- Phase 3 evidence pack assembled belatedly (this commit): test-scope, test-plan, test-execution-summary, security-summary, ai-prompts, ai-use-note, implementation-plan copy, RELEASE-TICKET-REQ-056.md in pending-releases/. The operator caught that the release ticket was missing on the portal after the release PR opened — corrected within the same session.
+- Updated `compliance/RTM.md` with the REQ-056 row.
+
+## What the human did
+
+- Reviewed and approved the implementation plan ("Approve as scoped").
+- Merged the integration PR #229 → develop.
+- Merged the vitest CVE bump PR #230 (unrelated dep-audit failure surfaced on REQ-056's CI; npm advisory db published the critical between REQ-055's CI and REQ-056's).
+- Merged the attribution PR #231 — same pattern as PR #163 (REQ-048).
+- Caught the missing Phase 3 release ticket on the portal; surfaced "Release ticket not yet uploaded — wait for the developer to complete SDLC step 3."
+- Authorised filing two upstream issues that emerged from the cycle:
+  - [DevAudit-Installer #95](https://github.com/metasession-dev/DevAudit-Installer/issues/95) — resolver step-4-bis (scan RTM.md for IN PROGRESS rows).
+  - [DevAudit-Installer #96](https://github.com/metasession-dev/DevAudit-Installer/issues/96) — ci.yml upload-evidence-on-failure-too.
+- Will perform Phase 4 portal UAT approval + Phase 5 Production approval after CI green on develop after this evidence pack lands.
+
+## Risk-tier compliance
+
+- MEDIUM-HIGH risk → plan-approval offered + granted before any code was written (matches `feedback_sdlc_impl_plan_review`).
+- Tests written before implementation (matches `feedback_tests_before_push`).
+- All gates run locally before push (`feedback_wait_for_ci`).
+- Single bundled PR for the implementation per `feedback_single_pr_default`; chore + attribution + evidence-pack PRs are housekeeping follow-ups, each justified by a hard sequencing reason (CVE blocker, attribution-window expired, Phase 3 omission).
+- E2E policy honoured per `project_e2e_targeted_until_117` — no full regression dispatched; unit + integration boundary is load-bearing.
+- STOP compliance treated as Meta WABA hard policy requirement, not a UX nicety — clears both consent flags regardless of state, confirms free-form within 24h window.
+- No `--no-verify`, no `--delete-branch` on the release PR (per `feedback_no_delete_develop_on_release_merge`).

--- a/compliance/evidence/REQ-056/implementation-plan.md
+++ b/compliance/evidence/REQ-056/implementation-plan.md
@@ -1,0 +1,245 @@
+# REQ-056 — WhatsApp inbound-message router
+
+**Requirement ID:** REQ-056
+**Risk Level:** MEDIUM-HIGH
+**GitHub Issue:** [#117 WA-3](https://github.com/metasession-dev/wawagardenbar-app/issues/117)
+**Date:** 2026-06-01
+
+## Context
+
+The WhatsApp surface is outbound-only today. `WhatsAppService.handleWebhook` in `lib/whatsapp.ts` parses inbound message events but only `console.log`'s them; nothing routes customer replies, nothing honours `STOP`, nothing creates the User record that future outbound sends would gate on.
+
+Meta WhatsApp Business Policy makes the `STOP` opt-out keyword a hard compliance requirement — failing to honour it is grounds for WABA suspension. The current handler does not honour it. Separately, Meta opens a 24-hour "customer service window" when a customer messages us, during which free-form replies are allowed without a template. Today that window is unused.
+
+REQ-056 closes both gaps with a customer-state-aware router that:
+
+1. Classifies the inbound by **customer state** (new / signing_up / active / dormant) and by **intent** (opt_out / chat_with_staff / support_text).
+2. Persists every inbound to a new `IncomingMessage` audit collection (companion to REQ-055's `NotificationLog`).
+3. Honours STOP by clearing both WhatsApp consent flags (`whatsappTransactional`, `whatsappMarketing`) and confirming free-form.
+4. Sends the state-appropriate welcome template via REQ-054's `NotificationService.send` for non-active states.
+5. Auto-creates a `User` row for unknown phone numbers so the customer is referenceable on future inbound messages.
+
+REQ-055 already wired the **status-event** branch of `handleWebhook` to `NotificationLogService.updateStatus`; REQ-056 owns the **inbound-message** branch of the same function. The route at `app/api/webhooks/whatsapp/route.ts` does HMAC-SHA256 signature verification and is **unchanged** by this REQ.
+
+## Acceptance criteria
+
+1. **AC1 — `IncomingMessage` model** — new Mongoose model `models/incoming-message-model.ts` with fields:
+   - `from: string` (required, indexed) — Meta's `wa_id` (sanitized phone)
+   - `body: string | null` — text body if message type is `text`, otherwise null (image / sticker / interactive button payload labels are coerced to text-equivalent where possible)
+   - `messageType: string` (required) — `text` / `interactive` / `image` / etc. straight from Meta's payload
+   - `messageId: string` (required, unique) — Meta's inbound message id
+   - `classifiedState: 'new' | 'signing_up' | 'active' | 'dormant'` (required)
+   - `classifiedIntent: 'opt_out' | 'chat_with_staff' | 'support_text'` (required)
+   - `actionTaken: string` (required) — short tag describing the router's decision (e.g. `'sent_welcome_new_user'`, `'persisted_opt_out'`, `'queued_for_staff'`)
+   - `userId: string | null` — resolved/created User OID
+   - `receivedAt: Date` (required, default Date.now)
+   - `createdAt` / `updatedAt` — auto via `{ timestamps: true }`
+
+2. **AC2 — customer-state classifier** — helper `classifyCustomerState(phone)` in the inbound service:
+   - Looks up `UserModel.findOne({ phone: sanitizedPhone, accountStatus: { $ne: 'deleted' } })`
+   - Returns `{ state, user }` where:
+     - `'new'` — no User row found
+     - `'signing_up'` — User exists, `phoneVerified === false`
+     - `'active'` — User exists, `phoneVerified === true`, `lastLoginAt` within 30 days
+     - `'dormant'` — User exists, `phoneVerified === true`, `lastLoginAt > 30d` ago OR null
+
+3. **AC3 — intent classifier** — helper `classifyMessageIntent(message)` returns one of:
+   - `'opt_out'` — text body matches `/^\s*(stop|unsubscribe|opt[-\s]?out)\s*$/i` (case-insensitive; Meta-required STOP keywords)
+   - `'chat_with_staff'` — text body equals the welcome-template Quick Reply payload (`"💬 Chat with Staff"`) OR Meta `interactive.button_reply.title` equals same OR `interactive.button_reply.id` equals `chat_with_staff`
+   - `'support_text'` — default catch-all for any other text content
+
+4. **AC4 — routing matrix** — `state × intent → action`. For each combination, the router takes the action below, persists the action tag on the `IncomingMessage`, and returns:
+
+   | state          | opt_out                                                      | chat_with_staff                                     | support_text                                        |
+   | -------------- | ------------------------------------------------------------ | --------------------------------------------------- | --------------------------------------------------- |
+   | **new**        | auto-create User + persist opt-out flags + free-form confirm | auto-create User + send `welcome_new_user` template | auto-create User + send `welcome_new_user` template |
+   | **signing_up** | persist opt-out flags + free-form confirm                    | send `welcome_new_user` (re-engagement)             | send `welcome_new_user`                             |
+   | **active**     | persist opt-out flags + free-form confirm                    | log to staff queue (no template)                    | log to staff queue (no template)                    |
+   | **dormant**    | persist opt-out flags + free-form confirm                    | send `welcome_back`                                 | send `welcome_back`                                 |
+
+5. **AC5 — STOP compliance** — `'opt_out'` MUST set `preferences.communicationPreferences.whatsappTransactional = false` AND `preferences.communicationPreferences.whatsappMarketing = false` on the user doc, regardless of state. For the `'new'` state the user is auto-created first, then opt-out flags persisted on the new doc. Confirmation is a free-form WhatsApp reply (template-less) inside the 24h window — Meta does not restrict free-form replies once a customer has messaged us. The confirmation send is best-effort; failure does not block the opt-out persistence.
+
+6. **AC6 — User auto-creation for new phone numbers** — `classifyCustomerState` triggers `UserModel.create({ phone, phoneVerified: false, isGuest: false })` when no row exists. Mirrors the pattern in `app/actions/auth/send-pin.ts`. Created users start with WhatsApp defaults (transactional `true`, marketing `false`), then if the intent was `'opt_out'` the flags are immediately overwritten per AC5.
+
+7. **AC7 — safety / backwards-compat** — All routing logic wrapped in try/catch with `console.error`; webhook always returns 200 (existing pattern); persistence failures swallowed; outbound send failures swallowed (REQ-054's NotificationService handles its own fallback logic). The existing `console.log` lines in `handleWebhook`'s inbound branch are retained for ops grep.
+
+8. **AC8 — wire into existing `handleWebhook`** — Replace the current TODO log-only block for inbound messages (`lib/whatsapp.ts:314-336`) with a call to `WhatsAppInboundService.handle(message, value)`. Status-event branch (REQ-055) untouched. Use the lazy-import pattern established in REQ-055's status-update wiring to avoid the `lib/whatsapp` ↔ `services/whatsapp-inbound-service` ↔ `services/notification-service` circular.
+
+## Technical approach
+
+### 1. `models/incoming-message-model.ts` (new, ~60 LOC)
+
+Mongoose model with the fields in AC1. Compound indexes:
+
+- `{ from: 1, receivedAt: -1 }` — "show me this customer's recent inbound traffic"
+- `{ messageId: 1 }` — unique; serves as the dedup gate if Meta retries
+- `{ receivedAt: -1 }` — admin recent-inbound view
+
+`{ timestamps: true }`. Same shape and discipline as REQ-055's `NotificationLogModel`.
+
+### 2. `services/whatsapp-inbound-service.ts` (new, ~200 LOC)
+
+Three exposed surfaces:
+
+- `classifyCustomerState(phone) → { state, user }` — pure lookup against `UserModel`. Returns `'new'` with `user: null` when no row found; the caller decides whether to auto-create.
+- `classifyMessageIntent(message) → 'opt_out' | 'chat_with_staff' | 'support_text'` — pure switch on Meta payload shape; no DB.
+- `handle(message, value)` — orchestrator. Reads the inbound, classifies, routes per the matrix, persists `IncomingMessage`, sends outbound reply via `NotificationService.send`. Returns the action tag string (for tests).
+
+Internal helpers:
+
+- `applyOptOut(user)` — persists `whatsappTransactional: false`, `whatsappMarketing: false`. Uses `$set` on the nested path to avoid clobbering other preferences.
+- `sendFreeFormConfirmation(phone, text)` — bypasses the template gate (24h window) by calling `WhatsAppService` directly with a `type: 'text'` payload. Best-effort; failures swallowed.
+
+### 3. `lib/whatsapp-inbound-templates.ts` (new, ~25 LOC)
+
+```ts
+export const INBOUND_WELCOME_TEMPLATE: Record<CustomerState, string | null> = {
+  new: 'welcome_new_user',
+  signing_up: 'welcome_new_user',
+  active: null, // free-form / staff handles it
+  dormant: 'welcome_back',
+};
+```
+
+Single source for the state→template mapping. Keeps the routing decisions out of the orchestrator switch statements.
+
+### 4. Wire `lib/whatsapp.ts:handleWebhook` inbound branch (~10 LOC change)
+
+Replace the current `for (const message of messages)` body with a lazy-imported call to the new service:
+
+```diff
+-  if (messageType === 'text') {
+-    console.log('User sent text message:', message.text?.body);
+-  }
++  try {
++    const { WhatsAppInboundService } = await import(
++      '@/services/whatsapp-inbound-service'
++    );
++    await WhatsAppInboundService.handle(message, value);
++  } catch (error) {
++    console.warn('[WhatsApp] inbound routing skipped:',
++      error instanceof Error ? error.message : String(error));
++  }
+```
+
+The existing `console.log` summarising the inbound is retained on the line above.
+
+### 5. Add a free-form text-send method to `WhatsAppService` (~25 LOC)
+
+Today `WhatsAppService.sendMessage` only sends templates. The STOP confirmation needs a free-form text reply. Add:
+
+```ts
+static async sendTextMessage(to: string, body: string): Promise<WhatsAppResult>
+```
+
+Same shape as `sendMessage` but with `type: 'text'` + `text: { body }` instead of the template block. Same error mapping. Falls under the 24-hour window rule — only valid when responding to an inbound within 24h, which is exactly the inbound-router context.
+
+### 6. No env vars, no new packages, no DB migration
+
+`IncomingMessageModel` collection created lazily on first write. No changes to existing collections. `welcome_new_user` and `welcome_back` template approvals are tracked separately (WA-1, blocked at Meta) — when the templates aren't approved, REQ-054's NotificationService returns `TEMPLATE_NOT_FOUND` and falls through to email, which for an inbound-WA customer means no reply is delivered. The IncomingMessage audit log still records the inbound; STOP opt-out persistence still works (uses the free-form text path, not the template path).
+
+## Tests (TDD — written before implementation)
+
+### `__tests__/models/incoming-message-model.test.ts` (~5 cases)
+
+- AC1 — schema defaults: `receivedAt` defaults to now-ish.
+- AC1 — required fields throw validation if missing (`from`, `messageType`, `messageId`, `classifiedState`, `classifiedIntent`, `actionTaken`).
+- AC1 — `classifiedState` enum constraint rejects unknown values.
+- AC1 — `classifiedIntent` enum constraint rejects unknown values.
+- AC1 — `userId: null` accepted (new-customer auto-create path before User exists).
+
+### `__tests__/services/whatsapp-inbound-service.classify.test.ts` (~12 cases)
+
+State classifier (6 cases):
+
+- AC2 — no user → `'new'` with `user: null`.
+- AC2 — user with `phoneVerified: false` → `'signing_up'`.
+- AC2 — user with `phoneVerified: true`, `lastLoginAt: now` → `'active'`.
+- AC2 — user with `phoneVerified: true`, `lastLoginAt: 31 days ago` → `'dormant'`.
+- AC2 — user with `phoneVerified: true`, `lastLoginAt: undefined` → `'dormant'`.
+- AC2 — deleted-account user (`accountStatus: 'deleted'`) skipped → `'new'`.
+
+Intent classifier (6 cases):
+
+- AC3 — text body `"STOP"` → `'opt_out'`.
+- AC3 — text body `"stop  "` (whitespace + lowercase) → `'opt_out'`.
+- AC3 — text body `"unsubscribe"` → `'opt_out'`.
+- AC3 — text body `"💬 Chat with Staff"` → `'chat_with_staff'`.
+- AC3 — interactive button reply with `title: "💬 Chat with Staff"` → `'chat_with_staff'`.
+- AC3 — text body `"hi can I get a menu"` → `'support_text'`.
+
+### `__tests__/services/whatsapp-inbound-service.routing.test.ts` (~10 cases)
+
+Router orchestration — one per significant cell of the matrix, plus safety:
+
+- AC4 — `new` + `support_text` → auto-creates User, sends `welcome_new_user`, persists `IncomingMessage` with `actionTaken: 'sent_welcome_new_user'`.
+- AC4 — `signing_up` + `support_text` → no auto-create, sends `welcome_new_user`.
+- AC4 — `active` + `support_text` → no template send, `actionTaken: 'queued_for_staff'`.
+- AC4 — `dormant` + `chat_with_staff` → sends `welcome_back`.
+- AC5 — `active` + `opt_out` → calls `UserModel.updateOne` setting both whatsapp flags to false; sends free-form text confirmation; `actionTaken: 'persisted_opt_out'`.
+- AC5 — `new` + `opt_out` → auto-creates User, persists opt-out flags on the new doc.
+- AC5 — `opt_out` persists even when the outbound free-form confirmation fails.
+- AC6 — `new` + `support_text` calls `UserModel.create` with `{ phone, phoneVerified: false, isGuest: false }`.
+- AC7 — `IncomingMessage.create` rejecting does not throw out of `handle()`.
+- AC7 — `NotificationService.send` rejecting does not throw out of `handle()`.
+
+### `__tests__/lib/whatsapp.inbound-integration.test.ts` (~2 cases)
+
+- AC8 — `handleWebhook` with an inbound messages payload calls `WhatsAppInboundService.handle` once per message.
+- AC8 — `handleWebhook` with a status-events payload does NOT call the inbound service (existing REQ-055 path stays untouched).
+
+## Dependencies
+
+- **REQ-053** — `whatsappTransactional` / `whatsappMarketing` consent fields on `IPreferences.communicationPreferences`. ✅ Released 2026-05-31.
+- **REQ-054** — `NotificationService.send` for outbound welcome templates. ✅ Released 2026-06-01.
+- **REQ-055** — `IncomingMessage` mirrors `NotificationLog` shape; lazy-import pattern established. ✅ Released 2026-06-01.
+- **Existing `app/api/webhooks/whatsapp/route.ts`** — Meta HMAC-SHA256 signature verification. **No changes.**
+- **Existing `lib/whatsapp.ts`** — status-event branch (REQ-055) untouched; inbound-message branch rewired (~10 LOC); new `sendTextMessage` method added (~25 LOC).
+- **`lib/auth-utils.ts:sanitizePhone`** — existing helper, reused.
+- **No new packages, no env vars, no DB migration.**
+
+## Security considerations
+
+### STRIDE
+
+| Cat                     | Risk                                                                                                                   | Mitigation                                                                                                                                                                                                                                                             |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **S** — Spoofing        | Inbound webhook events from a non-Meta source could trigger router logic (User auto-create, opt-out, welcome template) | Route at `app/api/webhooks/whatsapp/route.ts` verifies `x-hub-signature-256` HMAC-SHA256 against `META_APP_SECRET` BEFORE `handleWebhook` runs. REQ-056 does not change that. Same posture as REQ-055                                                                  |
+| **T** — Tampering       | Malicious phone-number input could attempt NoSQL injection through `findOne({ phone })`                                | `sanitizePhone()` strips to digits + leading `+` only — no operator characters survive. Mongoose treats the value as a string, not an expression                                                                                                                       |
+| **R** — Repudiation     | Every inbound message is persisted in `IncomingMessage` with phone, messageId, classifications, action taken           | `IncomingMessage` IS the audit trail; mirror of REQ-055's `NotificationLog` for the inbound direction                                                                                                                                                                  |
+| **I** — Info disclosure | Persisting raw message bodies could expose PII if `IncomingMessage` query surface ever leaks                           | No new query endpoint exposed by REQ-056. Future admin UI is a separate REQ. Body is logged for support context, same posture as today's `console.log` — no regression                                                                                                 |
+| **D** — DoS             | Mass-flood of inbound messages could write-storm Mongo, create-storm Users, or saturate outbound send                  | Each inbound = constant-time work (one find, one create-if-missing, one log write, at most one outbound send). Mongo handles trivially at expected volumes. Webhook ACKs 200 fast (existing pattern). Rate-limiting at webhook ingress is a future operational concern |
+| **E** — Elevation       | Auto-created User starts with `role: 'customer'` (Mongoose default), never with elevated permissions                   | `UserModel.create({ phone, phoneVerified: false, isGuest: false })` — no role override; defaults are restrictive                                                                                                                                                       |
+
+### Privacy / regulatory
+
+- Phone numbers are already collected at signup; persisting them on inbound messages is no new PII surface.
+- Message bodies are persisted — this is the audit-trail tradeoff. A future REQ can add a TTL index or admin-driven purge.
+- STOP compliance is the user-protection lever: once opted out, no further marketing or transactional WhatsApp sends.
+
+### Four-eyes attestation
+
+- **Submitter**: Claude Code (AI tool) via project orchestrator.
+- **Reviewer**: ostendo-io (solo-operator dual-actor interpretation per DevAudit-Installer issue #89 gap 10).
+
+## Rollback plan
+
+1. Single PR. `git revert <merge-sha>` removes the new model, service, templates module, and the `handleWebhook` inbound branch is restored to its log-only TODO state. The `IncomingMessage` collection persists in MongoDB (harmless; orphaned table). No data loss; no schema change to existing collections.
+2. Any auto-created User rows from the new-state inbound path persist (legitimate accounts — phone numbers that messaged us). They behave identically to pre-REQ-056 users with `phoneVerified: false`.
+3. Any opt-out flags persisted via STOP also persist — that's the desired behaviour even after rollback; we don't unsend an opt-out.
+4. Detection: `IncomingMessage.find().count()` stops growing post-revert; `console.log` lines in `handleWebhook` keep firing as the only observability source for inbound.
+
+## Test scope
+
+| Gate                            | Expected                                                                                               |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `npx tsc --noEmit`              | exit 0                                                                                                 |
+| `npx vitest run`                | 0 failures; new tests pass; existing suite unchanged                                                   |
+| `npx eslint <changed>`          | 0 errors                                                                                               |
+| `semgrep scan --severity ERROR` | 0 new findings on REQ-056 code                                                                         |
+| `npm audit --audit-level=high`  | 0 high/critical                                                                                        |
+| E2E focused                     | n/a — server-side webhook surface; unit boundary is load-bearing; per `project_e2e_targeted_until_117` |
+
+## Plan deviation log
+
+(populated during implementation if anything diverges from the above)

--- a/compliance/evidence/REQ-056/security-summary.md
+++ b/compliance/evidence/REQ-056/security-summary.md
@@ -1,0 +1,65 @@
+# REQ-056 — Security summary
+
+**Requirement ID:** REQ-056
+**Risk class:** MEDIUM-HIGH
+**Surface:** new `models/incoming-message-model.ts`, `services/whatsapp-inbound-service.ts`, `lib/whatsapp-inbound-templates.ts`; additions to `lib/whatsapp.ts` (new `sendTextMessage` method + rewired inbound branch in `handleWebhook`).
+
+## STRIDE assessment
+
+| Category                | Risk introduced? | Rationale / mitigation                                                                                                                                                                                                                                                                                                                                                                          |
+| ----------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **S** — Spoofing        | No               | The webhook route at `app/api/webhooks/whatsapp/route.ts` already verifies Meta's `x-hub-signature-256` HMAC-SHA256 before any payload reaches `WhatsAppService.handleWebhook` (and therefore before any `WhatsAppInboundService.handle` call). REQ-056 doesn't change the auth surface. Same posture as REQ-055.                                                                               |
+| **T** — Tampering       | Low              | Malicious phone-number input could attempt NoSQL injection through `findOne({ phone })`. `sanitizePhone()` (existing helper in `lib/auth-utils.ts`) strips to digits + leading `+` only — no operator characters survive. Mongoose treats the value as a string, not an expression.                                                                                                             |
+| **R** — Repudiation     | No               | Every inbound message is persisted to `IncomingMessage` with phone, messageId, classifiedState, classifiedIntent, actionTaken, userId, timestamps. Audit-trail mirror of REQ-055's `NotificationLog` on the inbound direction.                                                                                                                                                                  |
+| **I** — Info disclosure | Low              | Persisting raw inbound message bodies could expose PII if `IncomingMessage` query surface ever leaks. No new query endpoint exposed by REQ-056; same posture as today's `console.log` lines. Future admin UI is a separate REQ. **Note for retention:** body content IS persisted (unlike REQ-055's NotificationLog which is metadata-only) — a future TTL/redaction policy should target this. |
+| **D** — DoS             | Low              | Each inbound = constant-time work (one findOne, one create-if-missing, one log write, at most one outbound send). Mongo handles trivially at expected volumes. Webhook ACKs 200 fast regardless of persistence outcome. Rate-limiting at webhook ingress is a future operational concern.                                                                                                       |
+| **E** — Elevation       | No               | Auto-created User starts with `role: 'customer'` (Mongoose default) — never with elevated permissions. `UserModel.create({ phone, phoneVerified: false, isGuest: false })` — no role override. STOP opt-out is the only privilege change; restrictive direction (turns flags OFF, never ON).                                                                                                    |
+
+## Threat model — inbound routing lifecycle
+
+The inbound flow is: customer messages our WA number → Meta delivers webhook → `app/api/webhooks/whatsapp/route.ts` verifies signature → `WhatsAppService.handleWebhook(payload)` parses → `WhatsAppInboundService.handle(message, value)` classifies + routes.
+
+Failure modes considered:
+
+1. **Spoofed inbound message with crafted body** — signature verification at the route layer blocks. The service would never see the call. Same gate REQ-055 relies on.
+
+2. **STOP keyword bypass attempt** — what if the customer sends `"STOP."` or `"Stop please"` or `"please stop"`? Current regex `^\s*(stop|unsubscribe|opt[-\s]?out)\s*$` is strict (whole-message match only). Trade-off: false negatives on chatty STOPs ("please stop the messages") — those route to `support_text` and reach a staff queue, where a human can apply the opt-out. False positives are zero (only intentional opt-out keywords match). This matches Meta's documented STOP keyword set; conservative is correct here — accidentally opting people out is worse than missing chatty STOPs that a human will catch.
+
+3. **Spam flood from a single phone** — each inbound = constant-time work. Per `from` an attacker creates one User row + writes one IncomingMessage per message. Mongo handles trivially. The webhook route ACKs 200 fast so Meta doesn't retry-storm. Rate-limiting at webhook ingress is a future operational concern (out of scope per the plan).
+
+4. **NoSQL injection via phone** — `sanitizePhone()` strips to digits + leading `+`. The resulting string is passed to `findOne({ phone })` as a value, not an expression. Mongoose doesn't interpret operator-shaped strings inside string-typed fields. Defense-in-depth: even if a payload escaped sanitisation, the query is value-typed against a `phone: { type: String }` schema field.
+
+5. **Auto-create + opt-out race** — if a customer sends `"STOP"` from a phone we've never seen before, AC5 path: `classifyCustomerState('new', user: null)` → AC6 path: `UserModel.create(...)` → AC5 path: `UserModel.updateOne({ _id: newUser._id }, { $set: { ... } })`. The create-then-update sequence is two round-trips. If the create succeeds but the update fails (rare), the user exists but is NOT opted-out — i.e., they may still receive future marketing. The `try/catch` around the update logs the failure to `console.error` so it's recoverable. Stricter alternative (atomic upsert with opt-out flags baked in) is a follow-up.
+
+6. **Persistence layer down** — `IncomingMessageModel.create`, `UserModel.create`, `UserModel.updateOne`, `NotificationService.send` and `WhatsAppService.sendTextMessage` are all individually `try/catch`-wrapped inside `handle()`. The outer `try/catch` around the whole orchestrator covers anything missed. Webhook ACK remains 200. Same safety posture as REQ-055.
+
+7. **Meta Outbound restriction** — Meta's "Your business is restricted" alert blocks outbound template sends (WA-1 is blocked separately). REQ-056's welcome_new_user / welcome_back sends will fail through `NotificationService.send` → REQ-054's `console.warn` "no channel delivered". The IncomingMessage row still records `actionTaken: 'sent_welcome_new_user'` even when delivery failed, because the router returns the intent, not the delivery outcome. Operator-visible — fine for v1.
+
+8. **STOP confirmation outside 24h window** — `WhatsAppService.sendTextMessage` only works within Meta's 24h customer-service window opened by the customer's incoming message. Since STOP confirmations are always sent in direct response to an inbound, the window is always open at the moment of reply. No edge case here.
+
+## Privacy / regulatory
+
+- No new PII collected at first contact beyond what Meta already supplies (phone via `wa_id`).
+- Message body content IS persisted (different posture from REQ-055's NotificationLog which is metadata-only). **Justification:** the router needs to log what was said so operators can audit STOP opt-outs and support-queue items. A future REQ can add a Mongo TTL index or admin-driven purge endpoint.
+- STOP compliance: once opted out, **no further** WhatsApp transactional or marketing send (REQ-054's NotificationService consent gate enforces). This is the Meta WABA policy requirement.
+
+## Static analysis
+
+`semgrep scan --severity=ERROR models/incoming-message-model.ts services/whatsapp-inbound-service.ts lib/whatsapp-inbound-templates.ts lib/whatsapp.ts` → 0 findings.
+
+## Dependency audit
+
+`npm audit --audit-level=high` → 0 high / 0 critical. The unrelated vitest GHSA was patched via PR #230 between PR #229 merge and the final develop CI green; REQ-056 introduced no new packages.
+
+## Four-eyes attestation
+
+- **Submitter**: Claude Code (AI tool) via project orchestrator.
+- **Reviewer**: ostendo-io (solo-operator dual-actor interpretation per DevAudit-Installer issue #89 gap 10).
+
+## Out of scope
+
+- Webhook signature verification → already implemented; not modified by REQ-056.
+- Order-cancellation / balance-inquiry / full SupportTicket model → future REQs.
+- Rate limiting at webhook ingress → future operational concern.
+- TTL / retention policy on `IncomingMessage` → future REQ.
+- Meta Flows / interactive lists / conversational signup → future REQ.

--- a/compliance/evidence/REQ-056/test-execution-summary.md
+++ b/compliance/evidence/REQ-056/test-execution-summary.md
@@ -1,0 +1,150 @@
+# REQ-056 — Test execution summary
+
+**Date:** 2026-06-01
+**Branch:** `feat/REQ-056-whatsapp-inbound-router`
+
+## Gate results
+
+### `npx tsc --noEmit`
+
+Exit 0. Clean.
+
+### `npx vitest run __tests__/models/incoming-message-model.test.ts`
+
+```
+ ✓ __tests__/models/incoming-message-model.test.ts (5 tests)
+
+ Test Files  1 passed (1)
+      Tests  5 passed (5)
+```
+
+Cases:
+
+- AC1 — receivedAt defaults to now-ish
+- AC1 — required fields throw validation error if missing
+- AC1 — classifiedState enum rejects unknown values
+- AC1 — classifiedIntent enum rejects unknown values
+- AC1 — `userId: null` accepted (new customer, before auto-create)
+
+### `npx vitest run __tests__/services/whatsapp-inbound-service.classify.test.ts`
+
+```
+ ✓ __tests__/services/whatsapp-inbound-service.classify.test.ts (13 tests)
+
+ Test Files  1 passed (1)
+      Tests  13 passed (13)
+```
+
+State classifier (6):
+
+- AC2 — no user → "new" with `user: null`
+- AC2 — user with `phoneVerified: false` → "signing_up"
+- AC2 — `phoneVerified: true` + recent `lastLoginAt` → "active"
+- AC2 — `phoneVerified: true` + `lastLoginAt` 31 days ago → "dormant"
+- AC2 — `phoneVerified: true` + `lastLoginAt` undefined → "dormant"
+- AC2 — deleted-account users skipped (filter excludes `accountStatus: 'deleted'`)
+
+Intent classifier (7):
+
+- AC3 — `"STOP"` → "opt_out"
+- AC3 — `"stop  "` (whitespace + lowercase) → "opt_out"
+- AC3 — `"unsubscribe"` → "opt_out"
+- AC3 — `"opt out"` / `"opt-out"` → "opt_out"
+- AC3 — text body `"💬 Chat with Staff"` → "chat_with_staff"
+- AC3 — Meta interactive `button_reply.title: "💬 Chat with Staff"` → "chat_with_staff"
+- AC3 — arbitrary text → "support_text"
+
+### `npx vitest run __tests__/services/whatsapp-inbound-service.routing.test.ts`
+
+```
+ ✓ __tests__/services/whatsapp-inbound-service.routing.test.ts (10 tests)
+
+ Test Files  1 passed (1)
+      Tests  10 passed (10)
+```
+
+Cases (in roughly AC order):
+
+- AC4 — `new` + `support_text` → auto-creates User, sends `welcome_new_user`, action `sent_welcome_new_user`
+- AC4 — `signing_up` + `support_text` → no auto-create, sends `welcome_new_user`
+- AC4 — `active` + `support_text` → no template send, action `queued_for_staff`
+- AC4 — `dormant` + `chat_with_staff` → sends `welcome_back`
+- AC5 — `active` + `opt_out` → both whatsapp flags set to false; free-form confirm sent; action `persisted_opt_out`
+- AC5 — `new` + `opt_out` → auto-creates User, then persists opt-out flags on the new doc
+- AC5 — opt_out persists even when outbound free-form confirmation fails
+- AC6 — `UserModel.create` called with `phone, phoneVerified: false, isGuest: false`
+- AC7 — `IncomingMessageModel.create` rejecting does not throw out of `handle()`
+- AC7 — `NotificationService.send` rejecting does not throw out of `handle()`
+
+### `npx vitest run __tests__/lib/whatsapp.inbound-integration.test.ts`
+
+```
+ ✓ __tests__/lib/whatsapp.inbound-integration.test.ts (2 tests)
+
+ Test Files  1 passed (1)
+      Tests  2 passed (2)
+```
+
+Cases:
+
+- AC8 — inbound-messages payload routes to `WhatsAppInboundService.handle` once per message
+- AC8 — status-events payload does NOT call the inbound service (REQ-055 path stays untouched)
+
+### `npx vitest run` (full)
+
+```
+ Test Files  95 passed | 1 skipped (96)
+      Tests  966 passed | 4 skipped (970)
+   Duration  3.29s
+```
+
+Up from 936 / 4 skip (REQ-055 baseline) → **+30 new REQ-056 cases**. 0 failures.
+
+### `npx eslint <changed>`
+
+```
+lib/whatsapp.ts
+  306:7   warning  Unexpected console statement  no-console
+  318:7   warning  Unexpected console statement  no-console
+  333:11  warning  Unexpected console statement  no-console
+  355:13  warning  Unexpected console statement  no-console
+  360:13  warning  Unexpected console statement  no-console
+  404:11  warning  Unexpected console statement  no-console
+
+✖ 6 problems (0 errors, 6 warnings)
+```
+
+0 errors on REQ-056 code. The 6 `no-console` warnings are on intentional `console.error` / `console.warn` lines on the new `sendTextMessage` method + the lazy-import safety net (matches the v1 observability pattern carried over from REQ-054/055).
+
+### `semgrep scan --severity=ERROR <REQ-056 files>`
+
+```
+Ran 78 rules on 4 files: 0 findings.
+```
+
+Clean across `models/incoming-message-model.ts`, `services/whatsapp-inbound-service.ts`, `lib/whatsapp-inbound-templates.ts`, `lib/whatsapp.ts`.
+
+### `npm audit --audit-level=high`
+
+```
+high: 0  critical: 0
+```
+
+After the unrelated vitest 4.1.x GHSA bump landed via PR #230 (npm advisory DB published the critical between REQ-055's CI and REQ-056's, no REQ-056-introduced deps).
+
+## E2E execution
+
+n/a — REQ-056's surface is server-side webhook routing. The unit + integration boundary at 30 cases is the load-bearing gate. Honours `project_e2e_targeted_until_117` policy.
+
+## CI on develop
+
+After PR #229 merged + the vitest CVE was fixed (PR #230) + the re-attribution PR landed (PR #231): CI Pipeline run [26774830299](https://github.com/metasession-dev/wawagardenbar-app/actions/runs/26774830299) passed all 3 jobs (Register Release / Quality Gates / Upload Evidence) and attributed to `--release REQ-056` per `derive-release-version.sh` step 3 picking up the `[REQ-056]` bracket in the merge-commit body.
+
+## Summary
+
+- Unit + integration gate: PASS (966 / 0 / 4 skipped — +30 from REQ-055 baseline).
+- Type gate: PASS.
+- Lint gate: PASS (no errors; intentional `no-console` warnings per v1 observability pattern).
+- Static-analysis gate: PASS (semgrep 0 findings).
+- Dependency-audit gate: PASS (no new high/critical post-vitest-bump).
+- E2E gate: n/a (scope-justified + policy-justified).

--- a/compliance/evidence/REQ-056/test-plan.md
+++ b/compliance/evidence/REQ-056/test-plan.md
@@ -1,0 +1,56 @@
+# REQ-056 — Test plan
+
+**Requirement ID:** REQ-056
+**Risk:** MEDIUM-HIGH
+**Related issue:** [#117 WA-3](https://github.com/metasession-dev/wawagardenbar-app/issues/117)
+**Date:** 2026-06-01
+
+## Acceptance criteria → tests
+
+| AC  | Statement                                                                                 | Test                                                                                                                                                                                   |
+| --- | ----------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AC1 | `IncomingMessage` model with documented fields, defaults, enums, unique `messageId`       | `__tests__/models/incoming-message-model.test.ts` (5 cases) — defaults, required, enum constraints on state + intent, guest `userId: null` accepted                                    |
+| AC2 | `classifyCustomerState(phone)` returns `'new' / 'signing_up' / 'active' / 'dormant'`      | `__tests__/services/whatsapp-inbound-service.classify.test.ts` — 6 cases covering every branch + deleted-account filter                                                                |
+| AC3 | `classifyMessageIntent(message)` returns `'opt_out' / 'chat_with_staff' / 'support_text'` | Same file — 7 cases covering STOP regex variants, `"💬 Chat with Staff"` text + Meta `interactive.button_reply`, support-text fallback                                                 |
+| AC4 | Routing matrix `state × intent → action`                                                  | `__tests__/services/whatsapp-inbound-service.routing.test.ts` — 4 cases at significant cells (new+support_text, signing_up+support_text, active+support_text, dormant+chat_with_staff) |
+| AC5 | STOP compliance clears both `whatsappTransactional` and `whatsappMarketing`               | Same file — 3 cases (active+opt_out, new+opt_out auto-create-then-opt-out, opt_out persists when outbound confirm fails)                                                               |
+| AC6 | New-state path calls `UserModel.create({ phone, phoneVerified: false, isGuest: false })`  | Same file — 1 case asserting on the create payload                                                                                                                                     |
+| AC7 | Safety: persistence + outbound failures swallowed inside `handle()`                       | Same file — 2 cases (IncomingMessage.create rejection, NotificationService.send rejection)                                                                                             |
+| AC8 | `handleWebhook` inbound branch delegates; status branch (REQ-055) untouched               | `__tests__/lib/whatsapp.inbound-integration.test.ts` — 2 cases (inbound delegates once per message; status-payload does NOT call inbound)                                              |
+
+## Test environment
+
+- **Unit/Integration**: vitest 4.1.x. Mongo / network boundary fully mocked. `UserModel.findOne`, `UserModel.create`, `UserModel.updateOne` mocked at `@/models` import boundary. `IncomingMessageModel.create` and `NotificationService.send` mocked separately. `WhatsAppService.sendTextMessage` mocked for the free-form opt-out confirmation. Customer-state classifier exercises real time-math against synthetic `lastLoginAt` Date objects.
+- **No E2E**: REQ-056's surface is server-side webhook routing; e2e would require a Meta WhatsApp Cloud API sandbox + a way to simulate inbound — not in v1 testing infrastructure. Honours `project_e2e_targeted_until_117` policy.
+
+## Quality gates
+
+| Gate                                                                          | Expected        | Actual (2026-06-01)                                                                                                  |
+| ----------------------------------------------------------------------------- | --------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `npx tsc --noEmit`                                                            | exit 0          | exit 0                                                                                                               |
+| `npx vitest run` (full)                                                       | 0 failures      | 966 pass / 4 skip / 0 fail                                                                                           |
+| `npx vitest run __tests__/models/incoming-message-model.test.ts`              | 5 pass          | 5 pass                                                                                                               |
+| `npx vitest run __tests__/services/whatsapp-inbound-service.classify.test.ts` | 13 pass         | 13 pass                                                                                                              |
+| `npx vitest run __tests__/services/whatsapp-inbound-service.routing.test.ts`  | 10 pass         | 10 pass                                                                                                              |
+| `npx vitest run __tests__/lib/whatsapp.inbound-integration.test.ts`           | 2 pass          | 2 pass                                                                                                               |
+| `npx eslint <changed>`                                                        | 0 errors        | 0 errors (6 intentional `no-console` warnings on `lib/whatsapp.ts` — pre-existing pattern carried over from REQ-055) |
+| `semgrep scan --severity=ERROR <changed>`                                     | 0 findings      | 0 findings on 4 files                                                                                                |
+| `npm audit --audit-level=high`                                                | 0 high/critical | 0 high / 0 critical (after vitest 4.1 bump for the unrelated GHSA — PR #230)                                         |
+
+## Test data
+
+- Synthetic user OIDs `65a1b2c3d4e5f6a7b8c9d0aa..ee` for the 4 customer states + auto-created user.
+- Phone `+2348012345678` reused across cases (sanitises to `2348012345678` per `auth-utils.sanitizePhone`).
+- Mock inbound messageIds shaped like Meta's wamid: `wamid.A1`, `wamid.S1`, `wamid.r1` etc.
+- STOP regex exercised at: `STOP`, `stop  ` (whitespace + lowercase), `unsubscribe`, `opt out`, `opt-out`.
+- Quick Reply payload exercised both as text body (`"💬 Chat with Staff"`) and as Meta `interactive.button_reply.title` + `button_reply.id`.
+
+## Sequencing
+
+1. Unit + integration gate runs locally + on CI per push.
+2. E2E not dispatched — `project_e2e_targeted_until_117` policy + scope justification.
+3. Release PR `develop → main` aggregates the CI evidence under `REQ-056`.
+
+## Rollback signal
+
+`IncomingMessage.find().count()` stops growing → revert `<merge-sha>`. The collection persists in Mongo (orphaned but harmless). Pre-REQ-056 `console.log` lines in `handleWebhook`'s inbound branch are removed by the revert; if needed, they can be restored as observability fallback in a follow-up commit. Any auto-created User rows persist as legitimate accounts; any opt-out flags persist (desired behaviour even after rollback).

--- a/compliance/evidence/REQ-056/test-scope.md
+++ b/compliance/evidence/REQ-056/test-scope.md
@@ -1,0 +1,27 @@
+# REQ-056 — Test scope
+
+**Requirement:** WhatsApp inbound-message router (#117 WA-3).
+
+## In scope
+
+- **Unit (model)** — `__tests__/models/incoming-message-model.test.ts` (5 cases) — `receivedAt` default, required-field validation, enum constraints on `classifiedState` + `classifiedIntent`, `userId: null` accepted (new-customer pre-auto-create path).
+- **Unit (classifier)** — `__tests__/services/whatsapp-inbound-service.classify.test.ts` (13 cases) — customer-state classifier across `new` / `signing_up` / `active` / `dormant` plus deleted-account exclusion; intent classifier across STOP/unsubscribe/opt-out regex, `"💬 Chat with Staff"` text and `interactive.button_reply`, and the support-text catch-all.
+- **Unit (router)** — `__tests__/services/whatsapp-inbound-service.routing.test.ts` (10 cases) — orchestration across the state × intent matrix (new+support_text, signing_up+support_text, active+support_text, dormant+chat_with_staff), STOP compliance (active+opt_out flag persistence, new+opt_out auto-create-then-opt-out, opt_out survives outbound failure), AC6 auto-create payload, AC7 safety (IncomingMessage.create rejection + NotificationService.send rejection both swallowed).
+- **Integration** — `__tests__/lib/whatsapp.inbound-integration.test.ts` (2 cases) — `handleWebhook` inbound branch delegates to `WhatsAppInboundService.handle` once per message; status-events payload does NOT call the inbound service (REQ-055 status branch stays untouched).
+- **Regression** — full vitest suite runs to confirm no impact on existing tests.
+- **Static** — `tsc --noEmit`, `eslint`, `semgrep --config auto`, `npm audit --audit-level=high`.
+
+## Out of scope
+
+- **Webhook route signature verification** — `app/api/webhooks/whatsapp/route.ts` already exists with HMAC-SHA256 verification + GET-handshake; not modified by REQ-056. Same pre-existing surface that REQ-055 left alone.
+- **Order-cancellation intent** (`/^cancel order \d+$/`) — bigger order-modification surface; deferred to a future REQ.
+- **Balance-inquiry intent** — P3 #16 owns; deferred.
+- **Full SupportTicket model** (P3 #17) — v1 logs `support_text` to the `IncomingMessage` collection + a `console.log`; admin queue UI is a future REQ.
+- **Meta Flows / interactive lists / conversational signup** — deferred (Option B/C from prior signup-architecture discussion).
+- **Mismatch / phone-recovery intent** — requires additional lookup paths; deferred.
+- **Rate limiting at webhook ingress** — future operational concern.
+- **E2E spec** — server-side webhook surface; unit + integration boundary is load-bearing; honours `project_e2e_targeted_until_117` policy.
+
+## Risk-based depth
+
+MEDIUM-HIGH risk → unit + integration is the load-bearing gate. 30 cases cover: model schema/enums/validation, customer-state lookup across all four states + deleted-account exclusion, intent classifier across all three intents including Meta interactive payloads, full routing matrix at every significant cell, STOP compliance (which is the Meta WABA policy enforcement lever), auto-create User pattern (mirrors `send-pin.ts`), and the safety-net pattern (persistence + outbound failures both swallowed inside `handle()`). Webhook signature verification doesn't appear in the scope because it pre-exists and isn't modified.

--- a/compliance/pending-releases/RELEASE-TICKET-REQ-056.md
+++ b/compliance/pending-releases/RELEASE-TICKET-REQ-056.md
@@ -1,0 +1,157 @@
+# Release Ticket: REQ-056 — WhatsApp inbound-message router
+
+**Status:** TESTED - PENDING SIGN-OFF
+**Date:** 2026-06-01
+**Requirement ID:** REQ-056
+**Risk Level:** MEDIUM-HIGH
+**GitHub Issue:** [#117 WA-3](https://github.com/metasession-dev/wawagardenbar-app/issues/117)
+**Integration PR:** [#229](https://github.com/metasession-dev/wawagardenbar-app/pull/229) — merged to develop 2026-06-01 (commit `8b39326` via merge `c3c470d`).
+**Release PR:** [#232](https://github.com/metasession-dev/wawagardenbar-app/pull/232) — open develop → main; awaiting UAT + Production approval on the DevAudit portal.
+**DevAudit Release:** [`devaudit.metasession.co/projects/wgb/`](https://devaudit.metasession.co/projects/wgb/) — release version `REQ-056`, status `draft` → `uat_review` on this evidence push.
+
+---
+
+## Summary
+
+Fourth code item in #117's WhatsApp expansion bundle (WA-3). Adds a customer-state-aware inbound router so the WhatsApp surface stops being outbound-only. Closes three gaps in the previous behaviour:
+
+1. **Meta WABA STOP-opt-out compliance gap** — Meta WhatsApp Business Policy requires `STOP` / `UNSUBSCRIBE` keywords to be honoured; failure to do so is grounds for WABA suspension. Today's `handleWebhook` only `console.log`'d inbound messages.
+2. **24-hour customer-service window unused** — Meta allows free-form replies (no template) inside the window opened when a customer messages us; we did nothing with it.
+3. **No User row created for unknown phones** — future outbound sends had no consent record to gate on for new inbound customers.
+
+The router classifies by **customer state** (`new` / `signing_up` / `active` / `dormant`, derived from `phoneVerified` + 30-day `lastLoginAt` threshold) and **intent** (`opt_out` / `chat_with_staff` / `support_text`), then routes per a 4×3 matrix that sends the right welcome template (or no template) and honours STOP across all states. Auto-creates User rows for unknown phones mirroring `send-pin.ts`. Persists every inbound to a new `IncomingMessage` audit collection (companion to REQ-055's `NotificationLog` on the outbound side).
+
+**Honesty note on Meta restriction:** the `welcome_new_user` / `welcome_back` template sends will fail until Meta's WABA restriction is lifted (separate WA-1 thread). STOP opt-out + IncomingMessage audit + free-form opt-out confirmations all work from day one — Meta does not restrict free-form replies within the 24h customer-service window opened by the customer's inbound message.
+
+## AI Involvement
+
+- **AI Tool Used:** Claude Opus 4.7 via Claude Code (CLI).
+- **AI-Generated Changes:** implementation plan with STRIDE + threat model + rollback, the `IncomingMessage` Mongoose model + indexes + enums, the `WhatsAppInboundService` (state classifier + intent classifier + `handle()` orchestrator + matrix), `lib/whatsapp-inbound-templates.ts` lookup, new `WhatsAppService.sendTextMessage` for 24h-window free-form replies, lazy-import wire-up in `lib/whatsapp.ts:handleWebhook`, 30 new vitest cases (5 model + 13 classifier + 10 router + 2 integration), full REQ-056 compliance markdown pack. See `compliance/evidence/REQ-056/ai-prompts.md` + `ai-use-note.md`.
+- **Operator action this cycle:** approved the implementation plan at the MEDIUM-HIGH-risk checkpoint. Merged the integration PR, the unrelated vitest CVE bump (PR #230), the attribution PR (PR #231 — same pattern as PR #163), and authorised filing two upstream issues (DevAudit-Installer #95 and #96). Caught the missing Phase 3 release ticket and surfaced the gap.
+- **Human Reviewer:** Stage 4 `dual_actor` approver — see `implementation-plan.md` § _Four-eyes attestation_.
+
+## Implementation Details
+
+**Files Added:**
+
+- `models/incoming-message-model.ts` — Mongoose schema for inbound audit log with `from / body / messageType / messageId / classifiedState / classifiedIntent / actionTaken / userId / receivedAt`; compound indexes on `from + receivedAt`, unique `messageId`, `receivedAt`.
+- `services/whatsapp-inbound-service.ts` — `WhatsAppInboundService.classifyCustomerState(phone)` + `classifyMessageIntent(message)` + `handle(message, value)` orchestrator with STRIDE-aware try/catch posture.
+- `lib/whatsapp-inbound-templates.ts` — `INBOUND_WELCOME_TEMPLATE` state → template name map.
+- `__tests__/models/incoming-message-model.test.ts` — 5 schema cases.
+- `__tests__/services/whatsapp-inbound-service.classify.test.ts` — 13 classifier cases.
+- `__tests__/services/whatsapp-inbound-service.routing.test.ts` — 10 routing-matrix + safety cases.
+- `__tests__/lib/whatsapp.inbound-integration.test.ts` — 2 handleWebhook delegation cases.
+- `compliance/plans/REQ-056/implementation-plan.md` — plan with ACs, STRIDE, rollback.
+
+**Files Modified:**
+
+- `lib/whatsapp.ts` — new `sendTextMessage(to, body)` method (~50 LOC) for free-form 24h-window replies; rewired inbound branch in `handleWebhook` to lazy-import `WhatsAppInboundService.handle(message, value)` (~10 LOC). Status branch (REQ-055) untouched.
+- `compliance/RTM.md` — REQ-056 row.
+
+**Dependencies Added/Changed:**
+
+- No new packages introduced by REQ-056.
+- Pre-existing critical (vitest GHSA UI-server file-read/exec) surfaced on develop CI after PR #229 merge — npm advisory DB published the critical between REQ-055's CI (~13:00 UTC) and REQ-056's (~17:51 UTC). Patched via PR #230 (`chore: bump vitest to 4.1.x`) — unrelated to REQ-056.
+
+## Test Evidence
+
+| Test Type         | Count | Passed | Failed | Evidence Location                                                                           |
+| ----------------- | ----- | ------ | ------ | ------------------------------------------------------------------------------------------- |
+| Model unit        | 5     | 5      | 0      | DevAudit portal: `wgb/REQ-056`; `compliance/evidence/REQ-056/test-execution-summary.md`     |
+| Classifier unit   | 13    | 13     | 0      | Same                                                                                        |
+| Router unit       | 10    | 10     | 0      | Same                                                                                        |
+| Integration       | 2     | 2      | 0      | Same                                                                                        |
+| Full vitest suite | 970   | 966    | 0      | Same (+4 skipped pre-existing)                                                              |
+| E2E               | n/a   | —      | —      | `project_e2e_targeted_until_117` policy + scope justification (server-side webhook surface) |
+
+**Net new from REQ-055 baseline (936 / 4 skip):** +30 REQ-056 cases. No existing tests changed.
+
+## Security Evidence
+
+| Check                 | Result                                    | Evidence Location                                                                                                                   |
+| --------------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| TypeScript Check      | exit 0                                    | DevAudit portal: `wgb/REQ-056`; CI run [26774830299](https://github.com/metasession-dev/wawagardenbar-app/actions/runs/26774830299) |
+| SAST (Semgrep)        | 0 ERROR-severity findings                 | Same                                                                                                                                |
+| Dependency Audit      | 0 high / 0 critical (post #230)           | Same                                                                                                                                |
+| Access Control review | N/A                                       | `compliance/evidence/REQ-056/security-summary.md`                                                                                   |
+| Audit Log review      | PASS — IncomingMessage IS the audit trail | `compliance/evidence/REQ-056/security-summary.md`                                                                                   |
+
+## Acceptance Criteria
+
+- [x] AC1 — `IncomingMessage` model with documented fields, defaults, enums, unique `messageId`
+- [x] AC2 — `classifyCustomerState(phone)` returns one of `new / signing_up / active / dormant`
+- [x] AC3 — `classifyMessageIntent(message)` returns one of `opt_out / chat_with_staff / support_text`
+- [x] AC4 — Routing matrix `state × intent → action` covers all 12 cells
+- [x] AC5 — STOP compliance clears both `whatsappTransactional` and `whatsappMarketing` regardless of state
+- [x] AC6 — `UserModel.create` called with `phone, phoneVerified: false, isGuest: false` for new state
+- [x] AC7 — Safety: persistence + outbound failures swallowed inside `handle()`
+- [x] AC8 — `handleWebhook` inbound branch delegates; status branch (REQ-055) untouched
+- [x] All unit + integration tests passing
+- [x] TypeScript clean
+- [x] SAST clean
+- [x] Dependencies clean (post unrelated PR #230)
+- [x] AI use documented
+
+## Risk Assessment
+
+- **Customer-facing auto-replies** — every inbound now potentially triggers an outbound template send. Mitigation: consent-gated via REQ-053; falls through to email when Meta template approval missing.
+- **Auto-create User on first inbound** — every unknown phone becomes a `phoneVerified: false` User row. Mitigation: same posture as `send-pin.ts` (no abuse mitigation today; rate-limiting at webhook ingress is a future operational concern).
+- **STOP compliance** — Meta WABA hard policy. Mitigation: STOP regex is conservative (whole-message match); intent always wins over state in the routing matrix; both consent flags cleared atomically per opt-out.
+- **Inbound body persisted in `IncomingMessage`** — different posture from REQ-055's metadata-only `NotificationLog`. Mitigation flagged in `security-summary.md`: future TTL/redaction REQ.
+- **No new dependencies** added by REQ-056; the unrelated vitest GHSA was patched in PR #230.
+
+## Post-Deploy Actions
+
+| Type | Script / Command | Target | Required | Notes                                                                                                                                                                                                                                                                                                                                                                                     |
+| ---- | ---------------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| —    | None             | —      | —        | No data migration, no schema migration. `IncomingMessage` collection created lazily on first write. No env vars to set. `welcome_new_user` / `welcome_back` template approvals are blocked at Meta (separate WA-1 thread); REQ-056 ships fully — the routing executes, the audit log fills, STOP free-form confirmations send within the 24h window, even before templates are unblocked. |
+
+**Run these after deployment, before production verification.**
+
+---
+
+## Reviewer Checklist
+
+- [ ] Code matches requirement (review `services/whatsapp-inbound-service.ts`, `models/incoming-message-model.ts`, `lib/whatsapp.ts` diff)
+- [ ] Test evidence present and all-pass (5 + 13 + 10 + 2 = 30 cases — green on develop CI)
+- [ ] Security evidence present and clean (SAST 0, dep-audit 0, STRIDE assessed)
+- [ ] Test scope fully addressed (test-scope.md ↔ test-plan.md ↔ test-execution-summary.md)
+- [ ] RTM correct status and risk (MEDIUM-HIGH, will flip to RELEASED at close-out)
+- [ ] No sensitive data committed (no secrets, no .env files)
+- [ ] No regressions (full vitest 966 / 0 fail / 4 skip — unchanged from REQ-055 baseline)
+- [ ] AI code reviewed (`ai-use-note.md` + `ai-prompts.md`)
+- [ ] No hallucinated dependencies (no new packages)
+- [ ] Post-deploy actions documented (None required)
+
+---
+
+## 🛡️ Compliance & UAT Sign-off
+
+_This section must be completed by a human reviewer before merging to Production._
+
+| Role                | Name | Date | Status              | Signature/Notes |
+| :------------------ | :--- | :--- | :------------------ | :-------------- |
+| **QA Lead**         |      |      | [ ] PASS / [ ] FAIL |                 |
+| **Product Owner**   |      |      | [ ] PASS / [ ] FAIL |                 |
+| **Security Review** |      |      | [ ] N/A / [ ] OK    |                 |
+
+> **Audit Note:** This release was assisted by Claude Code (Opus 4.7) via the project's `sdlc-implementer` skill. All AI-generated content was reviewed by the operator and linked to the Requirement Traceability Matrix. AC1–AC8 are covered by 30 new unit + integration cases (5 model + 13 classifier + 10 router + 2 integration), 0 failures, with E2E policy honoured per `project_e2e_targeted_until_117`. The Phase 3 evidence-pack (this ticket + 7 evidence markdowns) was assembled in a follow-up commit after the operator caught that it was missing on the portal — corrected within the same session.
+
+## Audit Trail
+
+| Date       | Action                              | Actor       | Notes                                                                                                |
+| ---------- | ----------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------- |
+| 2026-06-01 | Requirement created                 | ostendo-io  | Risk: MEDIUM-HIGH                                                                                    |
+| 2026-06-01 | Implementation plan presented       | Claude Code | 8 ACs + STRIDE + threat model + rollback                                                             |
+| 2026-06-01 | Plan approved                       | ostendo-io  | "Approve as scoped"                                                                                  |
+| 2026-06-01 | TDD red baseline (30 cases) written | Claude Code | 5 model + 13 classifier + 10 router + 2 integration                                                  |
+| 2026-06-01 | Implementation completed            | Claude Code | inbound-service + model + templates lookup + sendTextMessage + lazy-import wire-up                   |
+| 2026-06-01 | AI code reviewed                    | ostendo-io  | Integration PR #229 review                                                                           |
+| 2026-06-01 | Tests passed                        | Claude Code | 30 / 30; full suite 966 / 4 skip / 0 fail                                                            |
+| 2026-06-01 | Integration PR merged               | ostendo-io  | PR #229 → develop (`c3c470d`)                                                                        |
+| 2026-06-01 | CI failed on unrelated vitest GHSA  | —           | npm advisory DB published critical between REQ-055's CI and REQ-056's; Upload Evidence skipped       |
+| 2026-06-01 | Vitest CVE bumped (PR #230)         | ostendo-io  | `chore: bump vitest to 4.1.x` — develop CI passed but attributed to v2026.06.01 (no [REQ-056] tag)   |
+| 2026-06-01 | Attribution PR #231 merged          | ostendo-io  | `[REQ-056]` in subject → derive-release-version.sh step 3 → CI re-uploaded under `--release REQ-056` |
+| 2026-06-01 | Release PR #232 opened              | Claude Code | develop → main; awaiting UAT + Production portal approval                                            |
+| 2026-06-01 | Phase 3 evidence pack assembled     | Claude Code | Caught + corrected by operator note re missing release ticket                                        |
+| 2026-06-01 | Submitted for UAT review            | Claude Code | After this evidence-pack PR merges                                                                   |


### PR DESCRIPTION
## Phase 3 (compile-evidence) bundle for REQ-056

Catches up on `SDLC/3-compile-evidence.md` steps 8 + 9, which were originally skipped — went straight from Phase 2 (implement+test, PR #229) to Phase 4 (release PR, #232). Operator caught the gap: the portal had no reviewable release for REQ-056 because the pending release ticket wasn't on develop.

## What this PR adds

| File | Purpose |
|---|---|
| `compliance/pending-releases/RELEASE-TICKET-REQ-056.md` | Release ticket per Phase 3 step 8 — TESTED-PENDING-SIGN-OFF, links #229/#230/#231/#232, full audit trail. `submit-for-uat-review.sh` requires this exact file to exist. |
| `compliance/evidence/REQ-056/implementation-plan.md` | Phase 3 convention — copy of `compliance/plans/REQ-056/implementation-plan.md`. |
| `compliance/evidence/REQ-056/test-scope.md` | 30 cases mapped to AC1..AC8; out-of-scope items called out. |
| `compliance/evidence/REQ-056/test-plan.md` | AC ↔ test mapping; gate expectations vs actuals. |
| `compliance/evidence/REQ-056/test-execution-summary.md` | Per-file gate outputs + full-suite + eslint + semgrep + audit. |
| `compliance/evidence/REQ-056/security-summary.md` | STRIDE assessment + threat model (STOP regex strictness, NoSQL injection, auto-create-then-opt-out race, persistence-down posture). |
| `compliance/evidence/REQ-056/ai-use-note.md` | What the AI did vs what the human did. |
| `compliance/evidence/REQ-056/ai-prompts.md` | Session prompts + decision points + audit cross-refs. |

## Attribution

Subject doesn't carry `[REQ-056]` in brackets, but body does (and so does the PR title). On merge to develop:
- `derive-release-version.sh` step 3 picks `[REQ-056]` from the merge-commit body → CI's Compliance Evidence Upload workflow attributes to `--release REQ-056`.
- Markdown evidence (release ticket + 7 evidence files) uploads to the portal under REQ-056.
- Portal release status flips `draft` → `uat_review` (per `scripts/submit-for-uat-review.sh` prerequisites: working tree clean + release ticket present + CI gates green — all satisfied).

## Test plan

- [x] No code changes (markdown only — `paths-ignore` skips heavy gates on this push)
- [x] `compliance/pending-releases/RELEASE-TICKET-REQ-056.md` exactly named per the script's `find -maxdepth 1 -name 'RELEASE-TICKET-*.md'` pattern
- [ ] `Compliance Evidence Upload` workflow runs on merge → markdown evidence reaches the portal under `--release REQ-056`
- [ ] Portal release becomes reviewable / `uat_review` status

## Follow-ups (filed upstream this cycle)

- [DevAudit-Installer #95](https://github.com/metasession-dev/DevAudit-Installer/issues/95) — resolver step-4-bis: scan RTM.md for IN PROGRESS rows (zero-ceremony attribution).
- [DevAudit-Installer #96](https://github.com/metasession-dev/DevAudit-Installer/issues/96) — ci.yml: upload Quality Gates evidence on failure too (status=failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)