### PR TITLE
chore: devaudit update to 0.1.34 — evidenceShot AC + origin tagging

### DIFF
--- a/.claude/skills/e2e-test-engineer/SKILL.md
+++ b/.claude/skills/e2e-test-engineer/SKILL.md
@@ -10,12 +10,14 @@ Maintain or bootstrap a project's e2e and visual regression test suite. Given an
 ## Scope
 
 **In scope**
+
 - End-to-end tests (UI-driven, user-flow level) in any framework.
 - Visual regression tests in any tool.
 - Maintaining an existing test pack — adding, updating, retiring tests.
 - Bootstrapping a new e2e suite when none exists, including framework selection, structure, configuration, a starter smoke test, and (optionally) CI integration.
 
 **Out of scope**
+
 - Unit, component, or API-only tests.
 - Performance, load, or accessibility audits, unless the project's e2e pack already includes them — in which case follow its lead.
 
@@ -29,10 +31,10 @@ Three things must be in hand before designing tests: the **test stack**, the **c
 
 **Detect the test stack** from the repo:
 
-- *E2E framework signals* — `playwright.config.*`, `cypress.config.*`, `wdio.conf.*`, `nightwatch.conf.*`, `codecept.conf.*`, `testcafe.config.*`. Failing that, check `package.json` dependencies for `@playwright/test`, `cypress`, `webdriverio`, `puppeteer`, `selenium-webdriver`, or Python equivalents (`pytest-playwright`, `selenium`, `splinter`).
-- *Test location* — common patterns: `e2e/`, `tests/e2e/`, `cypress/e2e/`, `playwright/`, `test/e2e/`, `__tests__/e2e/`.
-- *Visual regression tool* — Playwright or Cypress built-in snapshots, `cypress-image-snapshot`, `cypress-visual-regression`, `percy`, `applitools-eyes-*`, `chromatic`, `backstop.json`, `loki`, `reg-suit`. If none of these are present, the project doesn't do visual regression and you should only add it if the issue explicitly asks for it.
-- *Run command* — search `package.json` scripts for `e2e`, `test:e2e`, `cy:run`, `pw:test`. Failing that, check `Makefile`, `justfile`, `tox.ini`, `pyproject.toml`, CI config. If still unclear, ask.
+- _E2E framework signals_ — `playwright.config.*`, `cypress.config.*`, `wdio.conf.*`, `nightwatch.conf.*`, `codecept.conf.*`, `testcafe.config.*`. Failing that, check `package.json` dependencies for `@playwright/test`, `cypress`, `webdriverio`, `puppeteer`, `selenium-webdriver`, or Python equivalents (`pytest-playwright`, `selenium`, `splinter`).
+- _Test location_ — common patterns: `e2e/`, `tests/e2e/`, `cypress/e2e/`, `playwright/`, `test/e2e/`, `__tests__/e2e/`.
+- _Visual regression tool_ — Playwright or Cypress built-in snapshots, `cypress-image-snapshot`, `cypress-visual-regression`, `percy`, `applitools-eyes-*`, `chromatic`, `backstop.json`, `loki`, `reg-suit`. If none of these are present, the project doesn't do visual regression and you should only add it if the issue explicitly asks for it.
+- _Run command_ — search `package.json` scripts for `e2e`, `test:e2e`, `cy:run`, `pw:test`. Failing that, check `Makefile`, `justfile`, `tox.ini`, `pyproject.toml`, CI config. If still unclear, ask.
 
 **Detect the issue tracker** so you can read the input issue now and file defect issues later:
 
@@ -77,7 +79,7 @@ The bootstrap workflow:
 
 5. **Lay out the directory structure** for the project's expected scale: a top-level test directory (`e2e/` or whatever the framework's installer chose), with subfolders for specs, fixtures, page objects (or fixture-based equivalent), helpers, and visual specs if applicable. Write the structure as a short tree in your reply so the user can see what was created.
 
-6. **Configure for best practice** — base URL pointing at the project's dev server, retries on CI only, parallel workers, an HTML reporter, trace on first retry, `screenshot: 'only-on-failure'` (failure forensics — see *Evidence vs failure forensics* below for per-AC evidence capture), video retention on failure, and (if the framework supports it) auto-starting the dev server before the suite runs. Specifics per framework are in `references/bootstrap.md`.
+6. **Configure for best practice** — base URL pointing at the project's dev server, retries on CI only, parallel workers, an HTML reporter, trace on first retry, `screenshot: 'only-on-failure'` (failure forensics — see _Evidence vs failure forensics_ below for per-AC evidence capture), video retention on failure, and (if the framework supports it) auto-starting the dev server before the suite runs. Specifics per framework are in `references/bootstrap.md`.
 
 7. **Establish the abstraction pattern** — write one Page Object Model (or one fixture, depending on framework idioms) as a worked example so the change's tests in Phase 5 have a template to follow.
 
