### PR TITLE
chore: devaudit update to 0.1.37 — governance authoring + framework attribution

### DIFF
--- a/.claude/skills/e2e-test-engineer/SKILL.md
+++ b/.claude/skills/e2e-test-engineer/SKILL.md
@@ -224,6 +224,75 @@ Each filed issue needs:
 - **Evidence** — link or path to the failing test, error output, screenshot, trace.
 - **Link back** to the originating issue/PR.
 - **Severity** — your honest call: blocker, major, minor. Don't inflate.
+- **`### Framework attribution`** section — the clauses this defect closes when its incident report lands. Always lists `ISO29119.3.5.4` as baseline; additional clauses depending on classification below.
+
+#### Framework classification + the `incident` label
+
+Every defect filed from Phase 6 becomes `incident_report` evidence when (a) the issue is labelled `incident` and (b) the issue is closed. The flow: closed-with-label → `incident-export.yml` exports the body to `compliance/governance/incident-report-<N>.md` → `compliance-evidence.yml` uploads as `incident_report` evidence → portal flips the attributed clauses MISSING → COVERED.
+
+Classify the defect against this table when filing — the canonical version lives at `governance-doc-author/references/incident-classification.md`, mirrored here for the e2e workflow:
+
+| Defect characteristic                                                          | Frameworks/clauses attributed                                                                                  |
+| ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| **Any test failure / defect** (baseline — always)                              | `ISO29119.3.5.4` Test incident report                                                                          |
+| **Ops impact** (downtime, persistent errors, perf regression, data corruption) | + `SOC2.CC7.2` System monitoring and incident response                                                         |
+| **Security vulnerability** (auth bypass, injection, data exposure)             | + `SOC2.CC7.2` + relevant ISO 27001 controls                                                                   |
+| **Personal data exposed / lost / mishandled**                                  | + `GDPR.Art-33` (always — 72h supervisory notification) + `GDPR.Art-34` (when data subjects need notification) |
+| **AI/ML failure** (model hallucination, biased output, oversight bypass)       | + relevant EU AI Act articles (`Art-9` risk, `Art-14` human oversight, `Art-15` accuracy/robustness)           |
+
+**Baseline rule:** the first row is **mandatory**. Even a defect with no specific framework impact STILL produces a valid incident_report attributed to `ISO29119.3.5.4`. Never silently drop the artefact because "it's just a bug".
+
+**Apply the `incident` label at filing time** for defects that warrant incident_report evidence — don't wait for the operator to add it later. Confirm with the operator first (per the **Confirm before destructive or public actions** principle).
+
+If the `incident` label doesn't exist yet on the repo, create it idempotently:
+
+```bash
+gh label list --json name --jq '.[].name' | grep -qx incident || \
+  gh label create incident --color 'B60205' --description 'Operational, test, or compliance incident; close to auto-archive as portal evidence'
+```
+
+Then file with `--label incident,<existing-labels>`.
+
+#### Issue body template
+
+Embed the `### Framework attribution` section near the end of every defect issue body so the auto-export PR (after close) inherits the attribution:
+
+```markdown
+### Framework attribution
+
+This defect, once closed with the `incident` label, will be auto-exported as `incident_report` evidence and attribute to:
+
+- [x] `ISO29119.3.5.4` (baseline — every incident_report)
+- [ ] `SOC2.CC7.2` — ops impact: <REPLACE — yes/no, with one-line rationale>
+- [ ] `GDPR.Art-33` — personal data scope: <REPLACE — yes/no>
+- [ ] `GDPR.Art-34` — data-subject notification required: <REPLACE — yes/no>
+- [ ] `EUAIA.Art-9 / Art-14 / Art-15` — AI failure: <REPLACE — yes/no, which article(s)>
+
+Once closed, the `incident-export.yml` workflow exports this issue's body to `compliance/governance/incident-report-<N>.md`, auto-files a PR with the GDPR triage + sign-off sections to fill in. Merge that PR → `compliance-evidence.yml` uploads as `incident_report`.
+```
+
+Pre-tick boxes you're confident about. Leave the operator-judgement ones (GDPR triage, AI-failure classification) for the operator to confirm in the export PR.
+
+#### Worked examples
+
+**Example 1 — Non-PII, non-security defect.** A unit-conversion bug rounds metric prices incorrectly. Found by failing e2e. No data exposure, no service impact beyond cosmetic.
+
+- Apply `incident` label: **yes** (every defect produces an incident_report on close).
+- Pre-ticked attribution: `ISO29119.3.5.4` only.
+- Operator confirms in the export PR: no SOC 2 / GDPR / EU AI Act ticks added.
+- Result: valid incident_report closing the baseline clause. Don't pad with false ticks.
+
+**Example 2 — PII exposure via misconfigured RLS.** Users see other users' applications. Found via e2e regression. ~3,000 users affected over 6 hours.
+
+- Apply `incident` label: **yes**.
+- Pre-ticked attribution: `ISO29119.3.5.4` + `SOC2.CC7.2` + `GDPR.Art-33`.
+- Leave `GDPR.Art-34` unticked — high-risk threshold needs operator + DPO judgement.
+- Severity: blocker.
+- The export PR will surface the GDPR triage section for the operator + DPO to fill in (data-subject count, notification method, 72h-window timestamp).
+
+#### Skipping the issue path — direct incident report
+
+When the incident wasn't found by an e2e run (e.g. an ops event surfaced externally, or a retrospective documentation of an event the team handled outside the tracker), file directly using the `governance-doc-author` skill against `compliance/governance/incident-report.md.template`. Same classification table applies; the doc gets committed, `compliance-evidence.yml` auto-uploads it.
 
 Show the user the full set of issues you're about to file. Get confirmation. Then file them.
 

