### PR TITLE
chore: devaudit update to 0.1.33 — audit-log export in CI

### DIFF
--- a/.github/workflows/compliance-evidence.yml
+++ b/.github/workflows/compliance-evidence.yml
@@ -186,6 +186,38 @@ jobs:
           upload_governance compliance/incident-report.md             incident_report
           upload_governance compliance/governance/incident-report.md  incident_report
 
+          # ── Audit-log export (DevAudit-Installer#98 WS2) ──────────────
+          # Snapshot the portal's audit log for the rolling 90-day window
+          # and upload as `evidence_type=audit_log`. Closes three
+          # framework-coverage clauses on every release:
+          #   - ISO27001.A.8.16 — Monitoring activities
+          #   - EUAIA.Art-12   — Record-keeping (automatic logging)
+          #   - GDPR.Art-32    — Security of processing (audit-log half)
+          #
+          # The portal endpoint defaults to the last 90 days when no
+          # `since`/`until` query params are passed; omit them so the
+          # consumer side stays zero-config. Endpoint shipped in
+          # META-COMPLY PR #413; project-scoped API key (uploader role)
+          # already has read access via `resolveCiUploadAuth`.
+          AUDIT_LOG_FILE="$(mktemp -t audit-log-XXXXXX.json)"
+          if curl -sSf -H "Authorization: Bearer ${DEVAUDIT_API_KEY}" \
+            "${DEVAUDIT_BASE_URL%/}/api/ci/projects/wgb/audit-log/export" \
+            -o "$AUDIT_LOG_FILE"; then
+            echo "Uploading: audit-log.json (audit_log — 90-day window)"
+            bash scripts/upload-evidence.sh \
+              wgb _compliance-docs audit_log "$AUDIT_LOG_FILE" \
+              --category compliance_document ${FLAGS} --release "${DERIVED_RELEASE}" \
+              "${DERIVED_META[@]}" \
+              || echo "Warning: Failed to upload audit-log.json"
+          else
+            # Soft-fail: an export hiccup shouldn't break the rest of the
+            # evidence pipeline. Surfaces as a warning in the workflow log;
+            # the framework-coverage panel will show MISSING for the three
+            # clauses above until the next successful upload.
+            echo "::warning::Audit-log export failed — endpoint unreachable or 4xx/5xx. Three framework-coverage clauses (ISO27001.A.8.16, EUAIA.Art-12, GDPR.Art-32 audit-log half) will stay MISSING until the next run."
+          fi
+          rm -f "$AUDIT_LOG_FILE"
+
           # Helper: emit a `--release-title …` `--change-type …` pair for a given
           # REQ, derived from its pending release-ticket H1 and the most recent
           # commit attributed to that REQ. Empty pair when neither is available.


### PR DESCRIPTION
## What

`devaudit update` sync to v0.1.33 — adds the audit-log export CI step (Closes the consumer side of DevAudit-Installer #98 WS2). Once landed, every release uploads an `evidence_type=audit_log` artefact that closes **three framework-coverage clauses**:

| Clause | Was | Becomes |
|---|---|---|
| ISO27001.A.8.16 — Monitoring activities | MISSING | COVERED |
| EUAIA.Art-12 — Record-keeping | MISSING | COVERED |
| GDPR.Art-32 — Security of processing (audit-log half) | PARTIAL | COVERED |

## Changes in `compliance-evidence.yml`

New step right after the project-level governance docs loop:

```bash
AUDIT_LOG_FILE="$(mktemp -t audit-log-XXXXXX.json)"
if curl -sSf -H "Authorization: Bearer ${DEVAUDIT_API_KEY}" \
  "${DEVAUDIT_BASE_URL%/}/api/ci/projects/<slug>/audit-log/export" \
  -o "$AUDIT_LOG_FILE"; then
  bash scripts/upload-evidence.sh \
    <slug> _compliance-docs audit_log "$AUDIT_LOG_FILE" \
    --category compliance_document ${FLAGS} --release "${DERIVED_RELEASE}" \
    "${DERIVED_META[@]}" \
    || echo "Warning: Failed to upload audit-log.json"
else
  echo "::warning::Audit-log export failed — endpoint unreachable or 4xx/5xx."
fi
rm -f "$AUDIT_LOG_FILE"
```

Omits `since` / `until` query params — META-COMPLY's endpoint defaults to a rolling 90-day window. Zero consumer-side config.

`curl -sSf` returns non-zero on 4xx/5xx; we catch it and warn rather than failing the job. The rest of the evidence pipeline still uploads on a transient endpoint hiccup; the three clauses revert to MISSING on the panel until the next successful run.

## Verification (after merge)

- Next CI run on develop uploads an `audit_log` evidence row.
- Portal's framework-coverage panel on the in-flight release detail flips the three clauses listed above.

## Risk

LOW — one new CI step + soft-fail. No runtime / app code touched. The other workflow files (`ci.yml`, `periodic-review.yml`, `incident-export.yml`) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
