### PR TITLE
chore: one-off workflow to republish per-REQ evidence under v2026.06.05

### DIFF
--- a/.github/workflows/_one-off-bundle-evidence-republish-v2026.06.05.yml
+++ b/.github/workflows/_one-off-bundle-evidence-republish-v2026.06.05.yml
@@ -1,0 +1,86 @@
+name: '[one-off] Republish per-REQ evidence under v2026.06.05 bundle release'
+
+# One-off workflow for the v2026.06.05 housekeeping bundle release.
+#
+# Symptom unblocked: portal shows "No evidence yet" + Approve-UAT button
+# disabled on the v2026.06.05 release record. Per-REQ evidence was uploaded
+# correctly to releases REQ-069/070/071/072/073 by the standard compliance-
+# evidence.yml workflow, but the bundle release record at v2026.06.05 has
+# only the release ticket + security summary — no test evidence.
+#
+# Root cause + framework fix tracked at DevAudit-Installer #122 (scope
+# expansion comment 2026-06-05). This workflow is the operator-side
+# workaround to unblock THIS release while the framework fix is in flight.
+#
+# Pushes `test-execution-summary.md` from each REQ-069/070/071/072/073
+# evidence directory with `--release v2026.06.05` so the portal's evidence-
+# present gate flips ✓.
+#
+# DELETE THIS FILE after the release ships — it's a one-off, not part of the
+# regular workflow set.
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "republish" to confirm. This is a manual operator unblock for the v2026.06.05 release.'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  republish:
+    name: Republish per-REQ evidence under v2026.06.05
+    runs-on: ubuntu-latest
+    if: ${{ inputs.confirm == 'republish' }}
+    env:
+      DEVAUDIT_API_KEY: ${{ secrets.DEVAUDIT_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: develop
+
+      - name: Resolve DevAudit base URL
+        id: resolve
+        run: |
+          BASE=$(jq -r '.devaudit.base_url // empty' sdlc-config.json)
+          if [ -z "$BASE" ]; then
+            echo "::error::devaudit.base_url not set in sdlc-config.json"
+            exit 1
+          fi
+          echo "DEVAUDIT_BASE_URL=${BASE%/}" >> "$GITHUB_ENV"
+          echo "DevAudit base: ${BASE}"
+
+      - name: Republish each REQ's test-execution-summary under v2026.06.05
+        run: |
+          chmod +x scripts/upload-evidence.sh
+          PROJECT_SLUG="wawagardenbar-app"
+          RELEASE="v2026.06.05"
+          GIT_SHA=$(git rev-parse HEAD)
+          BRANCH="develop"
+
+          for REQ in REQ-069 REQ-070 REQ-071 REQ-072 REQ-073; do
+            FILE="compliance/evidence/${REQ}/test-execution-summary.md"
+            if [ ! -f "$FILE" ]; then
+              echo "::warning::${FILE} missing — skipping ${REQ}"
+              continue
+            fi
+            echo ""
+            echo "=== Republishing ${REQ}/test-execution-summary.md under ${RELEASE} ==="
+            bash scripts/upload-evidence.sh \
+              "${PROJECT_SLUG}" "${REQ}" "test_report" "$FILE" \
+              --release "${RELEASE}" \
+              --create-release-if-missing \
+              --environment uat \
+              --category test_report \
+              --git-sha "${GIT_SHA}" \
+              --branch "${BRANCH}"
+          done
+
+      - name: Summary
+        run: |
+          echo "Republished 5 per-REQ test-execution-summary.md files under release v2026.06.05."
+          echo "Portal evidence-present gate should now flip to ✓ on the v2026.06.05 UAT environment."
+          echo "Operator: refresh the portal release page + retry Approve UAT."


### PR DESCRIPTION
## Unblocks v2026.06.05 release PR [#309](https://github.com/metasession-dev/wawagardenbar-app/pull/309)

The bundle release `v2026.06.05` on the portal shows "**No evidence yet**" + Approve-UAT button **disabled**, even though all 5 constituent REQs have their evidence uploaded under per-REQ releases (REQ-069/070/071/072/073). Per-REQ attribution is correct; bundle visibility is missing.

Root cause + framework fix scope appended to [DevAudit-Installer #122](https://github.com/metasession-dev/DevAudit-Installer/issues/122#issuecomment-4633689515). This PR adds a **one-off workflow_dispatch** to unblock THIS release while the framework fix is in flight.

## What it does

Iterates `REQ-069/070/071/072/073` and re-uploads each REQ's `compliance/evidence/<REQ>/test-execution-summary.md` with:

- `--release v2026.06.05`
- `--environment uat`
- `--category test_report`

5 files, ~5 seconds. Portal's evidence-present gate flips ✓ once they land.

## Why a workflow + not a local script

The `DEVAUDIT_API_KEY` is only in GitHub Actions secrets, not in any local env. The workflow runs in CI with that secret automatically wired.

## Safety

- `workflow_dispatch` with a `confirm: 'republish'` gate — random invocation gated by typing the literal word
- `permissions: contents: read` only
- File prefixed with `_` to mark for deletion after the release ships
- No side effects beyond uploading existing files to a different release tag

## After merge

1. **You: dispatch the workflow** — Actions tab → `[one-off] Republish per-REQ evidence under v2026.06.05 bundle release` → Run workflow → confirm: `republish`
2. Workflow runs ~10-20 seconds, uploads 5 files
3. Refresh portal v2026.06.05 release page
4. **Approve UAT button should be enabled** → flip it
5. Approve Production
6. Re-run Release Approval gate on PR #309 → turns green
7. Merge PR #309

## Cleanup (later)

Delete `.github/workflows/_one-off-bundle-evidence-republish-v2026.06.05.yml` after the release ships. Small `chore:` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)