@@ -87,7 +89,7 @@ The bootstrap workflow:
 
 10. **Offer a CI job** — write the YAML (or equivalent) for the project's CI system, but **do not commit it without confirmation**. Show it inline first. On a **DevAudit** project, `.github/workflows/ci.yml` is generated and marked do-not-edit-manually — don't hand-edit it; instead drive the E2E gate from `sdlc-config.json`. If the suite must run against a **disposable local database** (the rule on any project with no separate test instance — never test against prod), set `e2e_setup_command` (e.g. `supabase start` + load schema + seed) and `e2e_env` (e.g. `E2E_LOCAL=1`, local coords, a dummy email key) so the gate severs production. See [Local-database E2E in CI](https://github.com/metasession-dev/DevAudit-Installer/blob/main/docs/e2e-local-db-ci.md), then `devaudit update` to regenerate.
 
-    **Upload both artefact shapes.** Playwright writes per-test artefacts to *two* places: `test-results/<spec>-<title>[-retryN]/{trace.zip, video.webm, *.png, error-context.md}` — **spec-named**, human-mappable — and `playwright-report/data/<content-hash>.zip` — **hash-named**, indexed by the HTML report. Ensure the project's CI uploads **both** `playwright-report/` (for the HTML viewer) and `test-results/` (for spec-named traces / videos / error-context). If only one is uploaded, propose a small follow-up PR to add the other — it costs ~80 MB of artefact storage and saves the operator from walking the HTML report's hash index to find a specific trace.
+    **Upload both artefact shapes.** Playwright writes per-test artefacts to _two_ places: `test-results/<spec>-<title>[-retryN]/{trace.zip, video.webm, *.png, error-context.md}` — **spec-named**, human-mappable — and `playwright-report/data/<content-hash>.zip` — **hash-named**, indexed by the HTML report. Ensure the project's CI uploads **both** `playwright-report/` (for the HTML viewer) and `test-results/` (for spec-named traces / videos / error-context). If only one is uploaded, propose a small follow-up PR to add the other — it costs ~80 MB of artefact storage and saves the operator from walking the HTML report's hash index to find a specific trace.
 
 11. **Write a short README** in the test directory explaining structure, how to run, how to add new tests, and how to update visual baselines. Future contributors (and the skill itself, on next invocation) will thank you.
 
@@ -107,11 +109,11 @@ You cannot write the right tests without understanding what changed and why. Spe
 
 3. **Read the surrounding app** enough to know how a real user reaches the changed area. Look at routing, navigation, and the one or two most adjacent features.
 
-4. **Write a short mental model** in your reply: *trigger → new behaviour → expected outcomes → likely side-effects*. If anything is ambiguous, ask the user before designing scenarios. Guesses here cascade into bad tests.
+4. **Write a short mental model** in your reply: _trigger → new behaviour → expected outcomes → likely side-effects_. If anything is ambiguous, ask the user before designing scenarios. Guesses here cascade into bad tests.
 
 ### Phase 3 — Design scenarios
 
-The goal is the *minimum* set of scenarios that, if they all pass, would give a reasonable person high confidence the change works as intended and hasn't broken adjacent functionality. "Minimum" is load-bearing: e2e tests are slow to run and expensive to maintain, and a bloated suite gets ignored.
+The goal is the _minimum_ set of scenarios that, if they all pass, would give a reasonable person high confidence the change works as intended and hasn't broken adjacent functionality. "Minimum" is load-bearing: e2e tests are slow to run and expensive to maintain, and a bloated suite gets ignored.
 
 Derive scenarios from these sources, in this order:
 
@@ -127,7 +129,7 @@ Derive scenarios from these sources, in this order:
 
 Resist padding. A new endpoint doesn't need a test that re-verifies login if login is already covered. Match the project's existing depth — if it covers one happy path per feature, don't add six.
 
-For each scenario, write a one-line description. Present the full grouped list to the user before writing any code: *"Here's the coverage I'd propose — anything to add or drop?"*
+For each scenario, write a one-line description. Present the full grouped list to the user before writing any code: _"Here's the coverage I'd propose — anything to add or drop?"_
 
 ### Phase 4 — Reconcile with existing tests
 
@@ -145,6 +147,7 @@ For the area touched by the change, look at what's already there.
 3. **Needs updating** — existing tests where the scenario is still valid but selectors, routes, or assertions have shifted.
 
 Present three lists to the user:
+
 - **To add** — new scenarios not already covered.
 - **To update** — existing tests needing adjustment.
 - **To delete** — genuinely obsolete tests, each with a one-line rationale.
@@ -162,6 +165,7 @@ Write the tests in the project's existing style.
 - **Check `references/common-patterns.md` before writing role-based locators** for component-library UI (shadcn/ui, Radix, MUI, etc.). A short appendix of known framework × library gotchas — `CardTitle` is a `<div>` not a heading; Radix `<Select>` renders two `role="combobox"` nodes; Next.js `<Link>` clicks don't fire network requests — saves a round-trip through a failing selector each time.
 
 For **visual regression** specifically:
+
 - New tests need baseline images. Generate them, but **do not auto-approve** — surface them for the user to verify before they're committed.
 - Use the project's existing breakpoints, viewports, and element-masking conventions.
 
@@ -176,7 +180,7 @@ Run the suite. Strategy:
 3. **For CI-driven verification, ensure the workflow accepts a subset input.** A `workflow_dispatch.inputs.specs` (or equivalent) lets a developer fire a scoped run without local infrastructure. Recommend setting this up if the project doesn't have it — the speed-up (~5–10 min vs ~30–60 min) is the difference between a tractable loop and a hated one.
 4. **For visual regression**, run the project's normal comparison mode against existing baselines.
 
-Triage every failure into one of these buckets *before* taking any action:
+Triage every failure into one of these buckets _before_ taking any action:
 
 **0. Read the page snapshot first.** Modern Playwright writes `test-results/<spec>-<title>[-retryN]/error-context.md` — a markdown accessibility-tree snapshot of the page at failure time. It's enough to triage selector / role / wait-condition failures without extracting the trace zip. Reach for the trace only when the snapshot is ambiguous (e.g. the failure depends on a transition or a network race the snapshot can't show).
 
