### PR TITLE
chore: devaudit update to 0.1.29

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,6 @@ jobs:
           - 27017:27017
 
     env:
-
       MONGODB_DB_NAME: wawagardenbar_test
       NEXT_PUBLIC_API_URL: http://localhost:3000/api
       NEXT_PUBLIC_APP_URL: http://localhost:3000
@@ -88,11 +87,13 @@ jobs:
       # ── Gate 1: TypeScript ──
 
       - name: TypeScript Check
+        id: typescript
         run: npx tsc --noEmit
 
       # ── Gate 2: SAST (Semgrep) ──
 
       - name: SAST Scan
+        id: sast
         run: |
           # --output writes the JSON report to the file directly; stderr
           # (progress/metrics/version notices) goes to /dev/null. Using
@@ -118,6 +119,7 @@ jobs:
       # ── Gate 3: Dependency Audit ──
 
       - name: Dependency Audit
+        id: dep-audit
         run: |
           # stderr → /dev/null so warnings can't corrupt the JSON (DevAudit #48)
           npm audit --json > dependency-audit.json 2>/dev/null || true
@@ -202,6 +204,7 @@ jobs:
       # ── Gate 5: Build ──
 
       - name: Build Check
+        id: build
         run: npm run build
         env:
           MONGODB_DB_NAME: wawagardenbar_placeholder
@@ -209,6 +212,29 @@ jobs:
           NEXT_PUBLIC_API_URL: http://localhost:3000/api
           NEXT_PUBLIC_APP_URL: http://localhost:3000
           SESSION_PASSWORD: a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2
+
+      # ── Summarise per-gate outcomes ──
+      #
+      # Runs unconditionally so a failed earlier gate doesn't strand the
+      # outcome of the gates that did run. Step outcomes are one of
+      # `success` / `failure` / `skipped` / `cancelled`. The upload-evidence
+      # job maps these to `passed` / `failed` / `skipped` and sends the
+      # result as `gateStatus=` on each per-gate upload, so the portal can
+      # render a failed gate as failed (with the run artefact) rather than
+      # showing it as missing. DevAudit-Installer#96.
+
+      - name: Summarise gate outcomes
+        if: always()
+        run: |
+          cat > gate-outcomes.json <<EOF
+          {
+            "typescript": "${{ steps.typescript.outcome }}",
+            "sast": "${{ steps.sast.outcome }}",
+            "dependency_audit": "${{ steps.dep-audit.outcome }}",
+            "build": "${{ steps.build.outcome }}"
+          }
+          EOF
+          cat gate-outcomes.json
 
       # ── Upload artifacts ──
 
@@ -224,6 +250,7 @@ jobs:
             e2e-auth-results.json
             playwright-report/
             coverage/coverage-summary.json
