### PR TITLE
fix(contact): mark /contact dynamic to skip static pre-render [REQ-062]

### DIFF
--- a/app/(customer)/contact/page.tsx
+++ b/app/(customer)/contact/page.tsx
@@ -4,6 +4,11 @@ import { Phone, Mail, MessageCircle, Clock } from 'lucide-react';
 import { SettingsService } from '@/services/settings-service';
 import { SupportForm } from '@/components/features/communication/support-form';
 
+// REQ-062 — Force dynamic rendering. SettingsService.getSettings() hits
+// Mongo, so static pre-render at build time fails (no DB available during
+// `next build`). Marking the route dynamic skips the pre-render attempt.
+export const dynamic = 'force-dynamic';
+
 /**
  * @requirement REQ-062 — Contact page (P1 #11).
  *


### PR DESCRIPTION
## Hotfix on top of REQ-062

REQ-062 added \`app/(customer)/contact/page.tsx\` (P1 #11). The page calls \`SettingsService.getSettings()\` at server-render time. Next.js tries to **statically pre-render** server components at build time by default — no DB available during \`next build\` → Railway UAT deploy failed on the release PR check ([PR #262](https://github.com/metasession-dev/wawagardenbar-app/pull/262)).

## Fix

\`export const dynamic = 'force-dynamic'\` on the route so it renders request-time, matching the rewards/profile pages that also read settings.

## Verification

- \`npm run build\` locally — completes cleanly; \`/contact\` shows as \`ƒ (Dynamic)\` in the route summary.
- No other gates affected: tsc clean, vitest unchanged, eslint clean.

Same hotfix shape as REQ-051's DFR fix (small, targeted, ships ahead of the release PR to unblock the cycle).

## Sequencing

Merge this PR → develop CI runs + new build succeeds + Railway UAT deploys → reopen the release PR check (or wait for it to auto-refresh) → all green → merge to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)