### PR TITLE
chore: place REQ-069/070/071/073 implementation plans in compliance/evidence/

### DIFF
--- a/compliance/evidence/REQ-069/implementation-plan.md
+++ b/compliance/evidence/REQ-069/implementation-plan.md
@@ -1,0 +1,85 @@
+# REQ-069 — Payments & webhooks E2E coverage (sub-issue #294)
+
+**Status:** IN PROGRESS · **Risk:** MEDIUM · **Issue:** [#294](https://github.com/metasession-dev/wawagardenbar-app/issues/294) (sub-issue of umbrella [#291](https://github.com/metasession-dev/wawagardenbar-app/issues/291))
+
+## Context
+
+The payments + webhooks subsystem has substantial backend work shipped (REQ-049 webhook idempotency RELEASED 2026-05-28; REQ-066 AC1-AC6 chokepoint refactor RELEASED 2026-06-04) but **zero E2E pinning** of the webhook signature, idempotency-replay, or order-flow behaviors. The umbrella SRS audit (2026-06-04) flagged this as the highest-value gap because:
+
+- REQ-049's idempotency-key dedup is the load-bearing protection against double-charging customers when a webhook is delivered twice.
+- The chokepoint refactor in REQ-066 changed which side-effects fire from the webhook handler — those changes have unit-test coverage but no end-to-end pin.
+- The signature-verification path is the auth surface for an unauthenticated public endpoint.
+
+Sub-issue #294 owns the provider-mock infrastructure that #292 and #293 also depend on for customer-PIN-flow E2E.
+
+## Acceptance criteria
+
+1. **AC1 — Webhook mock infrastructure** authored as reusable helpers.
+   - `e2e/helpers/webhook-mock.ts` — HMAC-SHA512 signature generators matching paystack + monnify route handler verification exactly + `sendWebhook` HTTP dispatcher.
+   - `e2e/helpers/payment-provider-mock.ts` — paystack (`charge.success`, `charge.failed`) + monnify (`PAID`, `FAILED`, etc.) payload builders matching the wire shape the existing unit tests use.
+   - Helpers read provider secrets from the SAME source the server reads (`MONNIFY_SECRET_KEY` env for monnify; SystemSettings.paystack.secretKey for paystack), so the server's verification accepts the generated signatures.
+
+2. **AC2 — Signature rejection E2E** for both providers.
+   - `e2e/payments/webhook-signature-rejection.spec.ts`:
+     - paystack: invalid signature → 401, order paymentStatus unchanged
+     - monnify: invalid signature → 401, order paymentStatus unchanged
+     - paystack: missing signature header → 401
+   - Each test seeds a pending order, fires the synthetic webhook, asserts route returns 401 + order state preserved. Cleanup deletes seeded order + any incidental webhook-event rows.
+
+3. **AC3 — Monnify idempotency-replay E2E** pinning REQ-049's backstop.
+   - `e2e/payments/webhook-idempotency-replay.spec.ts`:
+     - First delivery: 200 + order flips pending → paid + ProcessedWebhookEvent row created.
+     - Replay (same transactionReference): 200 + "Event already processed" response + ZERO additional side effects + ProcessedWebhookEvent row count stays at 1.
+     - Different transactionReference for same paymentReference: NOT a dup (proves the dedup key is per-event, not per-payment).
+   - Uses monnify because the secret is env-based; paystack idempotency is deferred (see _Deferred to follow-up_).
+
+## Deferred to follow-up (not in this PR)
+
+- **Paystack idempotency replay spec** — needs `SystemSettings.payment.paystack.secretKey` configured on UAT (currently unset). Will require either operator-driven UAT configuration OR a synthetic-secret seed step before the spec can run. Tracked at the bottom of sub-issue #294.
+- **Payment-init happy-path specs (paystack + monnify)** — would exercise `createOrder` → `initializePayment` flow end-to-end. Requires either real provider calls (creates real test charges) OR a mock-checkout-URL flag (`ENABLE_TEST_PAYMENTS=true`) on UAT. Operator decision needed.
+- **REQ-PAY-004 partial-payment-reconciliation spec** — partially covered by existing `e2e/partial-payments.spec.ts` (UI structure) + `e2e/daily-report-payments.spec.ts` (tab + partial cash + card closure). A dedicated SRS-traced spec for the financial reconciliation contract is the natural next add but not blocking the V1 ship.
+
+These three deferrals are documented in the sub-issue #294 GitHub issue body as a checklist; they ship in a follow-up cycle once their prerequisites land.
+
+## Technical approach
+
+### New helper files (2)
+
+- `e2e/helpers/webhook-mock.ts` — pure functions for signature generation + Node fetch helper for dispatch. Zero Playwright dependency so the helpers can be reused by unit tests if needed.
+- `e2e/helpers/payment-provider-mock.ts` — pure payload builders. Shapes match the existing unit-test fixtures verbatim, so if the route handler grows a new required field the unit tests + E2E specs fail in lockstep.
+
+### New E2E spec files (2)
+
+- `e2e/payments/webhook-signature-rejection.spec.ts` — 3 tests, no secret needed.
+- `e2e/payments/webhook-idempotency-replay.spec.ts` — 2 tests, uses `MONNIFY_SECRET_KEY` env.
+
+### No production code changes
+
+This is a pure test-pack-coverage cycle. Zero changes to `app/api/webhooks/*`, `services/paystack-service.ts`, `services/monnify-service.ts`, or any service.
+
+## Risk
+
+**MEDIUM.** Net-new specs covering an existing financial-correctness path (webhook idempotency = double-charge protection). The HMAC-SHA512 signature generators must match the server's verification byte-for-byte; any mismatch is detected at signature-rejection time (server returns 401) so a bug in the helper is loud, not silent.
+
+**No production runtime change** — pure test addition.
+
+## Security considerations
+
+- The signature-generation helpers read the same secret the server reads (env var for monnify; SystemSettings DB row for paystack). Tests run against UAT Mongo + UAT webhook URL — no production touches.
+- Synthetic webhooks use `paymentReference: 'E2E-REQ069-*'` prefixes so test orders are easily distinguishable from real ones in audit queries. Cleanup deletes the seeded order + the dedup row in `afterEach`.
+
+## Dependencies
+
+- REQ-049 (RELEASED 2026-05-28) — webhook idempotency that this REQ pins.
+- REQ-066 (RELEASED 2026-06-04) — chokepoint refactor; webhook side-effects unchanged but the route handler delegates to it.
+
+## Test scope
+
+Vitest unchanged (1129 pass / 4 skip / 0 fail) — this REQ adds zero unit tests; the helpers are exercised by the E2E specs and indirectly by the existing webhook-idempotency unit tests.
+
+E2E (live against UAT):
+
+- `e2e/payments/webhook-signature-rejection.spec.ts` — 3 tests.
+- `e2e/payments/webhook-idempotency-replay.spec.ts` — 2 tests.
+
+Both files configured `describe.configure({ mode: 'serial' })` because they share the UAT processedwebhookevents collection.

--- a/compliance/evidence/REQ-070/implementation-plan.md
+++ b/compliance/evidence/REQ-070/implementation-plan.md
@@ -1,0 +1,79 @@
+# REQ-070 — Rewards & loyalty pipeline E2E coverage (sub-issue #293)
+
+**Status:** IN PROGRESS · **Risk:** MEDIUM · **Issue:** [#293](https://github.com/metasession-dev/wawagardenbar-app/issues/293) (sub-issue of umbrella [#291](https://github.com/metasession-dev/wawagardenbar-app/issues/291))
+
+## Context
+
+Second cycle of umbrella tracker [#291](https://github.com/metasession-dev/wawagardenbar-app/issues/291) (SRS → E2E regression-pack coverage closure). REQ-048 (rewards-ledger correctness — RELEASED 2026-05-28) has **zero E2E pinning** of its load-bearing contracts:
+
+- Cancel order reverses customer's earned points (writes `PointsTransaction` type='adjusted' carrying compensating amount; decrements `User.loyaltyPoints`).
+- Cancel order restores redeemed rewards (flips `Reward.status` from 'redeemed' to 'active'; clears `redeemedAt` + `redeemedInOrderId` stamps).
+
+This REQ pins both contracts end-to-end against live UAT Mongo.
+
+## Acceptance criteria
+
+1. **AC1 — Cancel reverses earned points** (REQ-048 leg 1).
+   - Seed: customer User with `loyaltyPoints: 600` + `totalPointsEarned: 100`; paid Order linked to user with `status: 'confirmed'`; `PointsTransaction` of `type: 'earned'`, `amount: 100`.
+   - Trigger: call `OrderService.cancelOrder(orderId, reason)` directly from the spec process.
+   - Assert: `User.loyaltyPoints` returns to pre-earn balance (500); a `PointsTransaction` of `type: 'adjusted'`, `orderId: <same>` is now in the collection; `Order.status === 'cancelled'`.
+
+2. **AC2 — Cancel restores redeemed rewards** (REQ-048 leg 2).
+   - Same spec seed extended with: a `Reward` document for the user with `status: 'redeemed'`, `redeemedAt` set, `redeemedInOrderId: <same orderId>`.
+   - Same trigger.
+   - Assert: `Reward.status === 'active'`; `Reward.redeemedAt === null`; `Reward.redeemedInOrderId === null`.
+
+Both ACs verified in a single E2E spec because they share the seed shape + are both side-effects of the same `cancelOrder` invocation.
+
+## Implementation approach
+
+### Single spec file
+
+- `e2e/rewards/order-cancel-reverses-points.spec.ts` — one test exercising both AC1 + AC2 in one cancel transition. Mongo seed + Mongoose-backed service call + Mongo readback. Cleanup deletes all seeded rows.
+
+### Service-layer invocation
+
+The spec imports `OrderService.cancelOrder` directly from `@/services/order-service` and calls it on the seeded order. This is what the production server actions wrap. The Playwright test runner respects the tsconfig path alias (`@/*`); no extra config needed.
+
+**Caveat — dynamic-import inside `OrderService.cancelOrder`:** the production code uses `await import('./points-service')` + `await import('./rewards-service')` inside the cancel transition's try/catch. These dynamic imports fail silently in the Playwright runner (different transpile path than Next.js). To compensate, the spec ALSO calls `PointsService.reverseOrderTransactions` and `RewardsService.restoreRedeemedRewards` directly after `cancelOrder` returns. Both are idempotent — the second call is a no-op if the first had already fired. This means:
+
+- The status-flip half of `cancelOrder` is pinned end-to-end via Playwright runner.
+- The reversal-helpers' contracts are pinned end-to-end (called from the test, write to live UAT Mongo, assert via readback).
+- The dynamic-import orchestration inside `cancelOrder` is NOT pinned by this spec (it IS pinned by `__tests__/services/order-service.cancel-reversal.test.ts` at the unit-test layer, which mocks the dynamic-import wiring).
+
+This gap is acceptable for V1 — the underlying contract is what REQ-048 owns and that's pinned. A follow-up could swap the dynamic imports for static imports in `cancelOrder` (no behavior change) and tighten this E2E to call `cancelOrder` alone.
+
+### No production code change
+
+Pure test addition.
+
+## Deferred to follow-up (tracked on sub-issue #293)
+
+- **Tab-checkout eligibility spec** (REQ-CHECKOUT-009) — requires understanding the customer-side tab-checkout flow + API auth.
+- **Tab-close-applies-rewards spec** (REQ-ORDER-004) — UI-driven E2E with admin tab-close flow.
+- **Admin reward-rule CRUD specs** (REQ-REWMGT-001-004) — 3 specs covering rules list/create/edit + issued-rewards list + templates editor. UI-heavy; PR #135 was the original attempt.
+
+These ship in a follow-up REQ within sub-issue #293 once the cancel-reversal contract is shipped (this REQ).
+
+## Risk
+
+**MEDIUM.** Pure test addition. The seeded state writes to live UAT Mongo with a deterministic prefix (`e2e-req070-cancel-` for the user email; `WGE70C*` for the order number; `RWD-E2E-*` for the reward code) so test rows are easy to identify + clean up. `afterEach` deletes the user, order, all the user's PointsTransactions, and the seeded reward.
+
+## Security considerations
+
+- **No production code change.** REQ-048's reversal logic is unchanged.
+- **No new auth surface.** The spec runs in the Playwright runner against UAT Mongo + UAT-resolved Mongoose models. Synthetic users carry `role: 'customer'` and `e2e-req070-*` email prefix.
+- **No new packages, env vars, or schema changes.**
+
+## Dependencies
+
+- REQ-048 (RELEASED 2026-05-28) — backend that this REQ pins.
+- REQ-069 (IN PROGRESS via #298) — established the "Playwright spec + live UAT Mongo + service-layer call" pattern.
+
+## Test scope
+
+E2E (live against UAT):
+
+- `e2e/rewards/order-cancel-reverses-points.spec.ts` — 1 test exercising AC1 + AC2 in one cancel transition.
+
+Vitest unchanged from REQ-069 baseline (1129 pass / 4 skip / 0 fail).

--- a/compliance/evidence/REQ-071/implementation-plan.md
+++ b/compliance/evidence/REQ-071/implementation-plan.md
@@ -1,0 +1,71 @@
+# REQ-071 — Public API authenticated contracts E2E coverage (sub-issue #297)
+
+**Status:** IN PROGRESS · **Risk:** LOW · **Issue:** [#297](https://github.com/metasession-dev/wawagardenbar-app/issues/297) (sub-issue of umbrella [#291](https://github.com/metasession-dev/wawagardenbar-app/issues/291))
+
+## Context
+
+Third cycle of umbrella tracker [#291](https://github.com/metasession-dev/wawagardenbar-app/issues/291) (SRS → E2E regression-pack coverage closure). Existing coverage at `e2e/requirements-verification.spec.ts` § Section 20 pins that every scoped public API endpoint REJECTS unauthenticated requests with 401/403/429. The missing half: **authenticated responses match the documented envelope shape**.
+
+REQ-071 adds the missing half — one spec exercising every read-scoped public endpoint with a valid API key and asserting the response envelope matches the JSDoc contract at the route.
+
+## Acceptance criteria
+
+1. **AC1 — Authenticated contract per endpoint.** For each of the following endpoints, a GET with a valid `x-api-key` returns 200 + envelope `{ success: true, data: <documented shape> }`:
+   - `/api/public/health` (no auth required)
+   - `/api/public/menu`
+   - `/api/public/menu/categories`
+   - `/api/public/inventory`
+   - `/api/public/inventory/summary`
+   - `/api/public/inventory/alerts`
+   - `/api/public/orders`
+2. **AC2 — Invalid-key rejection envelope.** A GET with an invalid `x-api-key` returns 401 + envelope `{ success: false, error: <string> }`.
+
+## Implementation approach
+
+### Single spec file with ephemeral API key
+
+- `e2e/api/public-contracts-authenticated.spec.ts` — `describe.configure({ mode: 'serial' })` so the rate-limit (30 req/min default) is respected.
+- `beforeAll`: calls `ApiKeyService.createKey({ name, role: 'admin', scopes: [all read scopes], rateLimit: 300 }, SYSTEM_USER_ID)`. Captures the plaintext key returned.
+- `afterAll`: revokes + deletes the key so it cannot be reused after the run.
+
+### Shape assertions
+
+Per-endpoint inline `expect` assertions on the response envelope + each nested field's type. No zod dependency added; the assertions are TypeScript-friendly + readable.
+
+The shape contracts are derived from each route file's JSDoc `@returns` comments. If a route handler changes its response shape without updating the JSDoc, this spec catches the contract drift immediately.
+
+### No production code change
+
+Pure test addition.
+
+## Deferred to follow-up (tracked on sub-issue #297)
+
+- **Dedicated audit-log spec** (REQ-AUDIT-001) — exercise 5+ admin actions + verify the audit log row count + shape. Requires admin UI navigation + DB readback, more complex than HTTP contracts.
+- **Profitability report E2E** (REQ-REPORT-003) — UI-driven E2E with admin reports page.
+- **CSV/JSON export E2E** (REQ-REPORT-004) — UI-driven E2E exercising the export endpoint and parsing the file shape.
+- **Per-endpoint contracts for write methods** (POST, PATCH, DELETE) — V1 covers reads only because writes carry larger side effects and need cleanup.
+
+These ship in a follow-up REQ within sub-issue #297.
+
+## Risk
+
+**LOW.** Pure test addition. The ephemeral API key has read-only scopes; revoked + deleted in `afterAll` so it cannot persist past the run. No production code change. Synthetic key names carry `e2e-req071-*` prefix so they're easy to identify in audit queries.
+
+## Security considerations
+
+- The ephemeral API key is created with broad read scopes for the duration of the spec. The plaintext is captured in a JS variable scope (no logs, no env writes, no commits).
+- `revokeKey` flips `isActive: false`, then `deleteKey` removes the row entirely. Even if the test crashes mid-run, the next manual cleanup is straightforward (filter apikeys by `name: /^e2e-req071-/`).
+- No production data is modified. Reads are scoped to existing UAT inventory/menu/orders.
+
+## Dependencies
+
+- REQ-069 (IN PROGRESS via PR #298) — established the "Playwright spec + Node fetch + live UAT" pattern.
+- REQ-070 (IN PROGRESS via PR #300) — established the "import service-layer functions in the spec" pattern.
+
+## Test scope
+
+E2E (live against UAT):
+
+- `e2e/api/public-contracts-authenticated.spec.ts` — 8 tests (1 health + 6 authenticated endpoints + 1 invalid-key rejection).
+
+Vitest unchanged from REQ-070 baseline (1129 pass / 4 skip / 0 fail).

--- a/compliance/evidence/REQ-073/implementation-plan.md
+++ b/compliance/evidence/REQ-073/implementation-plan.md
@@ -1,0 +1,97 @@
+# REQ-073 — Implementation plan
+
+**Requirement ID:** REQ-073
+**Risk:** MEDIUM (inherits from sub-issue #296's cluster classification — each spec is independently LOW; net-new safety-net coverage for destructive admin ops)
+**Related issue:** [#296](https://github.com/metasession-dev/wawagardenbar-app/issues/296) (sub-issue of umbrella [#291](https://github.com/metasession-dev/wawagardenbar-app/issues/291))
+**Date:** 2026-06-05
+
+## Context
+
+Sub-issue #296 of umbrella tracker #291 (SRS → E2E regression-pack coverage closure). Admin-side destructive operations + permission-gated workflows are mostly COULD-priority but represent **operator-facing risk surfaces** — destructive ops with no E2E pin are where regressions silently destroy or corrupt data.
+
+8 specs were proposed in the sub-issue body; V1 ships the 3 highest-value-lowest-cost ones. The remaining 5 are tracked on #296's checklist for follow-up cycles.
+
+## V1 scope
+
+| #   | SRS ID                      | Spec                                    | Behavior pinned                                                                                                                                                                                                                   |
+| --- | --------------------------- | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | REQ-MENUMGT-004 (delete)    | `e2e/admin/menu-item-delete.spec.ts`    | `MenuItemModel.deleteOne()` removes the active item; `findById` afterward returns null. Existing Order references with `menuItemId` snapshots remain readable (history preserved at the order-item snapshot layer).               |
+| 2   | REQ-MENUMGT-004 (duplicate) | `e2e/admin/menu-item-duplicate.spec.ts` | Duplicate creates a new MenuItem with " (Copy)" name suffix + unique slug + `isAvailable: false`; original unchanged.                                                                                                             |
+| 3   | REQ-KITCHEN-005             | `e2e/admin/kitchen-void-batch.spec.ts`  | `ProductionService.voidBatch` flips status to 'voided' + restores each `ingredientsDeducted` entry on Inventory + decrements yield from menu-item inventory + writes 2 StockMovement audit rows. Idempotent (re-void is a no-op). |
+
+## Acceptance criteria
+
+- **AC1** (Spec 1) — After `MenuItemModel.deleteOne()` against a seeded item, `MenuItemModel.findById(seededId)` returns null. The Order document seeded with `items: [{ menuItemId: seededId, name, price }]` retains its embedded snapshot intact (history layer not lost).
+- **AC2** (Spec 2) — After replicating the duplicate logic from `app/actions/admin/menu-actions.ts:864-909` against a seeded original, the new MenuItem document has: name === `${original.name} (Copy)`; `_id !== original._id`; `slug` ends with `-copy-${ts}` (or is null if original had no slug); `isAvailable === false`. Original MenuItem is unchanged.
+- **AC3** (Spec 3) — After `ProductionService.voidBatch({ productionId, voidedBy: superAdminId, voidedByName, voidedByRole: 'super-admin', reasonNote? })` against a seeded production: `production.status === 'voided'`; `production.voidedAt` is set; each `ingredientsDeducted[i]` increment landed on Inventory.currentStock; menu-item Inventory.currentStock decreased by `production.actualYield`; 2 StockMovement rows written (one per ingredient + one for yield reversal).
+- **AC4** (Spec 3 idempotency) — Calling `voidBatch` twice in succession on the same productionId leaves DB state unchanged on the second call (no double-reversal).
+
+## Technical approach
+
+Mirror REQ-070's pattern — Playwright runner connects directly to UAT Mongo, seeds + asserts at the storage/service layer.
+
+- Specs use the existing `MONGODB_UAT_EXTERNAL_URI` (already in `.env.local`) — same env var that REQ-070 and REQ-069's existing specs use.
+- Each spec seeds + tears down its own state in `beforeAll` / `afterAll` (no cross-test residue on UAT).
+- Spec 1 + Spec 2 use `MenuItemModel.create()` directly + the spec asserts post-state.
+- Spec 3 uses `ProductionService.voidBatch()` directly (imported statically) + asserts on Inventory + StockMovement collections.
+- Synthetic identifiers (e.g. `e2e-req073-{ts}` slugs) to avoid collisions with real menu items.
+
+What this pins:
+
+- ✓ Storage-layer correctness of each destructive op
+- ✓ State invariants across collections (Spec 3: Inventory + StockMovement + Production)
+- ✓ Idempotency (Spec 3)
+
+What this does NOT pin (deferred):
+
+- ✗ Action-layer auth wrapping (session cookie → `requireRole(['admin','super-admin'])`) — covered by separate action unit tests; out of scope for V1 E2E
+- ✗ UI flows (admin menu list → delete button → confirm modal → row removed) — deferred to V2 browser-context specs
+- ✗ Audit-log row writes from the action layer — Spec 1/2 don't drive the action so `AuditLog.create` isn't fired; Spec 3 verifies StockMovement rows (the void path's audit trail)
+
+Same honest framing as REQ-070's dynamic-import disclosure.
+
+## Out of scope (deferred to follow-up cycles within #296)
+
+| Item                                                                          | Why deferred                                                                                                               |
+| ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `tab-delete-reverses-payments.spec.ts` (REQ-TABMGT-004)                       | Multi-collection state changes (payments reversed + customer points restored + tab status flip). Complex seed + assertion. |
+| `force-password-change.spec.ts` (REQ-AUTHA-003)                               | UI-driven; needs browser context + admin login flow + session redirect handling.                                           |
+| `data-deletion-request-approval.spec.ts` (REQ-SETTINGS-004 + REQ-PRIVACY-002) | Admin workflow UI + cascade verification across multiple collections.                                                      |
+| `soft-delete-enforcement.spec.ts` (REQ-PRIVACY-002)                           | UI-driven across multiple admin views (orders list, revenue reports).                                                      |
+| `kitchen-ingredient-archive.spec.ts` (REQ-KITCHEN-006)                        | Same pattern as void-batch but lower urgency; ships easily in V2 once the helper pattern is established.                   |
+
+These ship in follow-up REQs within sub-issue #296.
+
+## Security considerations
+
+- All seed + teardown operations use `MONGODB_UAT_EXTERNAL_URI` (UAT only — never production). Honors `feedback_no_prod_db_touches`.
+- Synthetic identifiers (`e2e-req073-{ts}` prefixed) — guarantees no collision with real records.
+- `afterAll` deletes every seeded document by `_id`. No leftover state on UAT after a clean run.
+- No production code changes shipped.
+
+## Dependencies
+
+- `mongodb` driver (already in `package.json`).
+- `@playwright/test` (already in regression project).
+- `MONGODB_UAT_EXTERNAL_URI` — operator's local env (already there).
+
+## Test scope
+
+See `compliance/evidence/REQ-073/test-scope.md` for the full breakdown.
+
+## Quality gates
+
+| Gate                       | Expected                                       |
+| -------------------------- | ---------------------------------------------- |
+| `npx tsc --noEmit`         | exit 0                                         |
+| `npx vitest run` (full)    | 0 failures (unchanged — zero unit tests added) |
+| Focused E2E (UAT)          | 0 failures                                     |
+| Full regression pack (UAT) | green                                          |
+
+## Stage plan
+
+- [x] Stage 1 — Plan (this doc, operator-approved 2026-06-05)
+- [ ] Stage 2 — Implement 3 specs; live-pass against UAT
+- [ ] Stage 3 — Compile evidence (6-doc pack + release ticket)
+- [ ] Stage 4 — Submit for UAT review (PR open)
+- [ ] Stage 5 — Merge + close-out


### PR DESCRIPTION
## Unblocks release PR [#309](https://github.com/metasession-dev/wawagardenbar-app/pull/309) (v2026.06.05)

The `Compliance Validation` gate on #309 failed because `scripts/validate-compliance-artifacts.sh` expects implementation plans at `compliance/evidence/REQ-XXX/implementation-plan.md` for any MEDIUM/HIGH-risk REQ. The newer REQs in this bundle only had their plans at `compliance/plans/REQ-XXX/implementation-plan.md`.

REQ-066 has its plan mirrored in BOTH locations, which is why it passes the gate; REQ-069 through REQ-073 only had `compliance/plans/`.

## Fix

Copy the 4 affected plan files from `compliance/plans/` into `compliance/evidence/`. **Byte-identical** content — no edits.

| REQ | Risk (per RTM) | Plan added at |
|---|---|---|
| REQ-069 | MEDIUM | `compliance/evidence/REQ-069/implementation-plan.md` |
| REQ-070 | MEDIUM | `compliance/evidence/REQ-070/implementation-plan.md` |
| REQ-071 | LOW (validator false-positive due to loose grep) | `compliance/evidence/REQ-071/implementation-plan.md` |
| REQ-073 | MEDIUM | `compliance/evidence/REQ-073/implementation-plan.md` |

REQ-072 (LOW, no cross-ref hits) wasn't flagged and doesn't need a copy.

## Why REQ-071 errored despite being LOW

`grep "REQ-071" compliance/RTM.md | grep -qiE 'MEDIUM|HIGH'` matches if **any** line containing "REQ-071" also contains MEDIUM/HIGH. The REQ-071 row itself is LOW, but it appears in cross-references inside MEDIUM rows (e.g. REQ-070's narrative mentions REQ-069/070/071 in the "Related" section). The validator's grep can't distinguish "this is the REQ-071 row" from "this row mentions REQ-071".

That's a separate framework follow-up — for now adding the plan to `compliance/evidence/REQ-071/` satisfies the gate.

## Risk

**LOW** — pure documentation file relocation. Content byte-identical to what's already on develop under `compliance/plans/`. No production code change. No new files outside `compliance/evidence/`.

## Follow-up

Filing against DevAudit-Installer:

1. Update `validate-compliance-artifacts.sh` to also accept `compliance/plans/REQ-XXX/implementation-plan.md` (or both), and tighten the risk-level grep to only match the row that **starts with** the REQ ID.
2. Update the `sdlc-implementer` skill to either write plans to `compliance/evidence/` directly, or mirror to both directories (matching REQ-066's pattern).

## After merge

1. CI re-runs on release PR #309
2. `Compliance Validation` gate turns ✓
3. Then safe to approve UAT on the portal per `feedback_wait_for_ci`

🤖 Generated with [Claude Code](https://claude.com/claude-code)