+            gate-outcomes.json
             compliance/evidence/*/screenshots/*.png
           retention-days: 90
 
@@ -340,7 +367,11 @@ jobs:
     name: Upload Evidence
     runs-on: ubuntu-latest
     needs: [quality-gates, register-release]
-    if: ${{ !failure() && !cancelled() && vars.DEVAUDIT_BASE_URL != '' }}
+    # `always()` instead of `!failure()` so failed gates still upload their
+    # evidence — `status=failed` is itself the audit trail. `!cancelled()`
+    # still guards against partial state on operator-cancel.
+    # DevAudit-Installer#96.
+    if: ${{ always() && !cancelled() && vars.DEVAUDIT_BASE_URL != '' && needs.register-release.result == 'success' }}
     env:
       DEVAUDIT_BASE_URL: ${{ vars.DEVAUDIT_BASE_URL }}
       DEVAUDIT_API_KEY: ${{ secrets.DEVAUDIT_API_KEY }}
@@ -377,6 +408,32 @@ jobs:
             fi
           }
 
+          # Map step outcomes from gate-outcomes.json (written by the
+          # `Summarise gate outcomes` step) to gateStatus values the
+          # uploader forwards to the portal. Failed gates upload as
+          # gateStatus=failed so the portal can distinguish a gate that
+          # ran-and-failed from one that never ran. DevAudit-Installer#96.
+          gate_status() {
+            case "$1" in
+              success) echo passed ;;
+              failure) echo failed ;;
+              *) echo skipped ;;
+            esac
+          }
+          STATUS_TYPESCRIPT=skipped
+          STATUS_SAST=skipped
+          STATUS_DEPAUDIT=skipped
+          STATUS_BUILD=skipped
+          if [ -f ci-evidence/gate-outcomes.json ]; then
+            STATUS_TYPESCRIPT=$(gate_status "$(jq -r '.typescript // "skipped"' ci-evidence/gate-outcomes.json)")
+            STATUS_SAST=$(gate_status "$(jq -r '.sast // "skipped"' ci-evidence/gate-outcomes.json)")
+            STATUS_DEPAUDIT=$(gate_status "$(jq -r '.dependency_audit // "skipped"' ci-evidence/gate-outcomes.json)")
+            STATUS_BUILD=$(gate_status "$(jq -r '.build // "skipped"' ci-evidence/gate-outcomes.json)")
+            upload gate-outcomes.json \
+              wgb _compliance-docs compliance_document ci-evidence/gate-outcomes.json \
+              --category ci_pipeline ${FLAGS}
+          fi
+
           # Re-generate gate evidence as fallback if artifact download failed
           mkdir -p ci-evidence
           if [ ! -f ci-evidence/sast-results.json ]; then
@@ -399,7 +456,7 @@ jobs:
           if [ -f ci-evidence/sast-results.json ]; then
             upload sast-results.json \
               wgb _compliance-docs sast_report ci-evidence/sast-results.json \
-              --category security_scan ${FLAGS}
+              --category security_scan --gate-status "$STATUS_SAST" ${FLAGS}
           fi
 
           # Upload dependency audit — precise evidence_type=dependency_audit
@@ -407,7 +464,7 @@ jobs:
           if [ -f ci-evidence/dependency-audit.json ]; then
             upload dependency-audit.json \
               wgb _compliance-docs dependency_audit ci-evidence/dependency-audit.json \
-              --category security_scan ${FLAGS}
+              --category security_scan --gate-status "$STATUS_DEPAUDIT" ${FLAGS}
           fi
 
           # Upload E2E test results (ci_pipeline category)

--- a/scripts/derive-release-version.sh
+++ b/scripts/derive-release-version.sh
@@ -13,6 +13,9 @@
 #   4. Pending release ticket on disk: exactly one
 #                                      compliance/pending-releases/RELEASE-TICKET-REQ-XXX.md
 #                                                                    -> REQ-XXX
+#   4-bis. RTM.md IN PROGRESS row:    exactly one tracked REQ marked
+#                                      IN PROGRESS in compliance/RTM.md
+#                                                                    -> REQ-XXX
 #   5. Fallback:                      bare date                      -> v2026.05.17
 #
 # Step 4 (DevAudit-Installer#92) handles `chore:` / `docs:` / `ci:`
@@ -22,6 +25,12 @@
 # ticket on disk is a stronger explicit-operator-state signal than the
 # bare date — when exactly one ticket is open, attribute to it.
 # Multiple open tickets stays ambiguous → bare-date fallback.
+#
+# Step 4-bis (DevAudit-Installer#95) is the zero-ceremony equivalent:
+# RTM.md is the file the operator already maintains as the source of
+# truth for release state. When step 4 finds no ticket and exactly one
+# RTM row is IN PROGRESS, attribute to it. RTM_PATH defaults to
+# compliance/RTM.md and is overridable via env.
 #
 # The id is taken from a bracketed [REQ-XXX] tag (subject or body) or the
 # `Ref:` line — NOT from unbracketed prose (e.g. "target close: REQ-002" must
@@ -80,6 +89,33 @@ if [ -d compliance/pending-releases ]; then
       | head -1 | xargs -n1 basename \
       | sed -E 's/^RELEASE-TICKET-(REQ-[0-9]+)\.md$/\1/'
     exit 0
+  fi
+fi
+
+# 4-bis. RTM.md IN PROGRESS row: when exactly one REQ row in
+# compliance/RTM.md (or $RTM_PATH) is marked IN PROGRESS, attribute the
+# in-flight release to it. Reads the file the operator already
+# maintains so chore/docs/ci sync commits don't need a manually-dropped
+# pending-tickets file. Same exactly-one guard as step 4 — zero or
+# multiple IN PROGRESS rows → ambiguous, fall through.
+# DevAudit-Installer#95.
+RTM_PATH="${RTM_PATH:-compliance/RTM.md}"
+if [ -f "$RTM_PATH" ]; then
+  # Match REQ rows whose status column starts with `IN PROGRESS`.
+  # `\|[[:space:]]+IN PROGRESS` requires a pipe followed by whitespace,
+  # so legend rows (`| \`IN PROGRESS\``) and prose mentions don't match.
+  # Variable padding between REQ-ID and Status (Issue/Risk/Evidence
+  # columns) is fine — only the leading REQ-XXX and the status-cell
+  # marker matter.
+  IN_PROGRESS_REQS=$(grep -E '\|[[:space:]]+IN PROGRESS' "$RTM_PATH" 2>/dev/null \
+    | grep -oE '^\|[[:space:]]*REQ-[0-9]+' \
+    | grep -oE 'REQ-[0-9]+' | sort -u || true)
+  if [ -n "$IN_PROGRESS_REQS" ]; then
+    IN_PROGRESS_COUNT=$(echo "$IN_PROGRESS_REQS" | grep -c .)
+    if [ "$IN_PROGRESS_COUNT" = "1" ]; then
+      echo "$IN_PROGRESS_REQS"
+      exit 0
+    fi
   fi
 fi
 

--- a/scripts/upload-evidence.sh
+++ b/scripts/upload-evidence.sh
@@ -26,6 +26,12 @@
 #                               build / test / compliance / revert) for
 #                               the release row. Unknown values are
 #                               silently dropped server-side.
+#   --gate-status <status>      `passed` / `failed` / `skipped`. Lets the
+#                               portal distinguish a gate that ran-and-
+#                               failed from one that never ran. Forwarded
+#                               as `gateStatus`; unknown values are
+#                               silently dropped server-side.
+#                               DevAudit-Installer#96.
 #
 # Required environment variables:
 #   DEVAUDIT_BASE_URL  e.g. https://meta-comply-production.up.railway.app
@@ -65,6 +71,7 @@ ENVIRONMENT=""
 EVIDENCE_CATEGORY=""
 RELEASE_TITLE=""
 CHANGE_TYPE=""
+GATE_STATUS=""
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -80,6 +87,10 @@ while [ "$#" -gt 0 ]; do
     # unknown change-type values are dropped server-side, not 400'd.
     --release-title) RELEASE_TITLE="$2"; shift 2 ;;
     --change-type) CHANGE_TYPE="$2"; shift 2 ;;
+    # passed/failed/skipped — surfaces failed gates on the portal so
+    # ran-and-failed != never-ran. Unknown values dropped server-side.
+    # DevAudit-Installer#96.
+    --gate-status) GATE_STATUS="$2"; shift 2 ;;
     *) echo "Unknown option: $1"; exit 1 ;;
   esac
 done
@@ -181,6 +192,7 @@ for FILE in "${FILES[@]}"; do
   [ -n "$EVIDENCE_CATEGORY" ] && CURL_ARGS+=(-F "evidenceCategory=${EVIDENCE_CATEGORY}")
   [ -n "$RELEASE_TITLE" ] && CURL_ARGS+=(-F "releaseTitle=${RELEASE_TITLE}")
   [ -n "$CHANGE_TYPE" ] && CURL_ARGS+=(-F "changeType=${CHANGE_TYPE}")
+  [ -n "$GATE_STATUS" ] && CURL_ARGS+=(-F "gateStatus=${GATE_STATUS}")
 
   ATTEMPT=1
   BACKOFF=$INITIAL_BACKOFF_SECONDS

--- a/scripts/validate-commits.sh
+++ b/scripts/validate-commits.sh
@@ -22,14 +22,9 @@ echo "Comparing: $BASE_BRANCH...HEAD"
 echo ""
 
 # Conventional Commit regex: type(optional-scope): description
-#
-# Scope grammar widened (REQ-053 release): the Conventional Commits spec
-# permits any noun-like scope; the previous `[a-zA-Z0-9_-]+` rejected
-# legitimate multi-scope forms like `feat(auth,profile):`, blocking the
-# REQ-053 release. Match anything that's not `)` so commas + slashes are
-# accepted (existing scopes stay valid). Filed upstream as a small
-# DevAudit-Installer follow-up so the next `devaudit update` carries the
-# same widening and the local patch can be removed.
+# Scope accepts anything except `)` so multi-scope subjects like
+# `feat(auth,profile):` and `fix(rewards/expiry):` validate. The closing-paren
+# guard prevents pathological inputs. DevAudit-Installer#93.
 CC_REGEX='^(feat|fix|docs|test|refactor|chore|compliance|security|perf|ci|build|revert)(\([^)]+\))?!?: .+'
 
 COMMITS=$(git log "$BASE_BRANCH"..HEAD --format='%H' || true)


### PR DESCRIPTION
## What

\`devaudit update\` sync from DevAudit-Installer v0.1.29 — three release-pipeline coherence fixes.

### v0.1.29 changes

**\`scripts/validate-commits.sh\`** (devaudit#93)
The local CC_REGEX widening from commit f8b3b29 (\"ci: widen validate-commits.sh CC_REGEX to accept multi-scope subjects\") is now upstream. This sync replaces the local \"REQ-053 release\" comment with the upstream comment referencing DevAudit-Installer#93; the regex itself is identical to what we've been running locally. **No behaviour change — the local patch is now redundant and can be considered fully landed upstream.**

**\`scripts/derive-release-version.sh\`** (devaudit#95)
Adds step-4-bis: scans \`compliance/RTM.md\` for IN PROGRESS rows when steps 1–4 don't resolve. Closes the loop that bit REQ-048 / REQ-052 / REQ-056 — when a \`chore: bump CVE\` commit lands between feature-PR merge and release-PR open and no \`compliance/pending-releases/RELEASE-TICKET-REQ-XXX.md\` has been dropped, the resolver now finds the single IN PROGRESS row in RTM and attributes gate evidence to it. Multiple IN PROGRESS → ambiguous, falls through. \`RTM_PATH\` overridable via env.

**\`.github/workflows/ci.yml\`** + **\`scripts/upload-evidence.sh\`** (devaudit#96)
Failed gates now upload their evidence too. Pre-0.1.29, the REQ-056 dep-audit failure (vitest GHSA UI-server CVE) caused upload-evidence to skip entirely; all five gates showed as \"Missing\" on the portal even though TS/SAST passed. v0.1.29:
- Job \`if:\` switched from \`!failure()\` to \`always() && !cancelled() && needs.register-release.result == 'success'\`.
- New \`Summarise gate outcomes\` step in \`quality-gates\` writes \`gate-outcomes.json\` capturing each gate's \`success\`/\`failure\`/\`skipped\`.
- Each per-gate upload now threads \`--gate-status passed|failed|skipped\` so the portal can distinguish ran-and-failed from never-ran. Backwards compatible — unknown values dropped server-side until the portal grows the schema.

## Verification

- All v0.1.29 markers present (validate-commits #93 ref, derive-release step 4-bis + RTM_PATH, upload-evidence --gate-status, ci.yml Summarise step)

## Risk

LOW — scripts + CI workflow. No runtime / app code touched. The validate-commits.sh change is a no-op (same regex, different comment); the other three are additive on the failure / fix-forward path that didn't exist before. The \`always()\` switch on upload-evidence cannot regress green runs.

Closes devaudit#93, devaudit#95, devaudit#96 (consumer-side rollout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)