@@ -191,7 +195,21 @@ Then bucket each failure:
 - **Visual diff — intended** — the snapshot changed because the change intentionally changed the UI. Update the baseline and surface it for user approval.
 - **Visual diff — unintended** — a snapshot changed somewhere the change shouldn't have affected. File it as a regression.
 
-**Then check for missed requirements.** For each numbered acceptance criterion from Phase 2, confirm at least one *passing* test covers it. An AC with no passing test — because no test was written, or because the test fails — is a missed requirement. File it.
+**Then check for missed requirements.** For each numbered acceptance criterion from Phase 2, confirm at least one _passing_ test covers it. An AC with no passing test — because no test was written, or because the test fails — is a missed requirement. File it.
+
+### Phase 7 — Regression-pack handoff
+
+After Phase 6 succeeds — green run, all ACs proved, defects filed for anything missing — the new spec(s) you authored move into the project's regression pack. There is **no separate graduation step**. The pack is defined as:
+
+> **Every `*.spec.ts` (and `*.spec.tsx`) under `tests/e2e/` or `e2e/`.**
+
+There is no `regression/` sub-directory, no `@regression` tag, no manifest file. Being committed and merged to `develop` _is_ the graduation step. Once that happens:
+
+1. The next CI run (on this branch's PR, or on `develop` after merge) executes the new spec alongside every existing one.
+2. The evidenceShot helper sees `process.env.E2E_NEW_SPECS` (computed by CI as `git diff --diff-filter=A <merge-base>...HEAD`) and tags this branch's captures as `origin: 'feature'`.
+3. Post-merge, develop runs see an empty `E2E_NEW_SPECS` and tag every capture as `origin: 'regression'`. The original feature-branch captures stay tagged `feature` as the historical proof of original landing; subsequent develop runs accumulate `regression` captures alongside.
+
+You don't need to do anything explicit for this step — it's a property of the pipeline, not an action. Surface it in the final report so the reviewer knows the new tests are now load-bearing for every future release.
 
 ### Filing defects
 
@@ -199,7 +217,7 @@ Use whatever tracker integration you found in Phase 1: `gh issue create`, `glab 
 
 Each filed issue needs:
 
-- **Title** — short, specific, describes the symptom not the cause. *"Filter by status shows zero results when status=pending"*, not *"Filter broken"*.
+- **Title** — short, specific, describes the symptom not the cause. _"Filter by status shows zero results when status=pending"_, not _"Filter broken"_.
 - **Steps to reproduce** — numbered, minimal, exact.
 - **Expected vs actual** — on separate lines, no ambiguity.
 - **Environment** — branch, commit SHA, test command, browser/viewport if relevant.
@@ -234,7 +252,7 @@ import { evidenceShot } from './helpers/evidence';
 test('AC1: edit dialog opens with fields pre-filled', async ({ page }) => {
   await openEditDialog(page, item.id);
   await expect(dialog.locator('#name')).toHaveValue(item.name);
-  await evidenceShot(page, 'REQ-037', 'AC1-edit-dialog-prefilled');
+  await evidenceShot(page, 'REQ-037', 1, 'edit-dialog-prefilled');
   // ...rest of test
 });
 ```
@@ -242,11 +260,14 @@ test('AC1: edit dialog opens with fields pre-filled', async ({ page }) => {
 **Discipline:**
 
 - Call `evidenceShot` **immediately after** the AC-proving assertion, before navigating, closing dialogs, or any further interaction.
-- Slug as `AC<n>-<what-this-proves>` — the filename documents the claim.
+- AC number is a separate argument (`ac: number`) — the helper composes the filename `REQ-XXX-AC<n>-<slug>.png`. The slug describes what the screenshot proves (`edit-dialog-prefilled`), NOT the AC number.
+- Slug is kebab-case lowercase (`[a-z0-9-]+`). Capitalised slugs, underscores, or spaces throw.
 - One screenshot per AC, not per test.
 - Failure forensics stays untouched (`screenshot: 'only-on-failure'` + `trace: 'on-first-retry'`).
 
-The helper is shipped automatically into `e2e/helpers/evidence.ts` by the SDLC sync (node-stack consumers). Output lands at `compliance/evidence/<REQ-ID>/screenshots/<slug>.png` — commit these PNGs as part of the evidence pack so reviewers can corroborate the test-plan AC mapping.
+The helper is shipped automatically into `e2e/helpers/evidence.ts` by the SDLC sync (node-stack consumers). Output lands at `compliance/evidence/<REQ-ID>/screenshots/REQ-XXX-AC<n>-<slug>.png` — commit these PNGs as part of the evidence pack so reviewers can corroborate the test-plan AC mapping.
+
+The helper also writes a sidecar `<filename>.meta.json` containing the AC mapping + the screenshot's **origin** — `feature` if the spec was added on the current branch, `regression` if the spec already existed. The consumer's CI passes `origin` through to the DevAudit portal as evidence metadata so the release-detail page can render feature vs regression captures distinctly. Auto-detected from `process.env.E2E_NEW_SPECS` — no manual tagging required.
 
 The canonical helper source lives at `references/evidence.ts` in this skill.
 

--- a/.claude/skills/e2e-test-engineer/references/evidence-shot-core.ts
+++ b/.claude/skills/e2e-test-engineer/references/evidence-shot-core.ts
@@ -1,0 +1,74 @@
+/**
+ * Pure helpers backing `evidenceShot`. Kept Playwright-free so they
+ * can be unit-tested without pulling `@playwright/test` into the
+ * installer repo. The thin wrapper in `evidence.ts` does the Page
+ * screenshot + fs writes around these.
+ */
+
+export type EvidenceShotOrigin = 'feature' | 'regression';
+
+export interface EvidenceShotSidecar {
+  readonly origin: EvidenceShotOrigin;
+  readonly reqId: string;
+  readonly ac: number;
+  readonly slug: string;
+  readonly specFile: string;
+  readonly capturedAt: string;
+}
+
+const REQ_ID_RE = /^REQ-[A-Z0-9-]+$/;
+const SLUG_RE = /^[a-z0-9-]+$/;
+
+export function validateEvidenceShotInputs(
+  reqId: string,
+  ac: number,
+  slug: string
+): void {
+  if (!REQ_ID_RE.test(reqId)) {
+    throw new Error(
+      `evidenceShot: invalid reqId "${reqId}" (must match ${REQ_ID_RE})`
+    );
+  }
+  if (!Number.isInteger(ac) || ac <= 0) {
+    throw new Error(
+      `evidenceShot: invalid ac "${ac}" (must be a positive integer)`
+    );
+  }
+  if (!SLUG_RE.test(slug)) {
+    throw new Error(
+      `evidenceShot: invalid slug "${slug}" (must match ${SLUG_RE} — kebab-case, no AC prefix)`
+    );
+  }
+}
+
+export function composeScreenshotFilename(
+  reqId: string,
+  ac: number,
+  slug: string
+): string {
+  return `${reqId}-AC${ac}-${slug}.png`;
+}
+
+/**
+ * Auto-detect origin from `process.env.E2E_NEW_SPECS` — the consumer
+ * globalSetup writes the newline-delimited list of spec files added
+ * on the current branch (`git diff --diff-filter=A`). If the calling
+ * spec appears in that list, it's `feature`; otherwise `regression`.
+ *
+ * Empty / missing env (typical for post-merge develop runs) → every
+ * capture is `regression`, which is the correct semantic outcome.
+ */
+export function autoDetectEvidenceShotOrigin(
+  specFile: string,
+  newSpecsEnv: string | undefined
+): EvidenceShotOrigin {
+  const list = (newSpecsEnv ?? '').trim();
+  if (list.length === 0) return 'regression';
+  const newSpecs = new Set(
+    list
+      .split(/\r?\n/)
+      .map((s) => s.trim())
+      .filter(Boolean)
+  );
+  return newSpecs.has(specFile) ? 'feature' : 'regression';
+}

--- a/.claude/skills/e2e-test-engineer/references/evidence.ts
+++ b/.claude/skills/e2e-test-engineer/references/evidence.ts
@@ -1,40 +1,105 @@
+import fs from 'fs';
 import path from 'path';
-import { type Page } from '@playwright/test';
+import { test, type Page } from '@playwright/test';
+import {
+  autoDetectEvidenceShotOrigin,
+  composeScreenshotFilename,
+  validateEvidenceShotInputs,
+  type EvidenceShotOrigin,
+  type EvidenceShotSidecar,
+} from './evidence-shot-core';
 
-const SLUG_RE = /^[A-Za-z0-9_-]+$/;
+export type { EvidenceShotOrigin };
+
+export interface EvidenceShotOptions {
+  /** Capture the full page rather than the viewport. Default: true. */
+  readonly fullPage?: boolean;
+  /**
+   * Override the auto-detected origin. By default the helper consults
+   * `process.env.E2E_NEW_SPECS` — set by the consumer's Playwright
+   * `globalSetup` step in CI — and tags the screenshot `feature` if
+   * the calling spec's file appears in that list, else `regression`.
+   */
+  readonly origin?: EvidenceShotOrigin;
+}
 
 /**
- * Write a per-assertion screenshot into the requirement's evidence pack.
+ * Write a per-AC behavioural-proof screenshot into the requirement's
+ * evidence pack.
  *
  * Call this AT the assertion that proves the AC, before any further
  * interaction or navigation. The PNG is committed as part of the
  * evidence pack and used by reviewers to corroborate the test-plan
  * AC mapping.
  *
- * Output path: `compliance/evidence/<reqId>/screenshots/<slug>.png`
+ * Filename: `REQ-XXX-AC<n>-<slug>.png`
+ * Output path: `compliance/evidence/<reqId>/screenshots/<filename>`
+ *
+ * The helper also writes a sidecar `<filename>.meta.json` containing
+ * `{ origin, reqId, ac, slug, specFile, capturedAt }`. The consumer's
+ * CI upload step reads the sidecar and passes `origin` as evidence
+ * metadata to the portal so the release-detail page can tell feature
+ * captures apart from regression-pack reruns.
  *
  * @example
  *   await expect(dialog.locator('#name')).toHaveValue(item.name);
- *   await evidenceShot(page, 'REQ-037', 'AC1-edit-dialog-prefilled');
+ *   await evidenceShot(page, 'REQ-037', 1, 'edit-dialog-prefilled');
+ *
+ * @param page Playwright Page
+ * @param reqId `REQ-` prefixed requirement id (e.g. `REQ-037`)
+ * @param ac AC number — mandatory; every screenshot proves one AC
+ * @param slug kebab-case descriptive slug (no `AC<n>-` prefix; the
+ *             helper composes it from `ac`)
  */
 export async function evidenceShot(
   page: Page,
   reqId: string,
+  ac: number,
   slug: string,
-  opts: { fullPage?: boolean } = {},
+  opts: EvidenceShotOptions = {}
 ): Promise<void> {
-  if (!SLUG_RE.test(reqId)) {
-    throw new Error(`evidenceShot: invalid reqId "${reqId}" (must match ${SLUG_RE})`);
-  }
-  if (!SLUG_RE.test(slug)) {
-    throw new Error(`evidenceShot: invalid slug "${slug}" (must match ${SLUG_RE})`);
-  }
-  const out = path.join(
+  validateEvidenceShotInputs(reqId, ac, slug);
+  const fileName = composeScreenshotFilename(reqId, ac, slug);
+  const dir = path.join(
     process.cwd(),
     'compliance/evidence',
     reqId,
-    'screenshots',
-    `${slug}.png`,
+    'screenshots'
   );
-  await page.screenshot({ path: out, fullPage: opts.fullPage ?? true });
+  const pngPath = path.join(dir, fileName);
+  const sidecarPath = `${pngPath}.meta.json`;
+
+  await page.screenshot({ path: pngPath, fullPage: opts.fullPage ?? true });
+
+  const specFile = resolveSpecFile();
+  const origin =
+    opts.origin ??
+    autoDetectEvidenceShotOrigin(specFile, process.env.E2E_NEW_SPECS);
+  const sidecar: EvidenceShotSidecar = {
+    origin,
+    reqId,
+    ac,
+    slug,
+    specFile,
+    capturedAt: new Date().toISOString(),
+  };
+  await fs.promises.writeFile(
+    sidecarPath,
+    `${JSON.stringify(sidecar, null, 2)}\n`,
+    'utf8'
+  );
+}
+
+/**
+ * Test-info gives us the absolute spec path. Make it repo-relative so
+ * it survives serialisation into the sidecar JSON + the CI's git diff
+ * comparison list.
+ */
+function resolveSpecFile(): string {
+  try {
+    const info = test.info();
+    return path.relative(process.cwd(), info.file);
+  } catch {
+    return 'unknown';
+  }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history so the "new specs on this branch" calculation
+          # (E2E_NEW_SPECS, below) can do a real diff against the merge
+          # base — Playwright's evidenceShot helper reads that env var to
+          # tag each captured screenshot as feature vs regression.
+          fetch-depth: 0
 
       # ── Cached installs (skip if already present on self-hosted runner) ──
 
@@ -182,6 +188,32 @@ jobs:
       - name: Wait for dev server
         run: npx wait-on http://localhost:3000 --timeout 120000
 
+      # Compute the set of e2e spec files added on this branch (relative
+      # to the merge base). The evidenceShot helper in the consumer's
+      # tests reads E2E_NEW_SPECS at capture time and tags each screenshot
+      # `origin=feature` when its spec appears in the list, else
+      # `origin=regression`. On main / develop (post-merge) the diff is
+      # empty and every capture is `regression`, which is the intended
+      # behaviour. Newline-delimited; relative paths.
+      - name: Compute new-spec list for E2E origin tagging
+        run: |
+          BASE_REF="${{ github.base_ref || github.event.repository.default_branch || 'main' }}"
+          BASE_SHA=$(git merge-base "origin/${BASE_REF}" HEAD 2>/dev/null || git rev-parse HEAD)
+          NEW_SPECS=$(git diff --name-only --diff-filter=A "${BASE_SHA}...HEAD" \
+            -- 'tests/e2e/**/*.spec.ts' 'tests/e2e/**/*.spec.tsx' \
+               'e2e/**/*.spec.ts' 'e2e/**/*.spec.tsx' 2>/dev/null || true)
+          {
+            echo "E2E_NEW_SPECS<<EOF"
+            echo "$NEW_SPECS"
+            echo "EOF"
+          } >> "$GITHUB_ENV"
+          if [ -n "$NEW_SPECS" ]; then
+            echo "New e2e specs on this branch (origin=feature for captures):"
+            echo "$NEW_SPECS" | sed 's/^/  /'
+          else
+            echo "No new e2e specs detected — all captures will tag origin=regression."
+          fi
+
       - name: E2E Tests
         env:
           # PLAYWRIGHT_JSON_OUTPUT_NAME makes the json reporter write straight
@@ -252,6 +284,7 @@ jobs:
             coverage/coverage-summary.json
             gate-outcomes.json
             compliance/evidence/*/screenshots/*.png
+            compliance/evidence/*/screenshots/*.png.meta.json
           retention-days: 90
 
   # ──────────────────────────────────────────────
@@ -547,16 +580,32 @@ jobs:
               [ -n "$REQ_TITLE" ] && REQ_META+=(--release-title "$REQ_TITLE")
               [ -n "$REQ_CT" ] && REQ_META+=(--change-type "$REQ_CT")
               for PNG in "${SHOTS[@]}"; do
-                # The folder is the (SRS) requirement id, the basename is the AC
-                # slug (ACn-…). Upload as <srs-req>-<slug>.png so the reviewer can
-                # see which requirement/AC each image proves and names don't collide.
-                SRS_REQ="$(basename "$(dirname "$(dirname "$PNG")")")"
-                NAMED="${SHOT_TMP}/${SRS_REQ}-$(basename "$PNG")"
+                # The basename is the canonical evidenceShot filename
+                # `REQ-XXX-AC<n>-<slug>.png`. The portal validates this
+                # shape on upload — anything else is rejected with 400.
+                BASE="$(basename "$PNG")"
+                NAMED="${SHOT_TMP}/${BASE}"
                 cp "$PNG" "$NAMED" 2>/dev/null || continue
+
+                # Read the sidecar JSON (`<png>.meta.json`) written by the
+                # evidenceShot helper. Pull `origin` out so the portal
+                # render can tell feature vs regression captures apart.
+                # Sidecar missing → upload with no origin metadata; the
+                # portal renders those as "unknown" until consumers re-
+                # onboard via `devaudit update`.
+                ORIGIN_META=()
+                if [ -f "${PNG}.meta.json" ]; then
+                  ORIGIN=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('origin',''))" "${PNG}.meta.json" 2>/dev/null || true)
+                  if [ "$ORIGIN" = "feature" ] || [ "$ORIGIN" = "regression" ]; then
+                    ORIGIN_META+=(--meta-key "origin=${ORIGIN}")
+                  fi
+                fi
+
                 bash scripts/upload-evidence.sh \
                   wgb "$REQ" screenshot "$NAMED" \
                   --category test_report ${FLAGS} --release "$REQ" \
                   "${REQ_META[@]}" \
+                  "${ORIGIN_META[@]}" \
                   || echo "::warning::evidence screenshot upload failed: ${PNG} -> ${REQ}"
               done
             done

--- a/e2e/helpers/evidence-shot-core.ts
+++ b/e2e/helpers/evidence-shot-core.ts
@@ -1,0 +1,74 @@
+/**
+ * Pure helpers backing `evidenceShot`. Kept Playwright-free so they
+ * can be unit-tested without pulling `@playwright/test` into the
+ * installer repo. The thin wrapper in `evidence.ts` does the Page
+ * screenshot + fs writes around these.
+ */
+
+export type EvidenceShotOrigin = 'feature' | 'regression';
+
+export interface EvidenceShotSidecar {
+  readonly origin: EvidenceShotOrigin;
+  readonly reqId: string;
+  readonly ac: number;
+  readonly slug: string;
+  readonly specFile: string;
+  readonly capturedAt: string;
+}
+
+const REQ_ID_RE = /^REQ-[A-Z0-9-]+$/;
+const SLUG_RE = /^[a-z0-9-]+$/;
+
+export function validateEvidenceShotInputs(
+  reqId: string,
+  ac: number,
+  slug: string
+): void {
+  if (!REQ_ID_RE.test(reqId)) {
+    throw new Error(
+      `evidenceShot: invalid reqId "${reqId}" (must match ${REQ_ID_RE})`
+    );
+  }
+  if (!Number.isInteger(ac) || ac <= 0) {
+    throw new Error(
+      `evidenceShot: invalid ac "${ac}" (must be a positive integer)`
+    );
+  }
+  if (!SLUG_RE.test(slug)) {
+    throw new Error(
+      `evidenceShot: invalid slug "${slug}" (must match ${SLUG_RE} — kebab-case, no AC prefix)`
+    );
+  }
+}
+
+export function composeScreenshotFilename(
+  reqId: string,
+  ac: number,
+  slug: string
+): string {
+  return `${reqId}-AC${ac}-${slug}.png`;
+}
+
+/**
+ * Auto-detect origin from `process.env.E2E_NEW_SPECS` — the consumer
+ * globalSetup writes the newline-delimited list of spec files added
+ * on the current branch (`git diff --diff-filter=A`). If the calling
+ * spec appears in that list, it's `feature`; otherwise `regression`.
+ *
+ * Empty / missing env (typical for post-merge develop runs) → every
+ * capture is `regression`, which is the correct semantic outcome.
+ */
+export function autoDetectEvidenceShotOrigin(
+  specFile: string,
+  newSpecsEnv: string | undefined
+): EvidenceShotOrigin {
+  const list = (newSpecsEnv ?? '').trim();
+  if (list.length === 0) return 'regression';
+  const newSpecs = new Set(
+    list
+      .split(/\r?\n/)
+      .map((s) => s.trim())
+      .filter(Boolean)
+  );
+  return newSpecs.has(specFile) ? 'feature' : 'regression';
+}

--- a/e2e/helpers/evidence.ts
+++ b/e2e/helpers/evidence.ts
@@ -1,40 +1,105 @@
+import fs from 'fs';
 import path from 'path';
-import { type Page } from '@playwright/test';
+import { test, type Page } from '@playwright/test';
+import {
+  autoDetectEvidenceShotOrigin,
+  composeScreenshotFilename,
+  validateEvidenceShotInputs,
+  type EvidenceShotOrigin,
+  type EvidenceShotSidecar,
+} from './evidence-shot-core';
 
-const SLUG_RE = /^[A-Za-z0-9_-]+$/;
+export type { EvidenceShotOrigin };
+
+export interface EvidenceShotOptions {
+  /** Capture the full page rather than the viewport. Default: true. */
+  readonly fullPage?: boolean;
+  /**
+   * Override the auto-detected origin. By default the helper consults
+   * `process.env.E2E_NEW_SPECS` — set by the consumer's Playwright
+   * `globalSetup` step in CI — and tags the screenshot `feature` if
+   * the calling spec's file appears in that list, else `regression`.
+   */
+  readonly origin?: EvidenceShotOrigin;
+}
 
 /**
- * Write a per-assertion screenshot into the requirement's evidence pack.
+ * Write a per-AC behavioural-proof screenshot into the requirement's
+ * evidence pack.
  *
  * Call this AT the assertion that proves the AC, before any further
  * interaction or navigation. The PNG is committed as part of the
  * evidence pack and used by reviewers to corroborate the test-plan
  * AC mapping.
  *
- * Output path: `compliance/evidence/<reqId>/screenshots/<slug>.png`
+ * Filename: `REQ-XXX-AC<n>-<slug>.png`
+ * Output path: `compliance/evidence/<reqId>/screenshots/<filename>`
+ *
+ * The helper also writes a sidecar `<filename>.meta.json` containing
+ * `{ origin, reqId, ac, slug, specFile, capturedAt }`. The consumer's
+ * CI upload step reads the sidecar and passes `origin` as evidence
+ * metadata to the portal so the release-detail page can tell feature
+ * captures apart from regression-pack reruns.
  *
  * @example
  *   await expect(dialog.locator('#name')).toHaveValue(item.name);
- *   await evidenceShot(page, 'REQ-037', 'AC1-edit-dialog-prefilled');
+ *   await evidenceShot(page, 'REQ-037', 1, 'edit-dialog-prefilled');
+ *
+ * @param page Playwright Page
+ * @param reqId `REQ-` prefixed requirement id (e.g. `REQ-037`)
+ * @param ac AC number — mandatory; every screenshot proves one AC
+ * @param slug kebab-case descriptive slug (no `AC<n>-` prefix; the
+ *             helper composes it from `ac`)
  */
 export async function evidenceShot(
   page: Page,
   reqId: string,
+  ac: number,
   slug: string,
-  opts: { fullPage?: boolean } = {},
+  opts: EvidenceShotOptions = {}
 ): Promise<void> {
-  if (!SLUG_RE.test(reqId)) {
-    throw new Error(`evidenceShot: invalid reqId "${reqId}" (must match ${SLUG_RE})`);
-  }
-  if (!SLUG_RE.test(slug)) {
-    throw new Error(`evidenceShot: invalid slug "${slug}" (must match ${SLUG_RE})`);
-  }
-  const out = path.join(
+  validateEvidenceShotInputs(reqId, ac, slug);
+  const fileName = composeScreenshotFilename(reqId, ac, slug);
+  const dir = path.join(
     process.cwd(),
     'compliance/evidence',
     reqId,
-    'screenshots',
-    `${slug}.png`,
+    'screenshots'
   );
-  await page.screenshot({ path: out, fullPage: opts.fullPage ?? true });
+  const pngPath = path.join(dir, fileName);
+  const sidecarPath = `${pngPath}.meta.json`;
+
+  await page.screenshot({ path: pngPath, fullPage: opts.fullPage ?? true });
+
+  const specFile = resolveSpecFile();
+  const origin =
+    opts.origin ??
+    autoDetectEvidenceShotOrigin(specFile, process.env.E2E_NEW_SPECS);
+  const sidecar: EvidenceShotSidecar = {
+    origin,
+    reqId,
+    ac,
+    slug,
+    specFile,
+    capturedAt: new Date().toISOString(),
+  };
+  await fs.promises.writeFile(
+    sidecarPath,
+    `${JSON.stringify(sidecar, null, 2)}\n`,
+    'utf8'
+  );
+}
+
+/**
+ * Test-info gives us the absolute spec path. Make it repo-relative so
+ * it survives serialisation into the sidecar JSON + the CI's git diff
+ * comparison list.
+ */
+function resolveSpecFile(): string {
+  try {
+    const info = test.info();
+    return path.relative(process.cwd(), info.file);
+  } catch {
+    return 'unknown';
+  }
 }

--- a/e2e/smoke/customer-auth.spec.ts
+++ b/e2e/smoke/customer-auth.spec.ts
@@ -26,29 +26,38 @@ test.describe('Customer auth — passwordless SMS PIN @smoke', () => {
     await expect(page.locator('#pin')).toBeVisible({ timeout: 15000 });
   }
 
-  test.fixme('REQ-AUTHC-001: SMS PIN login creates a session', async ({ page }) => {
-    const { phone, digits } = uniquePhone();
-    await requestSmsPin(page, phone);
+  test.fixme(
+    'REQ-AUTHC-001: SMS PIN login creates a session',
+    async ({ page }) => {
+      const { phone, digits } = uniquePhone();
+      await requestSmsPin(page, phone);
 
-    const pin = await getVerificationPinByPhone(digits);
-    expect(pin, 'a verification PIN should be stored for the customer').toMatch(/^\d{4}$/);
+      const pin = await getVerificationPinByPhone(digits);
+      expect(
+        pin,
+        'a verification PIN should be stored for the customer'
+      ).toMatch(/^\d{4}$/);
 
-    await page.fill('#pin', pin as string);
-    await evidenceShot(page, 'REQ-007', 'AUTHC-001-pin-entered');
-    await page.getByRole('button', { name: /verify & login/i }).click();
-    await expect(page).not.toHaveURL(/\/login(\?|$)/, { timeout: 15000 });
-  });
+      await page.fill('#pin', pin as string);
+      await evidenceShot(page, 'REQ-007', 1, 'authc-001-pin-entered');
+      await page.getByRole('button', { name: /verify & login/i }).click();
+      await expect(page).not.toHaveURL(/\/login(\?|$)/, { timeout: 15000 });
+    }
+  );
 
-  test.fixme('REQ-AUTHC-002: wrong PIN is rejected, no session', async ({ page }) => {
-    const { phone, digits } = uniquePhone();
-    await requestSmsPin(page, phone);
+  test.fixme(
+    'REQ-AUTHC-002: wrong PIN is rejected, no session',
+    async ({ page }) => {
+      const { phone, digits } = uniquePhone();
+      await requestSmsPin(page, phone);
 
-    const real = (await getVerificationPinByPhone(digits)) ?? '1234';
-    const wrong = String((Number(real) + 1) % 10000).padStart(4, '0');
+      const real = (await getVerificationPinByPhone(digits)) ?? '1234';
+      const wrong = String((Number(real) + 1) % 10000).padStart(4, '0');
 
-    await page.fill('#pin', wrong);
-    await page.getByRole('button', { name: /verify & login/i }).click();
-    await expect(page.locator('#pin')).toBeVisible();
-    await expect(page).toHaveURL(/\/login(\?|$)/);
-  });
+      await page.fill('#pin', wrong);
+      await page.getByRole('button', { name: /verify & login/i }).click();
+      await expect(page.locator('#pin')).toBeVisible();
+      await expect(page).toHaveURL(/\/login(\?|$)/);
+    }
+  );
 });

--- a/scripts/upload-evidence.sh
+++ b/scripts/upload-evidence.sh
@@ -72,6 +72,11 @@ EVIDENCE_CATEGORY=""
 RELEASE_TITLE=""
 CHANGE_TYPE=""
 GATE_STATUS=""
+# Repeatable `--meta-key key=value` accumulator. Each pair gets merged
+# into the metadata JSON sent to the portal. Used by the screenshot
+# upload loop to pass `origin=feature|regression` from the per-PNG
+# sidecar JSON written by the evidenceShot helper.
+META_KEYS=()
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -91,6 +96,17 @@ while [ "$#" -gt 0 ]; do
     # ran-and-failed != never-ran. Unknown values dropped server-side.
     # DevAudit-Installer#96.
     --gate-status) GATE_STATUS="$2"; shift 2 ;;
+    # --meta-key key=value (repeatable). Merged into the metadata JSON
+    # before posting. Validates the `key=value` shape; rejects bare
+    # keys without `=`.
+    --meta-key)
+      if [[ "$2" != *=* ]]; then
+        echo "Error: --meta-key requires key=value (got: $2)"
+        exit 1
+      fi
+      META_KEYS+=("$2")
+      shift 2
+      ;;
     *) echo "Unknown option: $1"; exit 1 ;;
   esac
 done
@@ -118,24 +134,27 @@ fi
 DEVAUDIT_BASE_URL="${DEVAUDIT_BASE_URL%/}"
 
 # --- Build metadata JSON ---
-METADATA="{}"
-if [ -n "$GIT_SHA" ] || [ -n "$CI_RUN_ID" ] || [ -n "$BRANCH" ]; then
-  METADATA="{"
-  FIRST=true
-  if [ -n "$GIT_SHA" ]; then
-    METADATA="${METADATA}\"gitSha\":\"${GIT_SHA}\""
-    FIRST=false
-  fi
-  if [ -n "$CI_RUN_ID" ]; then
-    [ "$FIRST" = false ] && METADATA="${METADATA},"
-    METADATA="${METADATA}\"ciRunId\":\"${CI_RUN_ID}\""
-    FIRST=false
-  fi
-  if [ -n "$BRANCH" ]; then
-    [ "$FIRST" = false ] && METADATA="${METADATA},"
-    METADATA="${METADATA}\"branch\":\"${BRANCH}\""
-  fi
-  METADATA="${METADATA}}"
+# Assemble entries first; only emit `{ ... }` if at least one field is
+# set. Each entry is a `"key":"value"` JSON pair with the value
+# json-escaped (quotes + backslashes).
+json_escape() {
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+META_ENTRIES=()
+[ -n "$GIT_SHA" ] && META_ENTRIES+=("\"gitSha\":\"$(json_escape "$GIT_SHA")\"")
+[ -n "$CI_RUN_ID" ] && META_ENTRIES+=("\"ciRunId\":\"$(json_escape "$CI_RUN_ID")\"")
+[ -n "$BRANCH" ] && META_ENTRIES+=("\"branch\":\"$(json_escape "$BRANCH")\"")
+for KV in "${META_KEYS[@]}"; do
+  KEY="${KV%%=*}"
+  VAL="${KV#*=}"
+  META_ENTRIES+=("\"$(json_escape "$KEY")\":\"$(json_escape "$VAL")\"")
+done
+if [ "${#META_ENTRIES[@]}" -gt 0 ]; then
+  IFS=','
+  METADATA="{${META_ENTRIES[*]}}"
+  unset IFS
+else
+  METADATA="{}"
 fi
 
 # --- Collect files ---


### PR DESCRIPTION
## Summary

Brings WGB up to DevAudit-Installer v0.1.34 plus the v0.1.35 hotfixes (in [metasession-dev/DevAudit-Installer#105](https://github.com/metasession-dev/DevAudit-Installer/pull/105)).

### Consumer-facing changes (from devaudit sync)

- **`e2e/helpers/evidence.ts`** — new signature `(page, reqId, ac, slug, opts?)`. Composes `REQ-XXX-AC<n>-<slug>.png`; writes sidecar JSON with origin (feature/regression).
- **`e2e/helpers/evidence-shot-core.ts`** — pure helpers (validation + filename compose + origin auto-detect) imported by the Playwright wrapper.
- **`.github/workflows/ci.yml`** — `fetch-depth: 0` on checkout; new pre-E2E step writes `E2E_NEW_SPECS` to `$GITHUB_ENV`; screenshot upload loop reads sidecar JSON and passes `--meta-key origin=<value>` to upload-evidence.sh. Sidecar JSONs included in actions/upload-artifact paths.
- **`scripts/upload-evidence.sh`** — `--meta-key key=value` repeatable flag.

### Migrated call site

One call site in `e2e/smoke/customer-auth.spec.ts`:

\`\`\`diff
- await evidenceShot(page, 'REQ-007', 'AUTHC-001-pin-entered');
+ await evidenceShot(page, 'REQ-007', 1, 'authc-001-pin-entered');
\`\`\`

Test is `test.fixme`-skipped — not currently in active CI.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `prettier --check` clean on the regenerated ci.yml
- [ ] CI green on push (first run after merge will populate `E2E_NEW_SPECS`; the fixme test stays skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)