--- a/.claude/skills/governance-doc-author/SKILL.md
+++ b/.claude/skills/governance-doc-author/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: governance-doc-author
+description: Author or refresh one of the project's governance documents — RoPA (GDPR Art. 30), DPIA (GDPR Art. 35), AI use disclosure (EU AI Act Art. 13), Periodic Security Review Schedule (ISO 27001 A.12.1 / SOC 2 CC4.1), or the project-level incident-report template. Drives source-data gathering, framework-clause attribution, content authoring against the existing starter template, and the commit + upload + portal-verification loop. Use when the user wants to "create / refresh the RoPA", "write a DPIA", "update the AI disclosure", "set up the periodic review schedule", or generally "I need to make our <governance doc> audit-ready". Use also when the framework-coverage matrix on the portal shows GDPR.Art-30 / GDPR.Art-35 / EUAIA.Art-13 / SOC2.CC4.1 / ISO27001.A.12.1 as MISSING and the operator asks how to close them. Do NOT use for incident response itself (that's the e2e-test-engineer + incident-export.yml pipeline), or for portal upload mechanics of evidence the CI already auto-uploads (test_report, e2e_result, sast_report, audit_log, screenshot).
+---
+
+# Governance Doc Author
+
+Author or refresh a single governance document so it correctly closes the framework clauses it's meant to satisfy. Five document classes covered:
+
+| Document                                     | File                                                                                                                 | Closes                                                                                                                                          |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| **RoPA**                                     | `compliance/governance/ropa.md`                                                                                      | `GDPR.Art-30`                                                                                                                                   |
+| **DPIA**                                     | `compliance/governance/dpia.md` (or `dpia-<reqid>.md`)                                                               | `GDPR.Art-35`                                                                                                                                   |
+| **AI Use Disclosure**                        | `compliance/governance/ai-disclosure.md`                                                                             | `EUAIA.Art-13`                                                                                                                                  |
+| **Periodic Security Review Schedule**        | `SDLC/Periodic_Security_Review_Schedule.md` _(Tier 2, uploaded as `compliance_document` via the portal Upload form)_ | `ISO27001.A.12.1` (the schedule itself; the quarterly runs close `ISO27001.A.12.1` + `SOC2.CC4.1` via `periodic_review` evidence — see Phase 6) |
+| **Incident Report (project-level template)** | `compliance/governance/incident-report.md`                                                                           | `ISO29119.3.5.4` baseline; conditionals via [[incident-classification]]                                                                         |
+
+Each doc has a starter template under `sdlc/files/_common/governance/*.md.template` (installed on demand via `devaudit bootstrap-governance` since v0.1.36). This skill does NOT regenerate the template — it walks the operator through _filling it in_ against the project's actual state.
+
+## Scope
+
+**In scope**
+
+- Authoring or refreshing one (or more) of the five governance docs above.
+- Gathering source data from the codebase / CI runs / git history.
+- Confirming framework attribution before commit.
+- Driving the commit + push → CI auto-upload → portal verification loop.
+
+**Out of scope**
+
+- Incident response itself — that path is the `e2e-test-engineer` skill's defect-filing flow plus `incident-export.yml` on issue close.
+- Test execution evidence — handled by `e2e-test-engineer`.
+- Implementation plans for individual REQs — handled by the `sdlc-implementer` skill's Phase 1 against `Implementation_Plan_TEMPLATE.md`.
+- Framework registry changes — clause definitions live in META-COMPLY (`lib/config/frameworks/`) and are not authored here.
+
+## The workflow
+
+Six phases. Phase 0 is a routing step; phases 1–5 are per-document.
+
+### Phase 0 — Route
+
+Determine which document the operator needs. Ask if ambiguous; otherwise infer from the trigger phrase.
+
+- _"create / refresh the RoPA"_ → Phase 1 with doc = ROPA
+- _"write / update a DPIA"_ → Phase 1 with doc = DPIA (ask: tied to a specific HIGH-risk REQ, or project-wide?)
+- _"AI use disclosure"_ / _"document our AI use"_ → Phase 1 with doc = AI_DISCLOSURE
+- _"periodic security review schedule"_ / _"how often do we review"_ → Phase 1 with doc = REVIEW_SCHEDULE
+- _"incident-report template"_ → Phase 1 with doc = INCIDENT_TEMPLATE (and remind the operator that per-incident reports come from `incident-export.yml`, not this skill)
+
+When the trigger is _"GDPR.Art-30 is MISSING on the matrix, what do I upload?"_ and similar — route to the matching doc above.
+
+### Phase 1 — Confirm the starter exists
+
+1. Check whether the starter template is on disk at the expected path. If yes, skip to Phase 2.
+2. If absent, tell the operator the v0.1.36+ install no longer auto-seeds these — the `devaudit bootstrap-governance` command copies them on demand. Offer to run it (with operator confirmation per the **Confirm before destructive or public actions** principle).
+3. Re-check the path. If still missing, halt with a clear error pointing at the starter file in the installer.
+
+### Phase 2 — Gather source data
+
+Each doc class has different inputs. Read what's needed; don't ask the operator for what you can derive from the codebase.
+
+- **ROPA**
+  - Read `app/`, `lib/`, `prisma/schema.prisma` (or equivalent) to enumerate processing activities.
+  - For each, infer: data categories, recipients (third-party SDKs / services), retention (DB triggers, env vars naming retention windows), lawful basis where reasonable.
+  - Read `.env.example` for third-party service names.
+  - Ask the operator to confirm purposes (you can guess the technical surface; the _purpose_ is a business decision).
+
+- **DPIA**
+  - Project-wide DPIA → same source data as RoPA, plus a risk identification pass against Art. 35(3) triggers (large-scale special category, systematic monitoring, automated decisions with legal effect).
+  - Per-REQ DPIA → read `compliance/plans/REQ-XXX/implementation-plan.md` §4 (data protection) for the specific REQ being assessed.
+
+- **AI_DISCLOSURE**
+  - Grep `git log --grep "Co-Authored-By: Claude\|Co-Authored-By: GPT"` for model usage signals.
+  - Grep the codebase for AI SDK imports (`@anthropic-ai/sdk`, `openai`, etc.) and prompt strings.
+  - Cross-reference each per-REQ implementation plan's §5 (AI / model considerations).
+  - Ask the operator about human-oversight paths if not documented in the implementation plans.
+
+- **REVIEW_SCHEDULE**
+  - Read `sdlc-config.json` for `risk_tier` — drives the cadence (low = annual + ad-hoc; medium = quarterly; high = monthly).
+  - Read `.github/workflows/periodic-review.yml` to confirm the cron is wired (or note it as a follow-up if not).
+  - Ask the operator which control areas to schedule (default: access control / secure SDLC / SAST / dep-audit / E2E / change management / monitoring).
+
+- **INCIDENT_TEMPLATE**
+  - No source-data gathering — the project-level template is the form per-incident reports inherit. Ensure the latest [[incident-classification]] reference is up to date.
+
+### Phase 3 — Author against the starter
+
+1. Open the starter at the path Phase 1 confirmed.
+2. Replace every `REPLACE — …` marker with project-specific content. Use the Phase 2 source data; don't invent values.
+3. Tick the **Framework checklist** items in the starter as you go. If you can't tick one honestly, leave it unticked and surface the gap in the Phase 5 report — never tick falsely.
+4. Update the frontmatter (`last_reviewed_at`, `controller`, etc.) to today's date and the project's actual values.
+
+### Phase 4 — Verify framework attribution
+
+For each clause the doc closes, confirm the corresponding section of the doc is non-stub:
+
+| Doc               | Clause                  | Section that must be non-stub                                                           |
+| ----------------- | ----------------------- | --------------------------------------------------------------------------------------- |
+| ROPA              | GDPR.Art-30             | §Controller + ≥1 §Processing activities row with all fields filled                      |
+| DPIA              | GDPR.Art-35             | All six sections (description / necessity / risks / measures / consultation / sign-off) |
+| AI_DISCLOSURE     | EUAIA.Art-13            | All six checklist items in the template's Framework checklist                           |
+| REVIEW_SCHEDULE   | ISO27001.A.12.1         | A schedule entry per control area + a named reviewer per cadence                        |
+| INCIDENT_TEMPLATE | ISO29119.3.5.4 baseline | §1–§8 of the template are skeletal but coherent (per-incident files inherit the shape)  |
+
+If any required section is still stub, **do not commit**. Surface the gap in the Phase 5 report, ask the operator for the missing input.
+
+### Phase 5 — Commit + verify
+
+1. Show the operator the diff. Confirm before committing (per the **Confirm before destructive or public actions** principle).
+2. Commit with a conventional-commit message: `compliance(governance): refresh <doc> for <reason>` — e.g. `compliance(governance): refresh ropa.md — annual review 2026-Q2`.
+3. Push to the current working branch. Surface the path: "next `git push` to `develop` → `compliance-evidence.yml` auto-uploads as `<evidence_type>`, closing `<framework_clause>` within ~2 minutes."
+4. Suggest the operator open `/projects/<slug>/compliance` on the portal post-merge to verify the clause flipped MISSING → COVERED.
+
+### Phase 6 — Special case: the Periodic Review Schedule vs the quarterly review itself
+
+These are **two different artefacts** and the skill must not conflate them:
+
+| Artefact                                 | What                                                         | Closes                                                    | Cadence                | Skill responsibility                                                                                                                        |
+| ---------------------------------------- | ------------------------------------------------------------ | --------------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Periodic_Security_Review_Schedule.md** | The _plan_ — which controls get reviewed, how often, by whom | `ISO27001.A.12.1` (the schedule presence)                 | Once, refresh annually | **In scope.** Author / refresh via this skill.                                                                                              |
+| **periodic-review.md**                   | The _execution evidence_ — this quarter's actual review      | `ISO27001.A.12.1` + `SOC2.CC4.1` (effectiveness evidence) | Quarterly              | **Out of scope.** Auto-generated by `periodic-review.yml`; the operator fills in the 60% operator-fill section per the PR body's checklist. |
+
+If the operator asks for "the periodic review", clarify which they mean. If they want the quarterly execution, point them at the open auto-PR (or, if cron hasn't fired yet, suggest `gh workflow run periodic-review.yml`).
+
+## Filing follow-ups + handoff
+
+When Phase 5 commits successfully, append a short narrator update in the final report:
+
+- Doc(s) authored, paths committed, framework clauses closed.
+- Any framework checklist items left unticked → file each as a follow-up issue (with operator confirmation) OR list as known gaps in the final report.
+- For DPIA tied to a HIGH-risk REQ: cross-link back to the REQ's `implementation-plan.md` §4.
+
+## Principles
+
+**One doc per invocation.** Don't try to refresh RoPA + DPIA + AI disclosure in one run. They have different cadences and different source data; batching them produces sloppy output.
+
+**Don't invent.** If you can't derive a value from the codebase / CI / git, ask the operator. Never guess at lawful basis, retention windows, controller contacts, or AI provider names.
+
+**Framework checklist is load-bearing.** The portal's matrix uses the _presence_ of the doc to flip COVERED; auditors use the _content_ to decide if that's defensible. Tick boxes only when they're actually true.
+
+**Confirm before destructive or public actions.** Same as the e2e-test-engineer principle. Diff, confirm, commit. The operator approves the doc going to GitHub before push.
+
+**Ambiguity is a question, not a guess.** Same as e2e-test-engineer.
+
+## References
+
+- `references/incident-classification.md` — the conditional-attribution decision tree for incident_report evidence (mirrors the table in `e2e-test-engineer` Phase 6 Filing Defects).
+- Starter templates: `sdlc/files/_common/governance/{ropa,dpia,ai-disclosure,periodic-review,incident-report}.md.template`.
+- Framework registries (META-COMPLY): `lib/config/frameworks/{gdpr,eu-ai-act,iso-27001,soc-2,iso-29119}.ts`.
+- Related skills: `sdlc-implementer` (per-REQ implementation plans), `e2e-test-engineer` (incident reports from defects).

--- a/.claude/skills/governance-doc-author/references/incident-classification.md
+++ b/.claude/skills/governance-doc-author/references/incident-classification.md
@@ -1,0 +1,88 @@
+# Incident Classification — framework attribution decision tree
+
+Used by both `e2e-test-engineer` (when filing defects) and `governance-doc-author` (when authoring the project-level incident-report template). Single source of truth so the two skills don't drift.
+
+## Decision tree
+
+Every `incident_report` evidence row closes `ISO29119.3.5.4` (baseline). Additional clauses depend on the incident's scope.
+
+| Defect / incident characteristic                                                               | Frameworks/clauses attributed                                                                                                     |
+| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| **Any test failure / defect** (baseline — always)                                              | `ISO29119.3.5.4` Test incident report                                                                                             |
+| **Ops impact** (downtime, persistent errors, perf regression, data corruption)                 | + `SOC2.CC7.2` System monitoring and incident response                                                                            |
+| **Security vulnerability** (auth bypass, injection, data exposure beyond GDPR scope)           | + `SOC2.CC7.2` + relevant ISO 27001 controls                                                                                      |
+| **Personal data exposed / lost / mishandled**                                                  | + `GDPR.Art-33` (always — supervisory authority within 72h) + `GDPR.Art-34` (when data subjects need notification per Art. 34(1)) |
+| **AI/ML failure** (model hallucination, biased output, oversight bypass, transparency failure) | + relevant EU AI Act articles (`Art-9` risk, `Art-14` human oversight, `Art-15` accuracy/robustness)                              |
+
+## Baseline rule
+
+The first row is **mandatory**: every incident_report attributes to `ISO29119.3.5.4` no matter what else applies. The "no specific framework impact" case (a regular bug with no PII, no security, no ops impact) still produces a valid incident_report closing the baseline — never a silently-dropped report.
+
+## Conditional rules
+
+The remaining rows are conditional. Tick the matching characteristic; ensure the corresponding section of the incident-report template is non-stub before commit.
+
+### Ops impact
+
+Signals: production downtime, sustained error-rate elevation, perf regression measured in p95 or SLO breaches, data corruption.
+
+If yes:
+
+- §1 Summary must name the affected systems + duration
+- §3 Affected scope must include user-count estimate
+- §6 Containment must name what was done to mitigate
+
+### Security vulnerability
+
+Signals: auth bypass, injection (SQL / NoSQL / template / OS), broken access control, secrets in logs / git, dependency CVE exploit path.
+
+If yes:
+
+- §5 Root cause must name the vulnerability class (OWASP / CWE id where applicable)
+- §7 Follow-up actions must include the regression test that prevents recurrence
+- Security lead listed in §8 Sign-off
+
+### Personal data exposed / lost / mishandled (GDPR)
+
+Signals: any unauthorised disclosure of personal data, data loss without backup, data sent to unintended recipients, retention exceeded, lawful-basis collapse.
+
+If yes:
+
+- §4 GDPR triage **must** be fully filled: data subject count, data categories, special-category-data Y/N
+- Art. 33: notification to supervisory authority within 72h of awareness → document timestamp + sent-to in §2 Timeline
+- Art. 34: notification to data subjects when likely to result in HIGH risk → document the decision (with rationale) in §4
+- DPO listed in §8 Sign-off
+
+### AI/ML failure (EU AI Act)
+
+Signals: model produced incorrect / biased / harmful output that reached a user; oversight gate bypassed; accuracy / robustness regression in production.
+
+If yes:
+
+- §5 Root cause must name the model + invocation path + what guardrail failed
+- §7 Follow-up actions must include the change to the AI oversight path (Art. 14)
+- Cross-link to `compliance/governance/ai-disclosure.md` from §1 Summary
+
+## Worked examples
+
+### Example 1 — Non-PII, non-security defect
+
+A unit-conversion bug in a public-facing page rounds metric prices incorrectly. Discovered via failing e2e. No data exposure, no ops impact beyond cosmetic, no AI involved.
+
+**Attribution:** `ISO29119.3.5.4` only.
+
+The incident-report is still valid and load-bearing — without it the test incident clause stays MISSING. Don't pad with false GDPR / security ticks.
+
+### Example 2 — PII exposure via misconfigured RLS policy
+
+A Supabase RLS policy was deployed with a typo causing users to see other users' application details (name, email, application status). Found by an e2e regression test. No financial impact, no service downtime — but ~3,000 users were affected over a 6-hour window.
+
+**Attribution:** `ISO29119.3.5.4` + `SOC2.CC7.2` (incident response invoked) + `GDPR.Art-33` (supervisory authority notified within 72h) + `GDPR.Art-34` (data subjects notified — risk threshold met).
+
+§4 GDPR triage filled: 3,000 affected, categories = name + email + application metadata, no special-category data, Art-34 notification sent within 72h via in-app banner + email.
+
+## Cross-references
+
+- `e2e-test-engineer/SKILL.md` Phase 6 (Filing defects) — uses this table when filing a defect that meets incident criteria.
+- `governance-doc-author/SKILL.md` Phase 6 — uses this table when authoring the project-level `incident-report.md` template.
+- `compliance/governance/incident-report.md.template` — Framework attribution section embeds the same conditional checklist.

--- a/.claude/skills/sdlc-implementer/SKILL.md
+++ b/.claude/skills/sdlc-implementer/SKILL.md
@@ -68,9 +68,10 @@ Runs **first**, before any `REQ-XXX` is assigned. It decides which of the six ch
    4. Body heuristics — acceptance criteria, or risk signals (auth, payments, RBAC, data egress, AI decisioning) → tracked, and raise the risk class.
 
    Map the result to one of the six paths in `change-workflows.md`.
+
 3. **Announce a "Workflow Decision" block** (template below): change-type, commit-type, whether a `REQ-XXX` is needed, risk class, which stages/gates run, which approvals the **operator** must perform (UAT four-eyes, Production approval), and what is **skipped**.
 4. **Pause policy — pause-when-it-matters.** Pause for explicit confirmation on **tracked / heavier** paths, or when classification is **ambiguous**; **announce-and-auto-proceed** on trivial / housekeeping. The operator can always reclassify ("treat this as housekeeping" / "this is HIGH risk").
-5. **Route — and stay on to completion.** A route is a choice of *which workflow to drive*, never a hand-off that abandons the operator. Whatever the path, the skill keeps guiding step by step until no further action is required (typically: merged).
+5. **Route — and stay on to completion.** A route is a choice of _which workflow to drive_, never a hand-off that abandons the operator. Whatever the path, the skill keeps guiding step by step until no further action is required (typically: merged).
    - **tracked** (feature / bug fix / refactor / perf) → continue into Phase 1 below (full Stages 1–5).
    - **housekeeping / trivial** → drive the **Lightweight path** below to completion. No `REQ-XXX`, no RTM row, no evidence pack, no portal release approvals — but the skill still branches, runs the gates, opens the PR, and walks the operator through review → merge.
    - **compliance-doc-only** → drive the same Lightweight path as a docs push (or PR, per the project's flow) referencing the **existing** `REQ-XXX`: no new requirement and no quality-gate ceremony, but driven through to merge.
@@ -79,6 +80,7 @@ Runs **first**, before any `REQ-XXX` is assigned. It decides which of the six ch
 **"Workflow Decision" announcement template**
 
 > **Workflow decision — #N**
+>
 > - **Change type:** \<Feature | Bug fix | Refactor/Perf | Housekeeping | Trivial | Compliance-doc-only\>
 > - **Commit type:** \<feat | fix | refactor | chore | docs | …\>
 > - **Requirement:** \<REQ-XXX assigned | none\>
@@ -87,13 +89,13 @@ Runs **first**, before any `REQ-XXX` is assigned. It decides which of the six ch
 > - **Gates/evidence:** \<…\>
 > - **Your approvals:** \<UAT four-eyes + Production approval | PR review only\>
 > - **Skipped:** \<…\>
-> Proceed? *(or reclassify)*
+>   Proceed? _(or reclassify)_
 
 Only the **tracked** route continues into Phase 1; the others run the Lightweight path below. The off-ramps are deliberate — dragging housekeeping through tracked-change machinery it doesn't need is exactly the failure mode this step exists to prevent — but they are still **driven to completion**, never dumped as a checklist for the operator to run alone.
 
 **Worked examples** (one per change-type the skill keeps mis-routing without one):
 
-*Tracked feature — REQ-XXX assigned*
+_Tracked feature — REQ-XXX assigned_
 
 > - **Change type:** Feature
 > - **Commit type:** feat
@@ -104,7 +106,7 @@ Only the **tracked** route continues into Phase 1; the others run the Lightweigh
 > - **Your approvals:** UAT four-eyes + Production approval
 > - **Skipped:** none
 
-*Test fix surfaced by suite drift*
+_Test fix surfaced by suite drift_
 
 > - **Change type:** Housekeeping (test maintenance)
 > - **Commit type:** test
@@ -115,7 +117,7 @@ Only the **tracked** route continues into Phase 1; the others run the Lightweigh
 > - **Your approvals:** PR review only
 > - **Skipped:** RTM, evidence pack, UAT four-eyes, Production approval
 
-*Workflow tweak (CI artifact upload, gate timeout bump, etc.)*
+_Workflow tweak (CI artifact upload, gate timeout bump, etc.)_
 
 > - **Change type:** Housekeeping (CI maintenance)
 > - **Commit type:** ci
@@ -128,14 +130,14 @@ Only the **tracked** route continues into Phase 1; the others run the Lightweigh
 
 ### Lightweight path (housekeeping / trivial / compliance-doc-only)
 
-Reached from Phase 0 for non-tracked change-types. The skill drives this end-to-end; the only difference from the tracked cycle is the absence of *ceremony*, not the absence of *guidance*. It pauses only where a human is genuinely required (PR review, merge).
+Reached from Phase 0 for non-tracked change-types. The skill drives this end-to-end; the only difference from the tracked cycle is the absence of _ceremony_, not the absence of _guidance_. It pauses only where a human is genuinely required (PR review, merge).
 
 1. **Branch off `$INTEGRATION_BRANCH`** with a housekeeping prefix — `chore/…`, `docs/…`, `ci/…`, `build/…`, `test/…`, or `compliance/…` for a doc-only change against an existing REQ.
 2. **Make the change**, single-purpose. If it turns out to touch runtime behaviour in `app/` / `lib/`, stop and reclassify as tracked — the commit-type rule is the backstop.
 3. **Run all gates locally** (`npm run lint`, `npx tsc --noEmit`, the test suite, `semgrep`, `npm audit` — or the stack-adapter equivalents). Trivial ≠ unverified; never `--no-verify`.
 4. **Commit** with a housekeeping type and **no** `REQ-XXX` — `docs:` / `chore:` / `ci:` / `build:` / `test:` / `revert:` are exempt from the `[REQ-XXX]` rule; a `compliance:` doc-only change references the existing REQ. `Co-Authored-By: Claude` if AI-assisted.
 5. **Push and open the PR** into `$INTEGRATION_BRANCH` (`gh pr create --base "$INTEGRATION_BRANCH" --head <branch>`). CI runs the same quality gates; `compliance-validation.yml` finds no `REQ-XXX` and skips artifact validation.
-6. **For `ci:` changes, verify-via-dispatch before merging.** `gh workflow run <workflow.yml> --ref <branch>` fires the modified workflow against the PR branch. If the change broke a step, the dispatch run fails loudly and you fix-forward *before* the merge ships the broken gate to `$INTEGRATION_BRANCH`. This is the cheapest insurance against silent CI regressions — a `ci:` change that breaks a gate is most damaging *after* it lands.
+6. **For `ci:` changes, verify-via-dispatch before merging.** `gh workflow run <workflow.yml> --ref <branch>` fires the modified workflow against the PR branch. If the change broke a step, the dispatch run fails loudly and you fix-forward _before_ the merge ships the broken gate to `$INTEGRATION_BRANCH`. This is the cheapest insurance against silent CI regressions — a `ci:` change that breaks a gate is most damaging _after_ it lands.
 7. **Report honest status** — wait for CI, name any failing check, fix and re-push. Never announce "ready" while a required check is red.
 8. **Guide review → merge.** A human still reviews the PR (separation of duties). There is **no** portal release approval, no UAT four-eyes, no Production gate, and no close-out. Merge once CI is green and the reviewer approves.
 9. **Done.** A housekeeping push produces at most a bare-date release (`vYYYY.MM.DD`) with no approval gate; a doc-only push attaches its docs to the existing `REQ-XXX` release. No further action required — report completion and stop.
@@ -148,7 +150,19 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
 2. **Classify risk** per `Test_Policy.md` §Risk-Based Testing. Emit a one-paragraph rationale citing the signals you used (auth surface, financial calc, data egress, RBAC, AI decisioning, etc.).
 3. **Assign REQ-XXX.** Inspect `compliance/RTM.md` for existing entries; take the next free number. If the issue references an existing REQ, use that instead.
 4. **Detect over-scoping.** If the issue spans clearly distinct deliverables (e.g. "build SAML SSO + reorganise the admin dashboard + migrate from Postgres 14 to 16"), halt with a clear message asking the user to split the issue into separate ones. Do not proceed past Phase 1.
-5. **Write the implementation plan.** Create `compliance/plans/REQ-XXX/implementation-plan.md` per the stage-1 template (sections: context, acceptance criteria, technical approach, security considerations, dependencies, test scope). For HIGH/CRITICAL also include: threat model (against STRIDE categories applicable to the touched surfaces), four-eyes attestation slot, rollback plan.
+5. **Write the implementation plan.** Create `compliance/plans/REQ-XXX/implementation-plan.md` from `sdlc/files/_common/Implementation_Plan_TEMPLATE.md` (synced into the consumer's `SDLC/` directory at install). The template's shape is load-bearing — it carries the **Framework attribution** section that closes four framework clauses on upload:
+
+   | Clause                                        | What the plan must contain                                                                                |
+   | --------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+   | **ISO 29119 §3.4** Test Plan                  | Acceptance criteria + verification strategy per AC.                                                       |
+   | **ISO 27001 A.8.25** Secure SDLC              | Threat model + secrets / dependency considerations.                                                       |
+   | **GDPR Art. 25** Data protection by design    | Per-purpose data flows + lawful basis + retention. Explicit "no personal data" callout if not applicable. |
+   | **EU AI Act Art. 11** Technical documentation | Model provenance + oversight path when AI is in scope. Explicit "no AI in scope" callout if not.          |
+
+   For HIGH/CRITICAL also include: threat model (against STRIDE categories applicable to the touched surfaces), four-eyes attestation slot, rollback plan — the template has slots for all of these.
+
+   **Don't delete sections** — mark with `N/A — <reason>` if a clause genuinely doesn't apply (e.g. UI-only change with no personal-data scope). Empty stubs commit-then-upload as placeholder evidence and break the audit trail.
+
 6. **Update `compliance/RTM.md`** with the new entry: REQ-XXX, title, risk class, linked issue, linked test cases (placeholder).
 7. **Post plan summary as an issue comment.** Format: TL;DR; Risk class + signals; Acceptance criteria; Technical approach (one paragraph); Dependencies; Test scope.
 8. **Checkpoint** — pause for human approval **iff** risk class is HIGH or CRITICAL. LOW and MEDIUM pass through to Phase 2 automatically. The checkpoint can be forced on for all classes via the `--require-plan-approval` flag (or `DEVAUDIT_REQUIRE_PLAN_APPROVAL=1` env var) for orgs that want it always-on.
@@ -172,8 +186,9 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
    - `semgrep scan --config auto`
    - `npm audit --audit-level=high` (or stack-adapter equivalent)
 
-   **E2E gate** — run *once*, after the fast gates are clean:
+   **E2E gate** — run _once_, after the fast gates are clean:
    - `npx playwright test` (delegated to `e2e-test-engineer`, which has its own focused-iteration discipline for within-e2e fix-and-verify loops)
+
 6. **On gate failure**, iterate up to N=3 attempts. Each iteration: read the failure output, propose a fix, apply, re-run. On exhausted attempts, halt with the full failure output and surface to the human — never use `--no-verify`, `eslint-disable`, `@ts-expect-error`, `xfail`, or any other bypass.
 7. **Commit** using Conventional Commits with `Ref: REQ-XXX` trailer and `Co-Authored-By: Claude` trailer. One commit per logical step; never amend a commit that's already been pushed.
 8. **Land the work on `$INTEGRATION_BRANCH`.** Push the feature branch, then:
@@ -186,6 +201,7 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
    - `npm run test:e2e -- --reporter=html` (produces `playwright-report/`)
    - `npx vitest run --coverage` (produces `coverage/`)
 2. **Organise artefacts** under `compliance/evidence/REQ-XXX/` with date-prefixed naming:
+
    ```
    compliance/evidence/REQ-XXX/
    ├── YYYY-MM-DD_e2e-results.json
@@ -195,7 +211,8 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
    └── YYYY-MM-DD_screenshots/*.png
    ```
 
-   Copy Playwright's `test-results/` folder verbatim into `YYYY-MM-DD_traces/` so trace-by-test-name is available for audit without walking the HTML report's hash-name index. For HIGH/CRITICAL releases the traces are part of the audit trail — *"what state was the page in when test X failed and was overridden?"* answers in one `ls` instead of an HTML-report walk.
+   Copy Playwright's `test-results/` folder verbatim into `YYYY-MM-DD_traces/` so trace-by-test-name is available for audit without walking the HTML report's hash-name index. For HIGH/CRITICAL releases the traces are part of the audit trail — _"what state was the page in when test X failed and was overridden?"_ answers in one `ls` instead of an HTML-report walk.
+
 3. **Upload each artefact to the portal**:
    ```bash
    devaudit push <project-slug> REQ-XXX <evidence-type> <file> \
@@ -223,9 +240,11 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
    - For HIGH/CRITICAL: Rollback plan: reference to `compliance/plans/REQ-XXX/implementation-plan.md` §Rollback
    - Test plan
    - SDLC checklist
+
 2. **Verify the UAT reviewer ≠ skill-trigger user** for HIGH/CRITICAL. If they match, halt with a configuration error: "HIGH/CRITICAL risk requires an independent UAT reviewer; the configured reviewer matches the trigger user — fix the four-eyes attestation slot in the implementation plan and re-run."
 
-   **Solo-operator teams.** On a one-person team, the literal "reviewer ≠ submitter" check is structurally unsatisfiable. The supported interpretation is *actor type, not human identity* — AI tooling (the skill-trigger) and the human operator (the portal-approver) are distinct actors. Document this on the release ticket under `## Sign-off (dual-actor)` with the explicit interpretation, and ensure the human operator has independently reviewed the diff before clicking *Approve Production* in the portal. Without this attestation the four-eyes claim is performative.
+   **Solo-operator teams.** On a one-person team, the literal "reviewer ≠ submitter" check is structurally unsatisfiable. The supported interpretation is _actor type, not human identity_ — AI tooling (the skill-trigger) and the human operator (the portal-approver) are distinct actors. Document this on the release ticket under `## Sign-off (dual-actor)` with the explicit interpretation, and ensure the human operator has independently reviewed the diff before clicking _Approve Production_ in the portal. Without this attestation the four-eyes claim is performative.
+
 3. **Apply labels** — `awaiting-uat-review`, `risk:<class>`.
 4. **Comment on the issue**: "Implementation complete. PR #M opened. Evidence on portal: <link>. UAT review requested. Resume with `resume REQ-XXX` once UAT approval is granted on the portal."
 5. **Hard stop.** Phase 4 ends here. Do not proceed to merge; the human's next action is reviewing on the portal.
@@ -244,7 +263,6 @@ Invoked separately by the user after UAT activity on the portal. Trigger: "resum
 1. **Read portal state.** `curl` `https://devaudit.metasession.co/api/projects/<slug>/releases/<version>` and inspect the approval status.
 
 2. **Branch on state:**
-
    - **UAT approved** → run stage 5:
      - `gh pr merge <M> --merge` (merge commit; `--squash` and `--rebase` are blocked by branch protection on SDLC repos and would break the audit trail).
      - Watch `post-deploy-prod.yml` via `gh run watch` — block until the workflow reaches a terminal state.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,6 @@ jobs:
           E2E_CSR_USERNAME: e2e-csr
           E2E_CSR_PASSWORD: E2eTest@2026!
         run: npx playwright test --project=smoke --reporter=json,html
-
       # ── Gate 5: Build ──
 
       - name: Build Check

--- a/.github/workflows/periodic-review.yml
+++ b/.github/workflows/periodic-review.yml
@@ -210,9 +210,63 @@ jobs:
           # Open PR (or update existing).
           EXISTING=$(gh pr list --head "${BRANCH}" --json number --jq '.[0].number' || true)
           if [ -z "$EXISTING" ]; then
+            # Two-part PR body:
+            # 1. The 60% operator-fill checklist with per-clause attribution
+            # 2. The auto-filled section list (40% workflow-derived)
+            # Both are inline so the reviewer can tick boxes and the
+            # auto-generated half stays visible. Per-clause links use the
+            # consumer's portal base URL — fall back to the SDLC docs when
+            # DEVAUDIT_BASE_URL isn't set in the workflow env.
+            BASE="${DEVAUDIT_BASE_URL:-https://github.com/metasession-dev/DevAudit-Installer/blob/main/docs/governance-templates.md}"
+            PR_BODY_FILE=$(mktemp)
+            printf '%s\n' \
+              "Auto-generated quarterly periodic-review for **${REVIEW_ID}** by the \`Periodic Review\` workflow." \
+              "" \
+              "## What auto-filled (~40%)" \
+              "" \
+              "- Review-period metrics: releases shipped, gate pass rate, SAST + dependency findings, audit-log volume, open issues" \
+              "- Frontmatter (\`review_id\`, period dates, generated_at)" \
+              "- Section 2 control-area headers wired to the right framework clauses" \
+              "" \
+              "## What still needs the operator (~60%)" \
+              "" \
+              "Each item below corresponds to a section of the doc. **Tick the box once the section is non-stub** — leaving REPLACE markers in place will fail audit review and the merge bar." \
+              "" \
+              "### §3 Review notes" \
+              "- [ ] Qualitative observations on the review period (≥2 sentences; no \`REPLACE\` text remaining)" \
+              "- [ ] Cross-reference any incidents from this period (\`compliance/governance/incident-report-*.md\`)" \
+              "" \
+              "### §4 Control-effectiveness judgement" \
+              "*Closes \`SOC2.CC4.1\` + \`ISO27001.A.12.1\` only when ALL control areas have a non-stub judgement.*" \
+              "" \
+              "- [ ] Access control (ISO 27001 A.5.15) — effective / partially / not + 1-line evidence" \
+              "- [ ] Secure SDLC (ISO 27001 A.8.25) — judgement + evidence" \
+              "- [ ] Secure coding (ISO 27001 A.8.28) — judgement + evidence (SAST + dep-audit pass rate)" \
+              "- [ ] Security testing (ISO 27001 A.8.29) — judgement + evidence (E2E pass rate)" \
+              "- [ ] Change management (ISO 27001 A.8.32 + SOC 2 CC8.1) — judgement + evidence (four-eyes approvals count)" \
+              "- [ ] Monitoring activities (ISO 27001 A.8.16 + EU AI Act Art. 12) — judgement + evidence (audit-log volume / coverage)" \
+              "" \
+              "### §5 Follow-up actions" \
+              "- [ ] Each material finding → owner → due date (or \"none for this period\" stated explicitly)" \
+              "- [ ] Carry-over actions from last quarter's review → status updated" \
+              "" \
+              "### §6 Sign-off" \
+              "- [ ] Reviewer name + date (must be different from the actor who made code changes that the review is judging)" \
+              "- [ ] Approver name + date (when \`risk_tier\` is medium or higher — dual-actor required)" \
+              "" \
+              "## Closes once merged" \
+              "" \
+              "- \`SOC2.CC4.1\` (Monitoring of internal controls)" \
+              "- \`ISO27001.A.12.1\` (Operational procedures and responsibilities)" \
+              "" \
+              "Verify at \`${BASE}/projects/<slug>/compliance\` after the PR-merge push lands on develop — both clauses should flip MISSING → COVERED within ~2 minutes. Stays COVERED for 365 days (portal's \`freshnessDays\`), then flips to EXPIRED until the next quarterly review." \
+              "" \
+              "See [\`docs/governance-templates.md\`](https://github.com/metasession-dev/DevAudit-Installer/blob/main/docs/governance-templates.md#soc-2--trust-services-criteria) for full guidance." \
+              > "$PR_BODY_FILE"
             gh pr create --base develop --head "${BRANCH}" \
               --title "chore(compliance): periodic review ${REVIEW_ID}" \
-              --body "Auto-generated quarterly periodic-review for **${REVIEW_ID}** by the \`Periodic Review\` workflow.\n\n**Required before merge:**\n- [ ] Replace \`REPLACE — …\` markers in the **Review notes** section\n- [ ] Fill in control-effectiveness judgement for each control area\n- [ ] Add reviewer + approver names (dual-actor)\n- [ ] List follow-up actions with owners + dates\n\nSee [\`docs/governance-templates.md\`](https://github.com/metasession-dev/DevAudit-Installer/blob/main/docs/governance-templates.md#soc-2--trust-services-criteria) (SDLC repo) for guidance.\n\nCloses \`SOC2.CC4.1\` + \`ISO27001.A.12.1\` for the period once the PR lands on develop."
+              --body-file "$PR_BODY_FILE"
+            rm -f "$PR_BODY_FILE"
           else
             echo "PR #${EXISTING} already open for this period — branch updated in place."
           fi

--- a/.github/workflows/post-deploy-prod.yml
+++ b/.github/workflows/post-deploy-prod.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0   # full history so merged commits' REQ tags are readable
+          fetch-depth: 0 # full history so merged commits' REQ tags are readable
 
       - name: Resolve DevAudit base URL and post-deploy terminal status
         run: |

--- a/SDLC/Implementation_Plan_TEMPLATE.md
+++ b/SDLC/Implementation_Plan_TEMPLATE.md
@@ -1,0 +1,126 @@
+---
+title: 'Implementation plan — REQ-XXX'
+requirement_id: 'REQ-XXX'
+risk_class: 'REPLACE — HIGH | MEDIUM | LOW'
+change_type: 'REPLACE — feat | fix | refactor | perf | chore | docs | ci | build | test | compliance | revert'
+authored_by: 'REPLACE — operator / agent'
+authored_at: 'REPLACE — YYYY-MM-DD'
+---
+
+> ⚠️ **STARTER TEMPLATE — REPLACE EVERY `REPLACE` MARKER BEFORE COMMITTING.**
+> The shape of this doc is load-bearing: the framework-coverage matrix
+> closes four different clauses based on this plan being present + tagged
+> with the correct evidence category. Empty stub commits flip the
+> matrix to COVERED with placeholder content — auditors reject this.
+
+# Implementation plan — REQ-XXX
+
+## Framework attribution
+
+**Evidence type:** `compliance_document` · **Category:** `planning` · **Scope:** per-REQ
+
+**Closes clauses** (every implementation plan satisfies all four):
+
+| Clause                                                    | What this plan must contain                                                                                                                                       |
+| --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **ISO 29119 §3.4** Test Plan                              | Acceptance criteria + the strategy for verifying each one. Reference the per-REQ `test-plan.md` if it lives separately.                                           |
+| **ISO 27001 A.8.25** Secure development life cycle        | Threat model + secure-design considerations (auth, data handling, dependencies, secrets).                                                                         |
+| **GDPR Art. 25** Data protection by design and by default | Per-purpose data flows; minimisation; lawful basis; retention. **Required for any REQ that processes personal data; explicit "no personal data" callout if not.** |
+| **EU AI Act Art. 11** Technical documentation (Annex IV)  | When the REQ touches AI / model behaviour: model provenance, prompt sources, oversight path. **Explicit "no AI in scope" callout if not.**                        |
+
+Each section below maps to one (or more) of these clauses. Don't delete sections — mark with "N/A — <reason>" if the clause genuinely doesn't apply.
+
+## 1. Goal + acceptance criteria
+
+> _Closes ISO 29119 §3.4 — test plan_
+
+- **Goal:** REPLACE — one sentence describing what this REQ delivers, no jargon.
+- **Acceptance criteria:**
+  - AC1 — REPLACE
+  - AC2 — REPLACE
+  - …
+
+## 2. Scope
+
+- **In scope:** REPLACE — list every file / module / surface the change touches.
+- **Out of scope:** REPLACE — adjacent areas the change deliberately leaves alone.
+
+## 3. Threat model + security considerations
+
+> _Closes ISO 27001 A.8.25 — secure development life cycle_
+
+| Threat                                           | Likelihood | Impact  | Mitigation |
+| ------------------------------------------------ | ---------- | ------- | ---------- |
+| REPLACE — e.g. SQL injection via X param         | REPLACE    | REPLACE | REPLACE    |
+| REPLACE — e.g. unauthenticated access to Y route | REPLACE    | REPLACE | REPLACE    |
+
+**Secrets / credentials:** REPLACE — does this REQ handle any? If yes, how stored, rotated, scoped?
+
+**Dependencies introduced:** REPLACE — list new npm/pip packages; flag any with known CVEs or transitive concerns.
+
+## 4. Data protection (GDPR Art. 25)
+
+> _Closes GDPR Art. 25 — data protection by design_
+
+**Personal data processed by this REQ:** REPLACE — yes / no.
+
+If **yes**, fill in:
+
+- **Categories of data subjects:** REPLACE
+- **Categories of personal data:** REPLACE (name, email, IP, etc.)
+- **Special categories (Art. 9):** REPLACE — none / specify
+- **Lawful basis:** REPLACE — Art. 6(1)(a-f) — pick one + justify
+- **Purpose limitation:** REPLACE — how the design prevents repurposing
+- **Data minimisation:** REPLACE — fields collected vs fields needed
+- **Retention:** REPLACE — how long, then what happens
+- **Cross-references:**
+  - Is the ROPA (`compliance/governance/ropa.md`) updated? REPLACE — yes / no / N/A
+  - Is a DPIA required? REPLACE — yes (file under `compliance/governance/dpia-<reqid>.md`) / no / N/A
+- **Cross-border transfers:** REPLACE — none / specify mechanism
+
+If **no**, write: _"N/A — this REQ does not process personal data. <Why — e.g. UI-only change, internal-routing refactor, dev-tooling.>"_
+
+## 5. AI / model considerations (EU AI Act Art. 11)
+
+> _Closes EUAIA Art. 11 — technical documentation_
+
+**AI / ML in scope for this REQ:** REPLACE — yes / no.
+
+If **yes**, fill in:
+
+- **Model(s) used:** REPLACE — provider, model name, version
+- **Inputs / outputs:** REPLACE
+- **Prompt sources:** REPLACE — hardcoded / user-supplied / template-substituted
+- **Human-oversight path:** REPLACE — what stops a bad output reaching a user? Review gate / circuit breaker / rate limit / etc.
+- **Accuracy / robustness considerations:** REPLACE — known failure modes, planned guardrails
+- **Cross-references:**
+  - Is `compliance/governance/ai-disclosure.md` updated? REPLACE — yes / no / N/A
+
+If **no**, write: _"N/A — this REQ does not introduce or change AI behaviour. <Why.>"_
+
+## 6. Rollback plan
+
+- **Reversible via:** REPLACE — git revert / migration down / config flip / etc.
+- **Data implications of rollback:** REPLACE — any data written by the new code that an older version can't read?
+- **Notification path if rollback during a release:** REPLACE — who hears, how quickly?
+
+## 7. Verification
+
+How the team will know the REQ is correct in production:
+
+- **Unit + integration tests:** REPLACE — what's added / changed
+- **E2E coverage:** REPLACE — which spec(s); reference per-AC `evidenceShot()` captures
+- **Manual smoke after deploy:** REPLACE — bullet-list, or "none" with reason
+- **Monitoring / alerting:** REPLACE — what dashboards / alerts the change adds or relies on
+
+## 8. Sign-off
+
+- **Plan reviewer (eng):** REPLACE — name + date
+- **Plan reviewer (security / DPO):** REPLACE — when GDPR or threat-model sections are non-trivial; otherwise "N/A"
+- **Plan approved by operator:** REPLACE — name + date
+
+## Upload path
+
+This file lives at `compliance/plans/REQ-XXX/implementation-plan.md` and is uploaded automatically on the next push to `develop` via `compliance-evidence.yml`. The portal's framework-coverage matrix flips ISO 29119 §3.4, ISO 27001 A.8.25, GDPR Art. 25, and EU AI Act Art. 11 to COVERED for this REQ once the upload lands.
+
+Verify the upload at `https://devaudit.metasession.co/projects/<slug>/releases/REQ-XXX` — the "Evidence by requirement" list should show this plan tagged with `category=planning`.


### PR DESCRIPTION
## Summary

Brings WGB up to DevAudit-Installer v0.1.37 (implements [#107](https://github.com/metasession-dev/DevAudit-Installer/issues/107) + the five workstreams of umbrella [#108](https://github.com/metasession-dev/DevAudit-Installer/issues/108)).

### Synced

- **\`.claude/skills/governance-doc-author/\`** — new skill covering ROPA / DPIA / AI disclosure / Periodic Security Review Schedule / incident-report template authoring with framework attribution. Includes the shared \`references/incident-classification.md\` decision tree.
- **\`.claude/skills/e2e-test-engineer/SKILL.md\`** — Filing-defects section now embeds the classification decision tree, auto-applies the \`incident\` label at filing time, embeds a \`### Framework attribution\` section in defect issue bodies, includes two worked examples (non-PII defect, PII exposure).
- **\`.claude/skills/sdlc-implementer/SKILL.md\`** — Phase 1 step 5 names the 4 framework clauses every implementation-plan satisfies (ISO 29119 §3.4, ISO 27001 A.8.25, GDPR Art. 25, EU AI Act Art. 11).
- **\`SDLC/Implementation_Plan_TEMPLATE.md\`** — new template synced from \`_common/\` with the framework-attribution shape.
- **\`.github/workflows/periodic-review.yml\`** — auto-PR body restructured as 60% operator-fill checklist with per-clause attribution + dual-actor sign-off tied to \`risk_tier\`.

### Workaround applied (v0.1.38 forthcoming)

The v0.1.37 sync's \`periodic-review.yml\` used a \`<<PRBODY\` heredoc with body lines at YAML column 1, which breaks prettier-yaml. Same shape of bug as v0.1.34's multiline python heredoc. Re-applied the v0.1.38 fix locally (printf '%s\n' → temp file → --body-file). [DevAudit-Installer#110](https://github.com/metasession-dev/DevAudit-Installer/pull/110) lands the fix in the installer; once published, \`devaudit update\` will produce the same shape.

## Test plan

- [x] tsc clean
- [x] prettier clean on every touched file
- [ ] CI green on push (periodic-review.yml format verified locally; cron hasn't fired yet so PR-creation flow not exercised in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)