### PR TITLE
chore: devaudit update to 0.1.42

### DIFF
--- a/.claude/skills/requirements-aligner/SKILL.md
+++ b/.claude/skills/requirements-aligner/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: requirements-aligner
+description: Catch drift between docs/SRS.md (the requirements source-of-truth) and the in-flight implementation. Runs at Stage 1 (plan APPROVAL) and Stage 3 (evidence pack) of the SDLC. Parses each REQ's acceptance criteria, fuzzy-matches each AC against existing SRS items, proposes new `REQ-AREA-NNN` stubs for behaviour the SRS doesn't yet describe, flags potentially-stale SRS items whose source-of-truth file was modified without the SRS prose being updated, and produces a per-REQ `compliance/evidence/REQ-XXX/srs-alignment.md` artefact that traces the audit back from code to spec. Use when invoking on a single REQ ("align SRS for REQ-066", "what SRS items did this REQ need?", "is the SRS in sync with this branch?"); when `sdlc-implementer` delegates at Stage 1 plan-approval or Stage 3 evidence-compilation; when running a branch-wide audit ("audit SRS drift across this PR's commits"). Do NOT use for SRS authoring from scratch (the operator drafts new items; this skill proposes the IDs and stubs); for changing the SRS prose conventions themselves (those are operator decisions); for framework-clause mapping of the `srs_alignment` evidence type (that's META-COMPLY's `framework-registry-auditor`).
+---
+
+# Requirements Aligner
+
+Catches the class of drift the wawagardenbar-app REQ-066 cycle surfaced: code, tests, and screenshots shipped across 10 ACs in 6 PRs while `docs/SRS.md` stayed untouched. Seven new SRS items + one stale item were filed retroactively after release. This skill catches them at Stage 1 or Stage 3, before merge.
+
+The skill is **Phase A scope** (per [DevAudit-Installer#119](https://github.com/metasession-dev/DevAudit-Installer/issues/119) review): Stage 1 + Stage 3 hooks only. Stage 2 (commit-time advisory) + Stage 5 (post-release audit) + automatic follow-up issue filing all defer to Phase B/C — the v1 surface is the safest enforcement points.
+
+## What this skill owns
+
+| Artefact                                                                 | Lives at                   | Tier                 |
+| ------------------------------------------------------------------------ | -------------------------- | -------------------- |
+| `docs/SRS.md` (the SoT, project-spanning)                                | Top-level project docs     | 2 (project strategy) |
+| `compliance/evidence/REQ-XXX/srs-alignment.md` (per-REQ Tier 3 evidence) | Per-REQ evidence directory | 3 (per-REQ)          |
+
+The skill does **not** own the SRS prose conventions (operator decision). It does propose new `REQ-AREA-NNN` IDs + Given/When/Then stubs the operator then edits.
+
+## Scope
+
+**In scope**
+
+- Phase 1 (Stage-1 hook) — parse plan AC table → fuzzy-match against `docs/SRS.md` → propose new IDs / flag stale → inject into plan's "SRS items proposed/touched" section.
+- Phase 2 (Stage-3 hook) — drop `compliance/evidence/REQ-XXX/srs-alignment.md` with the per-REQ trace from AC to SRS item.
+- Per-REQ alignment audit (operator invocation).
+- Branch-wide alignment audit (operator invocation — walks every REQ touched on the branch).
+
+**Out of scope**
+
+- Drafting SRS prose from scratch — the skill proposes stubs; the operator authors final language.
+- Stage 2 (commit-time advisory) — deferred to Phase B.
+- Stage 5 (post-release audit) — deferred to Phase B.
+- Automatic follow-up issue filing — deferred to Phase C (default OFF per [#119 review](https://github.com/metasession-dev/DevAudit-Installer/issues/119#issuecomment-4631840651)).
+- Threat modelling, ADR drafting, risk-register entries — adjacent skills (`adr-author`, `risk-register-keeper`).
+- Framework-clause mapping of the `srs_alignment` evidence type — that's META-COMPLY's `framework-registry-auditor`.
+
+## The workflow
+
+Five phases. Phase 0 routes; Phases 1–2 are the SDLC stage hooks; Phases 3–4 are utilities; Phase 5 reports.
+
+### Phase 0 — Route
+
+Determine what's being aligned:
+
+- **Stage-1 plan APPROVAL** — `sdlc-implementer` (or operator) says _"align SRS for REQ-XXX before approving the plan"_ → Phase 1.
+- **Stage-3 evidence pack** — `sdlc-implementer` (or operator) says _"drop the srs-alignment.md for REQ-XXX"_ → Phase 2.
+- **Per-REQ ad-hoc audit** — operator says _"is the SRS in sync with REQ-XXX?"_ / _"what SRS items did this REQ need?"_ → Phase 3.
+- **Branch-wide audit** — operator says _"audit SRS drift across this branch"_ / _"every REQ on develop since main needs an SRS check"_ → Phase 4.
+
+The skill does not fire spontaneously. The parent skill (`sdlc-implementer`) invokes it at Stages 1 + 3 per the parent's SKILL.md delegation contract.
+
+### Phase 1 — Stage-1 plan APPROVAL hook
+
+Input: the REQ's `compliance/plans/REQ-XXX/implementation-plan.md` plus the working-tree diff.
+
+**Step 1 — Parse the AC table.** The implementation plan template carries an "Acceptance Criteria" or equivalent section listing AC1, AC2, … with one-line descriptions of each behavioural change.
+
+**Step 2 — Fuzzy-match each AC against `docs/SRS.md`.** For each AC, search the SRS for items whose:
+
+- _Title_ phrase appears in the AC description, OR
+- _Implementation source-of-truth_ footnote names a file the AC's diff touches, OR
+- _Given/When/Then_ prose semantically aligns with the AC (use the AC's verbs + nouns as the match-key).
+
+**Step 3 — Categorise each AC:**
+
+| AC ⇒ SRS state                                                                                                                              | Action                                                                                                                            |
+| ------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| **Exact match** — AC traces 1:1 to an existing SRS item, no behavioural delta                                                               | Record the mapping; no SRS edit needed                                                                                            |
+| **Match + drift** — existing SRS item covers the AC's surface but the behaviour has shifted (e.g. new field, new edge case, new error path) | Flag the item as _potentially stale_; the plan must mark it for update in this cycle OR justify why the SRS prose still covers it |
+| **No match** — AC introduces behaviour the SRS doesn't yet describe                                                                         | Propose new `REQ-AREA-NNN` (next free ID per area — see Step 4) with a Given/When/Then stub the operator edits                    |
+| **Reverse drift** — an SRS item points at code that's been removed in this REQ                                                              | Propose deprecation: the SRS item is now obsolete                                                                                 |
+
+**Step 4 — Allocate new SRS-IDs.** Scan `docs/SRS.md` for the max-existing ID per `REQ-AREA` prefix (`REQ-ORDER`, `REQ-INV`, `REQ-OPS`, etc.) and propose `+1` for each new item. The skill does NOT support cross-branch ID coordination — if two parallel branches both consume the same next-free ID, git merge on `docs/SRS.md` is the canonical conflict signal. Re-run the skill post-merge to re-allocate.
+
+**Step 5 — Inject into the implementation plan.** The plan's "SRS items proposed/touched" section (added to `Implementation_Plan_TEMPLATE.md` alongside this skill's introduction) carries a table:
+
+```markdown
+## SRS items proposed/touched
+
+| AC  | SRS item                     | Status                | Notes                            |
+| --- | ---------------------------- | --------------------- | -------------------------------- |
+| AC1 | REQ-ORDER-005 (existing)     | unchanged             | Trace-only                       |
+| AC2 | REQ-INV-010 (new — proposed) | stub                  | <one-line behaviour description> |
+| AC3 | REQ-INV-011 (new — proposed) | stub                  | <one-line>                       |
+| AC4 | REQ-ORDER-002 (existing)     | stale — update needed | <one-line: what's drifted>       |
+```
+
+For **deferred** items (the operator decides the AC genuinely doesn't need an SRS entry), the row carries `@srs-deferred: <reason>` so the deferral is visible.
+
+**Step 6 — Block plan APPROVAL** until each AC has either:
+
+- (a) an existing SRS item it traces to, with no drift, OR
+- (b) a new SRS-ID stub added in this cycle, OR
+- (c) an explicit `@srs-deferred: <reason>` annotation in the AC row.
+
+The block is configurable via `sdlc-config.json` — see _Configuration_ below. For projects with sparse SRS, the **ramp-up mode** defaults to audit-only for the first N runs (default 5) so operators get used to the surface before it starts blocking.
+
+### Phase 2 — Stage-3 evidence pack hook
+
+Input: the REQ's implementation plan (post-approval) and the working-tree diff.
+
+**Step 1 — Generate `compliance/evidence/REQ-XXX/srs-alignment.md`.** Format:
+
+```markdown
+---
+req: REQ-XXX
+generated_by: requirements-aligner
+generated_at: <ISO timestamp>
+---
+
+# SRS alignment — REQ-XXX
+
+## ACs traced
+
+| AC  | SRS item      | Action this cycle              |
+| --- | ------------- | ------------------------------ |
+| AC1 | REQ-ORDER-005 | unchanged                      |
+| AC2 | REQ-INV-010   | added (new — see Phase 1 stub) |
+| AC3 | REQ-INV-011   | added (new)                    |
+| AC4 | REQ-ORDER-002 | updated (drift)                |
+
+## Operator sign-off
+
+I have reviewed the AC-to-SRS-item traces above and confirm:
+
+- [ ] Each AC has a defensible SRS item.
+- [ ] New SRS items have been edited from stubs to canonical Given/When/Then prose.
+- [ ] Stale items have been brought current.
+
+**Reviewer:** <operator-name>
+**Date:** <YYYY-MM-DD>
+```
+
+**Step 2 — Tag for upload.** The CI's `compliance-evidence.yml` uploads this file as `evidence_type=srs_alignment` (added to META-COMPLY's `EVIDENCE_TYPE_REGISTRY` in the paired sub-PR). The framework-coverage matrix then closes `ISO29119.3.4` (Test Plan — requirements traceability) and `SOC2.CC2.1` (Communication of policies — when paired with INSTRUCTIONS.md) for this REQ.
+
+**Step 3 — Hand-off back to `sdlc-implementer`.** The skill's job ends at the artefact + the operator sign-off. The parent orchestrator continues with the rest of Stage 3 (security summary, evidence upload, release ticket).
+
+### Phase 3 — Per-REQ ad-hoc audit
+
+Same logic as Phase 1's Step 2 + Step 3, but produces a markdown report rather than blocking. Useful when an operator asks _"is REQ-XXX's SRS coverage healthy?"_ outside the SDLC orchestration flow.
+
+### Phase 4 — Branch-wide audit
+
+For each REQ that has commits on the current branch (or in a specified range), run Phase 3. Produces an aggregated report listing per-REQ alignment status across the branch.
+
+### Phase 5 — Report
+
+- For Phase 1 — the plan's injected table + the block/allow decision.
+- For Phase 2 — the artefact path + summary line.
+- For Phase 3 / 4 — markdown report (one per REQ, or aggregated for branch audit).
+
+## Configuration (sdlc-config.json)
+
+```json
+{
+  "requirements_aligner": {
+    "enabled": true,
+    "block_on_stage_1": false,
+    "block_on_stage_3": true,
+    "auto_file_followup_issue": false,
+    "ramp_up_runs": 5
+  }
+}
+```
+
+Per the [#119 review](https://github.com/metasession-dev/DevAudit-Installer/issues/119#issuecomment-4631840651) defaults:
+
+- `block_on_stage_1: false` — advisory at Stage 1 by default. Operators flip to `true` once the SRS is populated enough that the skill is reliably catching real drift, not false-positives on sparse coverage.
+- `block_on_stage_3: true` — the per-REQ evidence pack is the hard gate (the Stage 3 artefact is what actually lands as evidence; missing it leaks).
+- `auto_file_followup_issue: false` — the skill never opens GitHub issues automatically. If gaps are detected at Stage 1 and the operator chooses to defer, the operator files the follow-up issue manually (or asks the skill to draft one, then confirms before filing).
+- `ramp_up_runs: 5` — on projects whose SRS is sparse, the first 5 invocations are audit-only regardless of `block_on_stage_1`. After 5 successful runs the configured blocking kicks in.
+
+## Principles
+
+**Don't author the SRS prose.** The skill proposes IDs + stubs the operator edits. Inventing canonical SRS language without operator review is exactly the kind of silent-drift this skill exists to prevent.
+
+**Fuzzy-match, don't presume.** When an AC matches an SRS item with low confidence, the skill surfaces the candidate and asks. False-positive matches (linking an unrelated SRS item to an AC) are worse than no match — they hide the gap they were trying to surface.
+
+**Block at Stage 3, advise at Stage 1.** The implementation plan can carry `@srs-deferred` annotations and ship. The evidence pack cannot — the per-REQ `srs-alignment.md` artefact must exist before Stage 3 completes. This is the asymmetric enforcement the [#119 review](https://github.com/metasession-dev/DevAudit-Installer/issues/119#issuecomment-4631840651) recommended.
+
+**Sibling-skill awareness.** When this skill proposes a new SRS-ID for an AC that documents an architectural decision, cross-link the proposed `adr-author` ADR (and vice versa). When it proposes an SRS-ID covering a HIGH-risk behaviour, cross-link the proposed `risk-register-keeper` RISK entry. The three SoT-alignment skills work together; each produces its own per-REQ Tier 3 artefact but they share the per-REQ context.
+
+**Ramp-up is the kindness.** Projects whose `docs/SRS.md` is sparse will trip every check on first contact. Audit-only first 5 runs gives operators time to populate the SoT before the blocking enforces.
+
+## References
+
+- [DevAudit-Installer#119](https://github.com/metasession-dev/DevAudit-Installer/issues/119) — the issue this skill closes, with the case study (wawagardenbar-app REQ-066) + the locked Phase A scope.
+- `sdlc-implementer/SKILL.md` Phase 1 + Phase 3 — the parent-skill invocation contract.
+- `sdlc/files/_common/Implementation_Plan_TEMPLATE.md` — carries the "SRS items proposed/touched" section this skill populates (companion change in this PR).
+- `sdlc/files/_common/3-compile-evidence.md` — the test-scope template gains an SRS-ID cross-reference table (companion change in this PR).
+- Sibling skills (forthcoming): `adr-author` (DevAudit-Installer#120), `risk-register-keeper` (DevAudit-Installer#121).
+- Meta-reviewer (META-COMPLY): `framework-registry-auditor` reviewed the `srs_alignment` evidence type's clause mappings before the META-COMPLY sub-PR opened. Per #119 sequencing.
+- Memory cross-link: `project_srs_supersedes_requirements` (docs/SRS.md is the requirements SoT — REQ-AREA-NNN; RTM uses REQ-XXX); `feedback_check_git_before_filing_from_umbrella` (Phase 5 post-release audit must grep git before claiming SRS-IDs are missing — deferred to Phase B but worth noting).

--- a/.claude/skills/sdlc-implementer/SKILL.md
+++ b/.claude/skills/sdlc-implementer/SKILL.md
@@ -68,9 +68,10 @@ Runs **first**, before any `REQ-XXX` is assigned. It decides which of the six ch
    4. Body heuristics — acceptance criteria, or risk signals (auth, payments, RBAC, data egress, AI decisioning) → tracked, and raise the risk class.
 
    Map the result to one of the six paths in `change-workflows.md`.
+
 3. **Announce a "Workflow Decision" block** (template below): change-type, commit-type, whether a `REQ-XXX` is needed, risk class, which stages/gates run, which approvals the **operator** must perform (UAT four-eyes, Production approval), and what is **skipped**.
 4. **Pause policy — pause-when-it-matters.** Pause for explicit confirmation on **tracked / heavier** paths, or when classification is **ambiguous**; **announce-and-auto-proceed** on trivial / housekeeping. The operator can always reclassify ("treat this as housekeeping" / "this is HIGH risk").
-5. **Route — and stay on to completion.** A route is a choice of *which workflow to drive*, never a hand-off that abandons the operator. Whatever the path, the skill keeps guiding step by step until no further action is required (typically: merged).
+5. **Route — and stay on to completion.** A route is a choice of _which workflow to drive_, never a hand-off that abandons the operator. Whatever the path, the skill keeps guiding step by step until no further action is required (typically: merged).
    - **tracked** (feature / bug fix / refactor / perf) → continue into Phase 1 below (full Stages 1–5).
    - **housekeeping / trivial** → drive the **Lightweight path** below to completion. No `REQ-XXX`, no RTM row, no evidence pack, no portal release approvals — but the skill still branches, runs the gates, opens the PR, and walks the operator through review → merge.
    - **compliance-doc-only** → drive the same Lightweight path as a docs push (or PR, per the project's flow) referencing the **existing** `REQ-XXX`: no new requirement and no quality-gate ceremony, but driven through to merge.
@@ -79,6 +80,7 @@ Runs **first**, before any `REQ-XXX` is assigned. It decides which of the six ch
 **"Workflow Decision" announcement template**
 
 > **Workflow decision — #N**
+>
 > - **Change type:** \<Feature | Bug fix | Refactor/Perf | Housekeeping | Trivial | Compliance-doc-only\>
 > - **Commit type:** \<feat | fix | refactor | chore | docs | …\>
 > - **Requirement:** \<REQ-XXX assigned | none\>
@@ -87,13 +89,13 @@ Runs **first**, before any `REQ-XXX` is assigned. It decides which of the six ch
 > - **Gates/evidence:** \<…\>
 > - **Your approvals:** \<UAT four-eyes + Production approval | PR review only\>
 > - **Skipped:** \<…\>
-> Proceed? *(or reclassify)*
+>   Proceed? _(or reclassify)_
 
 Only the **tracked** route continues into Phase 1; the others run the Lightweight path below. The off-ramps are deliberate — dragging housekeeping through tracked-change machinery it doesn't need is exactly the failure mode this step exists to prevent — but they are still **driven to completion**, never dumped as a checklist for the operator to run alone.
 
 **Worked examples** (one per change-type the skill keeps mis-routing without one):
 
-*Tracked feature — REQ-XXX assigned*
+_Tracked feature — REQ-XXX assigned_
 
 > - **Change type:** Feature
 > - **Commit type:** feat
@@ -104,7 +106,7 @@ Only the **tracked** route continues into Phase 1; the others run the Lightweigh
 > - **Your approvals:** UAT four-eyes + Production approval
 > - **Skipped:** none
 
-*Test fix surfaced by suite drift*
+_Test fix surfaced by suite drift_
 
 > - **Change type:** Housekeeping (test maintenance)
 > - **Commit type:** test
@@ -115,7 +117,7 @@ Only the **tracked** route continues into Phase 1; the others run the Lightweigh
 > - **Your approvals:** PR review only
 > - **Skipped:** RTM, evidence pack, UAT four-eyes, Production approval
 
-*Workflow tweak (CI artifact upload, gate timeout bump, etc.)*
+_Workflow tweak (CI artifact upload, gate timeout bump, etc.)_
 
 > - **Change type:** Housekeeping (CI maintenance)
 > - **Commit type:** ci
@@ -128,14 +130,14 @@ Only the **tracked** route continues into Phase 1; the others run the Lightweigh
 
 ### Lightweight path (housekeeping / trivial / compliance-doc-only)
 
-Reached from Phase 0 for non-tracked change-types. The skill drives this end-to-end; the only difference from the tracked cycle is the absence of *ceremony*, not the absence of *guidance*. It pauses only where a human is genuinely required (PR review, merge).
+Reached from Phase 0 for non-tracked change-types. The skill drives this end-to-end; the only difference from the tracked cycle is the absence of _ceremony_, not the absence of _guidance_. It pauses only where a human is genuinely required (PR review, merge).
 
 1. **Branch off `$INTEGRATION_BRANCH`** with a housekeeping prefix — `chore/…`, `docs/…`, `ci/…`, `build/…`, `test/…`, or `compliance/…` for a doc-only change against an existing REQ.
 2. **Make the change**, single-purpose. If it turns out to touch runtime behaviour in `app/` / `lib/`, stop and reclassify as tracked — the commit-type rule is the backstop.
 3. **Run all gates locally** (`npm run lint`, `npx tsc --noEmit`, the test suite, `semgrep`, `npm audit` — or the stack-adapter equivalents). Trivial ≠ unverified; never `--no-verify`.
 4. **Commit** with a housekeeping type and **no** `REQ-XXX` — `docs:` / `chore:` / `ci:` / `build:` / `test:` / `revert:` are exempt from the `[REQ-XXX]` rule; a `compliance:` doc-only change references the existing REQ. `Co-Authored-By: Claude` if AI-assisted.
 5. **Push and open the PR** into `$INTEGRATION_BRANCH` (`gh pr create --base "$INTEGRATION_BRANCH" --head <branch>`). CI runs the same quality gates; `compliance-validation.yml` finds no `REQ-XXX` and skips artifact validation.
-6. **For `ci:` changes, verify-via-dispatch before merging.** `gh workflow run <workflow.yml> --ref <branch>` fires the modified workflow against the PR branch. If the change broke a step, the dispatch run fails loudly and you fix-forward *before* the merge ships the broken gate to `$INTEGRATION_BRANCH`. This is the cheapest insurance against silent CI regressions — a `ci:` change that breaks a gate is most damaging *after* it lands.
+6. **For `ci:` changes, verify-via-dispatch before merging.** `gh workflow run <workflow.yml> --ref <branch>` fires the modified workflow against the PR branch. If the change broke a step, the dispatch run fails loudly and you fix-forward _before_ the merge ships the broken gate to `$INTEGRATION_BRANCH`. This is the cheapest insurance against silent CI regressions — a `ci:` change that breaks a gate is most damaging _after_ it lands.
 7. **Report honest status** — wait for CI, name any failing check, fix and re-push. Never announce "ready" while a required check is red.
 8. **Guide review → merge.** A human still reviews the PR (separation of duties). There is **no** portal release approval, no UAT four-eyes, no Production gate, and no close-out. Merge once CI is green and the reviewer approves.
 9. **Done.** A housekeeping push produces at most a bare-date release (`vYYYY.MM.DD`) with no approval gate; a doc-only push attaches its docs to the existing `REQ-XXX` release. No further action required — report completion and stop.
@@ -150,19 +152,21 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
 4. **Detect over-scoping.** If the issue spans clearly distinct deliverables (e.g. "build SAML SSO + reorganise the admin dashboard + migrate from Postgres 14 to 16"), halt with a clear message asking the user to split the issue into separate ones. Do not proceed past Phase 1.
 5. **Write the implementation plan.** Create `compliance/plans/REQ-XXX/implementation-plan.md` from `sdlc/files/_common/Implementation_Plan_TEMPLATE.md` (synced into the consumer's `SDLC/` directory at install). The template's shape is load-bearing — it carries the **Framework attribution** section that closes four framework clauses on upload:
 
-   | Clause | What the plan must contain |
-   |---|---|
-   | **ISO 29119 §3.4** Test Plan | Acceptance criteria + verification strategy per AC. |
-   | **ISO 27001 A.8.25** Secure SDLC | Threat model + secrets / dependency considerations. |
-   | **GDPR Art. 25** Data protection by design | Per-purpose data flows + lawful basis + retention. Explicit "no personal data" callout if not applicable. |
-   | **EU AI Act Art. 11** Technical documentation | Model provenance + oversight path when AI is in scope. Explicit "no AI in scope" callout if not. |
+   | Clause                                        | What the plan must contain                                                                                |
+   | --------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+   | **ISO 29119 §3.4** Test Plan                  | Acceptance criteria + verification strategy per AC.                                                       |
+   | **ISO 27001 A.8.25** Secure SDLC              | Threat model + secrets / dependency considerations.                                                       |
+   | **GDPR Art. 25** Data protection by design    | Per-purpose data flows + lawful basis + retention. Explicit "no personal data" callout if not applicable. |
+   | **EU AI Act Art. 11** Technical documentation | Model provenance + oversight path when AI is in scope. Explicit "no AI in scope" callout if not.          |
 
    For HIGH/CRITICAL also include: threat model (against STRIDE categories applicable to the touched surfaces), four-eyes attestation slot, rollback plan — the template has slots for all of these.
 
    **Don't delete sections** — mark with `N/A — <reason>` if a clause genuinely doesn't apply (e.g. UI-only change with no personal-data scope). Empty stubs commit-then-upload as placeholder evidence and break the audit trail.
-6. **Update `compliance/RTM.md`** with the new entry: REQ-XXX, title, risk class, linked issue, linked test cases (placeholder).
-7. **Post plan summary as an issue comment.** Format: TL;DR; Risk class + signals; Acceptance criteria; Technical approach (one paragraph); Dependencies; Test scope.
-8. **Checkpoint** — pause for human approval **iff** risk class is HIGH or CRITICAL. LOW and MEDIUM pass through to Phase 2 automatically. The checkpoint can be forced on for all classes via the `--require-plan-approval` flag (or `DEVAUDIT_REQUIRE_PLAN_APPROVAL=1` env var) for orgs that want it always-on.
+
+6. **Invoke `requirements-aligner` to populate the SRS-ID column on the AC table.** The plan's "Acceptance criteria" table carries an SRS-ID column per AC; `requirements-aligner` fuzzy-matches each AC against `docs/SRS.md` and proposes new `REQ-AREA-NNN` stubs, flags stale items, or annotates `@srs-deferred`. Don't author the SRS-ID column inline — call via the standard Claude Code Skill mechanism (`Skill(name: "requirements-aligner", …)`). Block plan APPROVAL until every AC has a resolved SRS-ID per the skill's Phase 1 contract (configurable via `sdlc-config.json:requirements_aligner.block_on_stage_1`; ramp-up mode default-on for legacy projects).
+7. **Update `compliance/RTM.md`** with the new entry: REQ-XXX, title, risk class, linked issue, linked test cases (placeholder).
+8. **Post plan summary as an issue comment.** Format: TL;DR; Risk class + signals; Acceptance criteria (with SRS-IDs); Technical approach (one paragraph); Dependencies; Test scope.
+9. **Checkpoint** — pause for human approval **iff** risk class is HIGH or CRITICAL. LOW and MEDIUM pass through to Phase 2 automatically. The checkpoint can be forced on for all classes via the `--require-plan-approval` flag (or `DEVAUDIT_REQUIRE_PLAN_APPROVAL=1` env var) for orgs that want it always-on.
 
 ### Phase 2 — Implement and test (SDLC stage 2)
 
@@ -183,8 +187,9 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
    - `semgrep scan --config auto`
    - `npm audit --audit-level=high` (or stack-adapter equivalent)
 
-   **E2E gate** — run *once*, after the fast gates are clean:
+   **E2E gate** — run _once_, after the fast gates are clean:
    - `npx playwright test` (delegated to `e2e-test-engineer`, which has its own focused-iteration discipline for within-e2e fix-and-verify loops)
+
 6. **On gate failure**, iterate up to N=3 attempts. Each iteration: read the failure output, propose a fix, apply, re-run. On exhausted attempts, halt with the full failure output and surface to the human — never use `--no-verify`, `eslint-disable`, `@ts-expect-error`, `xfail`, or any other bypass.
 7. **Commit** using Conventional Commits with `Ref: REQ-XXX` trailer and `Co-Authored-By: Claude` trailer. One commit per logical step; never amend a commit that's already been pushed.
 8. **Land the work on `$INTEGRATION_BRANCH`.** Push the feature branch, then:
@@ -193,12 +198,15 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
 
 ### Phase 3 — Compile evidence (SDLC stage 3)
 
-1. **Re-run the full test pack** with artefact capture:
+1. **Invoke `requirements-aligner` to drop the per-REQ SRS-alignment artefact.** The skill's Phase 2 produces `compliance/evidence/REQ-XXX/srs-alignment.md` — the per-REQ trace from each AC to its SRS item, with an operator sign-off block. The artefact uploads with `evidence_type=srs_alignment` and closes `ISO29119.3.4` + `SOC2.CC2.1` for the REQ. Call via the standard Skill mechanism; don't inline the alignment logic.
+2. **Re-run the full test pack** with artefact capture:
    - `npm run test:e2e -- --reporter=html` (produces `playwright-report/`)
    - `npx vitest run --coverage` (produces `coverage/`)
-2. **Organise artefacts** under `compliance/evidence/REQ-XXX/` with date-prefixed naming:
+3. **Organise artefacts** under `compliance/evidence/REQ-XXX/` with date-prefixed naming:
+
    ```
    compliance/evidence/REQ-XXX/
+   ├── srs-alignment.md                  ← produced in step 1 by requirements-aligner
    ├── YYYY-MM-DD_e2e-results.json
    ├── YYYY-MM-DD_playwright-report/
    ├── YYYY-MM-DD_traces/                ← per-test trace.zip + error-context.md
@@ -206,8 +214,9 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
    └── YYYY-MM-DD_screenshots/*.png
    ```
 
-   Copy Playwright's `test-results/` folder verbatim into `YYYY-MM-DD_traces/` so trace-by-test-name is available for audit without walking the HTML report's hash-name index. For HIGH/CRITICAL releases the traces are part of the audit trail — *"what state was the page in when test X failed and was overridden?"* answers in one `ls` instead of an HTML-report walk.
-3. **Upload each artefact to the portal**:
+   Copy Playwright's `test-results/` folder verbatim into `YYYY-MM-DD_traces/` so trace-by-test-name is available for audit without walking the HTML report's hash-name index. For HIGH/CRITICAL releases the traces are part of the audit trail — _"what state was the page in when test X failed and was overridden?"_ answers in one `ls` instead of an HTML-report walk.
+
+4. **Upload each artefact to the portal**:
    ```bash
    devaudit push <project-slug> REQ-XXX <evidence-type> <file> \
      --release "v$(date +%Y.%m.%d)" --create-release-if-missing \
@@ -215,9 +224,9 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
      --git-sha "$(git rev-parse HEAD)" \
      --branch "$(git rev-parse --abbrev-ref HEAD)"
    ```
-   Evidence types: `screenshot`, `e2e_result`, `test_report`, `audit_log`, `compliance_document`, `manual_upload`.
-4. **Verify uploads landed.** `gh api` or `curl` against `https://devaudit.metasession.co/projects/<slug>/requirements/REQ-XXX/evidence` should show every artefact.
-5. **Update `compliance/RTM.md`** with portal links for each evidence row.
+   Evidence types: `screenshot`, `e2e_result`, `test_report`, `audit_log`, `compliance_document`, `manual_upload`, `srs_alignment` (from step 1).
+5. **Verify uploads landed.** `gh api` or `curl` against `https://devaudit.metasession.co/projects/<slug>/requirements/REQ-XXX/evidence` should show every artefact.
+6. **Update `compliance/RTM.md`** with portal links for each evidence row.
 
 ### Phase 4 — Submit for UAT review (SDLC stage 4)
 
@@ -234,9 +243,11 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
    - For HIGH/CRITICAL: Rollback plan: reference to `compliance/plans/REQ-XXX/implementation-plan.md` §Rollback
    - Test plan
    - SDLC checklist
+
 2. **Verify the UAT reviewer ≠ skill-trigger user** for HIGH/CRITICAL. If they match, halt with a configuration error: "HIGH/CRITICAL risk requires an independent UAT reviewer; the configured reviewer matches the trigger user — fix the four-eyes attestation slot in the implementation plan and re-run."
 
-   **Solo-operator teams.** On a one-person team, the literal "reviewer ≠ submitter" check is structurally unsatisfiable. The supported interpretation is *actor type, not human identity* — AI tooling (the skill-trigger) and the human operator (the portal-approver) are distinct actors. Document this on the release ticket under `## Sign-off (dual-actor)` with the explicit interpretation, and ensure the human operator has independently reviewed the diff before clicking *Approve Production* in the portal. Without this attestation the four-eyes claim is performative.
+   **Solo-operator teams.** On a one-person team, the literal "reviewer ≠ submitter" check is structurally unsatisfiable. The supported interpretation is _actor type, not human identity_ — AI tooling (the skill-trigger) and the human operator (the portal-approver) are distinct actors. Document this on the release ticket under `## Sign-off (dual-actor)` with the explicit interpretation, and ensure the human operator has independently reviewed the diff before clicking _Approve Production_ in the portal. Without this attestation the four-eyes claim is performative.
+
 3. **Apply labels** — `awaiting-uat-review`, `risk:<class>`.
 4. **Comment on the issue**: "Implementation complete. PR #M opened. Evidence on portal: <link>. UAT review requested. Resume with `resume REQ-XXX` once UAT approval is granted on the portal."
 5. **Hard stop.** Phase 4 ends here. Do not proceed to merge; the human's next action is reviewing on the portal.
@@ -255,7 +266,6 @@ Invoked separately by the user after UAT activity on the portal. Trigger: "resum
 1. **Read portal state.** `curl` `https://devaudit.metasession.co/api/projects/<slug>/releases/<version>` and inspect the approval status.
 
 2. **Branch on state:**
-
    - **UAT approved** → run stage 5:
      - `gh pr merge <M> --merge` (merge commit; `--squash` and `--rebase` are blocked by branch protection on SDLC repos and would break the audit trail).
      - Watch `post-deploy-prod.yml` via `gh run watch` — block until the workflow reaches a terminal state.

--- a/SDLC/3-compile-evidence.md
+++ b/SDLC/3-compile-evidence.md
@@ -23,23 +23,23 @@ description: Compile test, security, and AI evidence, update RTM, create release
 
 **Markdown stays in git. Binary and JSON evidence goes to DevAudit.**
 
-| Artifact | Store in | Why |
-|----------|----------|-----|
-| `compliance/RTM.md` | Git | Source of truth, version history, PR-reviewable |
-| `compliance/evidence/REQ-XXX/test-scope.md` | Git | Planning artifact, reviewed in PRs |
-| `compliance/evidence/REQ-XXX/implementation-plan.md` | Git | Design decisions artifact (MEDIUM/HIGH risk), reviewed in PRs |
-| `compliance/evidence/REQ-XXX/test-plan.md` | Git | Test strategy — tests to add/update/remove, mapped to criteria |
-| `compliance/evidence/REQ-XXX/test-execution-summary.md` | Git | Gate results, test changes, coverage against test plan. **ISO 29119-3 §3.5.6 Test Completion Report for THIS release** — uploaded as `evidence_type=test_report` since v0.1.32, satisfying the portal's Test Reports gate with fresh per-release evidence. |
-| `compliance/evidence/REQ-XXX/ai-use-note.md` | Git | Small markdown, needs PR review |
-| `compliance/evidence/REQ-XXX/ai-prompts.md` | Git | Small markdown, needs PR review |
-| `compliance/evidence/REQ-XXX/security-summary.md` | Git | Small markdown, needs PR review |
-| `compliance/pending-releases/RELEASE-TICKET-*.md` | Git | Reviewed and moved to approved-releases |
-| E2E results (JSON) | DevAudit | Large, bloats git history |
-| Screenshots (PNG/JPG) | DevAudit | Binary, bloats git history |
-| SAST results (JSON) | DevAudit | Large JSON, bloats git history |
-| Dependency audit (JSON) | DevAudit | Large JSON, bloats git history |
-| Unit test output (TXT) | DevAudit | Verbose output, bloats git history |
-| Test reports (HTML) | DevAudit | Binary, bloats git history |
+| Artifact                                                | Store in | Why                                                                                                                                                                                                                                                        |
+| ------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `compliance/RTM.md`                                     | Git      | Source of truth, version history, PR-reviewable                                                                                                                                                                                                            |
+| `compliance/evidence/REQ-XXX/test-scope.md`             | Git      | Planning artifact, reviewed in PRs                                                                                                                                                                                                                         |
+| `compliance/evidence/REQ-XXX/implementation-plan.md`    | Git      | Design decisions artifact (MEDIUM/HIGH risk), reviewed in PRs                                                                                                                                                                                              |
+| `compliance/evidence/REQ-XXX/test-plan.md`              | Git      | Test strategy — tests to add/update/remove, mapped to criteria                                                                                                                                                                                             |
+| `compliance/evidence/REQ-XXX/test-execution-summary.md` | Git      | Gate results, test changes, coverage against test plan. **ISO 29119-3 §3.5.6 Test Completion Report for THIS release** — uploaded as `evidence_type=test_report` since v0.1.32, satisfying the portal's Test Reports gate with fresh per-release evidence. |
+| `compliance/evidence/REQ-XXX/ai-use-note.md`            | Git      | Small markdown, needs PR review                                                                                                                                                                                                                            |
+| `compliance/evidence/REQ-XXX/ai-prompts.md`             | Git      | Small markdown, needs PR review                                                                                                                                                                                                                            |
+| `compliance/evidence/REQ-XXX/security-summary.md`       | Git      | Small markdown, needs PR review                                                                                                                                                                                                                            |
+| `compliance/pending-releases/RELEASE-TICKET-*.md`       | Git      | Reviewed and moved to approved-releases                                                                                                                                                                                                                    |
+| E2E results (JSON)                                      | DevAudit | Large, bloats git history                                                                                                                                                                                                                                  |
+| Screenshots (PNG/JPG)                                   | DevAudit | Binary, bloats git history                                                                                                                                                                                                                                 |
+| SAST results (JSON)                                     | DevAudit | Large JSON, bloats git history                                                                                                                                                                                                                             |
+| Dependency audit (JSON)                                 | DevAudit | Large JSON, bloats git history                                                                                                                                                                                                                             |
+| Unit test output (TXT)                                  | DevAudit | Verbose output, bloats git history                                                                                                                                                                                                                         |
+| Test reports (HTML)                                     | DevAudit | Binary, bloats git history                                                                                                                                                                                                                                 |
 
 ## Release Identity
 
@@ -47,12 +47,12 @@ CI uploads are scoped to a **release record** in DevAudit, keyed by `(project, v
 
 The templated workflows derive the release version from the **latest commit on the branch** via `scripts/derive-release-version.sh`:
 
-| Commit shape | Release version |
-|---|---|
-| Subject `[REQ-037] feat(...)` | `REQ-037` |
-| Subject `feat(...)` + body `Ref: REQ-037` | `REQ-037` |
+| Commit shape                                               | Release version              |
+| ---------------------------------------------------------- | ---------------------------- |
+| Subject `[REQ-037] feat(...)`                              | `REQ-037`                    |
+| Subject `feat(...)` + body `Ref: REQ-037`                  | `REQ-037`                    |
 | Subject contains multiple tags (e.g. `[REQ-037][REQ-038]`) | First match wins → `REQ-037` |
-| No REQ tag (housekeeping, dep bumps) | Bare date → `v2026.05.17` |
+| No REQ tag (housekeeping, dep bumps)                       | Bare date → `v2026.05.17`    |
 
 Both `ci.yml` and `compliance-evidence.yml` call the same helper, so a feature spanning many commits and a mix of code/docs pushes converges on **one** release record. Subject takes priority over body when both are present.
 
@@ -62,19 +62,19 @@ If you need a separate release container for a sub-piece of work — e.g. carvin
 
 A release is classified by its version pattern. **Most of this doc walks the tracked path** (a REQ-XXX-tagged release for a single requirement). For develop pushes that don't carry a REQ tag — typically `docs:`, `chore:`, `ci:`, `build:`, `test:`, `compliance:`, `revert:` — the version-deriver falls back to a bare date and the release is **housekeeping**.
 
-| Shape | Version pattern | Triggered by | Per-REQ ceremony |
-|---|---|---|---|
-| **Tracked** | `REQ-037`, `REQ-046-FIX`, etc. | A `feat`/`fix`/`refactor`/`perf` commit (REQ tag required by commitlint) | Yes — full Steps 1-9 |
-| **Housekeeping** | `v2026.06.04` (bare date, optionally `.N`) | A push containing only REQ-exempt commit types | **No** per-REQ artefacts; the portal auto-skips test-scope, test-plan, implementation-plan, and test-execution-summary completeness checks |
+| Shape            | Version pattern                            | Triggered by                                                             | Per-REQ ceremony                                                                                                                           |
+| ---------------- | ------------------------------------------ | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Tracked**      | `REQ-037`, `REQ-046-FIX`, etc.             | A `feat`/`fix`/`refactor`/`perf` commit (REQ tag required by commitlint) | Yes — full Steps 1-9                                                                                                                       |
+| **Housekeeping** | `v2026.06.04` (bare date, optionally `.N`) | A push containing only REQ-exempt commit types                           | **No** per-REQ artefacts; the portal auto-skips test-scope, test-plan, implementation-plan, and test-execution-summary completeness checks |
 
 ### Housekeeping releases — what's required
 
 Housekeeping releases **skip** the per-requirement evidence (no REQ → no `compliance/evidence/REQ-XXX/` folder) but **still produce two release-scoped artefacts**:
 
-| Artefact | Tracked path | Housekeeping path | Auto-generated by CI? |
-|---|---|---|---|
-| Release ticket | `compliance/pending-releases/RELEASE-TICKET-REQ-XXX.md` (Step 8) | `compliance/pending-releases/RELEASE-TICKET-<version>.md` (e.g. `RELEASE-TICKET-v2026.06.04.md`) | **Yes** — `generate-housekeeping-release-ticket.sh` runs after `derive-release-version.sh` and emits a stub the operator reviews + signs off |
-| Security summary | `compliance/evidence/REQ-XXX/security-summary.md` (Step 4) | `compliance/security-summary-<version>.md` at the compliance root (release-scoped, not REQ-scoped) | **Yes** — `generate-security-summary.sh` scrapes the SAST + dep-audit gate JSON and emits a stub with an operator sign-off block |
+| Artefact         | Tracked path                                                     | Housekeeping path                                                                                  | Auto-generated by CI?                                                                                                                        |
+| ---------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| Release ticket   | `compliance/pending-releases/RELEASE-TICKET-REQ-XXX.md` (Step 8) | `compliance/pending-releases/RELEASE-TICKET-<version>.md` (e.g. `RELEASE-TICKET-v2026.06.04.md`)   | **Yes** — `generate-housekeeping-release-ticket.sh` runs after `derive-release-version.sh` and emits a stub the operator reviews + signs off |
+| Security summary | `compliance/evidence/REQ-XXX/security-summary.md` (Step 4)       | `compliance/security-summary-<version>.md` at the compliance root (release-scoped, not REQ-scoped) | **Yes** — `generate-security-summary.sh` scrapes the SAST + dep-audit gate JSON and emits a stub with an operator sign-off block             |
 
 **The portal evidence check is lenient on filename.** Any file whose name (case-insensitive) starts with `release-ticket` satisfies the release-ticket check, and any file named exactly `security-summary.md` satisfies the security-summary check. The version-suffixed conventions above are recommended for **searchability + audit trail** when a project has many housekeeping releases stacked up — they keep the artefacts distinct per release without needing folder scoping.
 
@@ -103,6 +103,7 @@ gh run list --branch develop --limit 1
 **Do NOT proceed** if CI is failing or was cancelled. Evidence must reflect a green pipeline. If CI failed, return to `2-implement-and-test.md` and fix the issue first.
 
 For MEDIUM/HIGH risk with AI involvement, also verify:
+
 ```bash
 # AI prompt log must exist and be non-empty
 test -s compliance/evidence/REQ-XXX/ai-prompts.md && echo "OK" || echo "MISSING — create ai-prompts.md before proceeding"
@@ -207,6 +208,7 @@ npm test -- --verbose 2>&1 | tee /tmp/unit-test-results.txt
 ```
 
 **Alternative (git-based):** If not using DevAudit, save evidence locally:
+
 ```bash
 cp [E2E_RESULTS_PATH] compliance/evidence/REQ-XXX/
 npm test -- --verbose 2>&1 | tee compliance/evidence/REQ-XXX/unit-test-results.txt
@@ -227,6 +229,7 @@ npm audit --json > /tmp/dependency-audit.json 2>&1
 ```
 
 Create a security summary (keep in git — this is a compliance document, not binary evidence):
+
 ```bash
 cat > compliance/evidence/REQ-XXX/security-summary.md << EOF
 ## Security Evidence Summary — REQ-XXX
@@ -265,6 +268,20 @@ cat compliance/evidence/REQ-XXX/test-scope.md
 # If not, complete the outstanding items before proceeding
 ```
 
+The test-scope artefact carries an **SRS-ID cross-reference table** so each test maps back to the requirement (SoT) it pins. Format:
+
+```markdown
+## SRS coverage
+
+| Test (file)                    | AC  | SRS item      |
+| ------------------------------ | --- | ------------- |
+| e2e/admin-order-flow.spec.ts   | AC1 | REQ-ORDER-005 |
+| services/order-service.test.ts | AC2 | REQ-INV-010   |
+| e2e/incident-dashboard.spec.ts | AC9 | REQ-OPS-001   |
+```
+
+The SRS-ID column populates from the implementation plan's SRS-ID column (populated by the `requirements-aligner` skill at Stage 1). Stage 3 cross-checks consistency: every AC's SRS item should resolve to a real entry in `docs/SRS.md`, every test should pin at least one AC. The skill also drops a `srs-alignment.md` per-REQ artefact alongside this one (Tier 3 evidence with `evidence_type=srs_alignment`).
+
 For MEDIUM/HIGH risk, verify the implementation plan exists and matches what was built:
 
 ```bash
@@ -297,37 +314,45 @@ Create `compliance/pending-releases/RELEASE-TICKET-REQ-XXX.md`:
 ---
 
 ## Summary
+
 [1-3 sentences]
 
 ## AI Involvement
+
 - **AI Tool Used:** [tool / none]
 - **AI-Generated Files:** [list, or "none"]
 - **Human Reviewer of AI Code:** [name]
 - **Components Regenerated:** [none / list]
 
 ## Implementation Details
+
 **Files Modified:**
+
 - `path/to/file1.ts` — [what changed]
 
 **Dependencies Added/Changed:**
+
 - [package@version — purpose — vulnerability status]
 - [or "No dependency changes"]
 
 ## Test Evidence
-| Test Type | Count | Passed | Failed | Evidence Location |
-|-----------|-------|--------|--------|-------------------|
-| E2E (Playwright) | [N] | [N] | 0 | DevAudit portal: [PROJECT_SLUG]/REQ-XXX |
-| Unit | [N] | [N] | 0 | DevAudit portal: [PROJECT_SLUG]/REQ-XXX |
+
+| Test Type        | Count | Passed | Failed | Evidence Location                       |
+| ---------------- | ----- | ------ | ------ | --------------------------------------- |
+| E2E (Playwright) | [N]   | [N]    | 0      | DevAudit portal: [PROJECT_SLUG]/REQ-XXX |
+| Unit             | [N]   | [N]    | 0      | DevAudit portal: [PROJECT_SLUG]/REQ-XXX |
 
 ## Security Evidence
-| Check | Result | Evidence Location |
-|-------|--------|-------------------|
-| SAST | 0 high/critical | DevAudit portal: [PROJECT_SLUG]/REQ-XXX |
-| Dependency Audit | 0 high/critical | DevAudit portal: [PROJECT_SLUG]/REQ-XXX |
-| Access Control | [PASS/N/A] | Git: `compliance/evidence/REQ-XXX/security-summary.md` |
-| Audit Log | [PASS/N/A] | Git: `compliance/evidence/REQ-XXX/security-summary.md` |
+
+| Check            | Result          | Evidence Location                                      |
+| ---------------- | --------------- | ------------------------------------------------------ |
+| SAST             | 0 high/critical | DevAudit portal: [PROJECT_SLUG]/REQ-XXX                |
+| Dependency Audit | 0 high/critical | DevAudit portal: [PROJECT_SLUG]/REQ-XXX                |
+| Access Control   | [PASS/N/A]      | Git: `compliance/evidence/REQ-XXX/security-summary.md` |
+| Audit Log        | [PASS/N/A]      | Git: `compliance/evidence/REQ-XXX/security-summary.md` |
 
 ## Acceptance Criteria
+
 - [x] [From test-scope.md]
 - [x] All E2E tests passing
 - [x] TypeScript clean
@@ -336,14 +361,15 @@ Create `compliance/pending-releases/RELEASE-TICKET-REQ-XXX.md`:
 - [x] AI use documented (if applicable)
 
 ## Risk Assessment
+
 - [Any risks introduced]
 - [New dependencies and trust assessment]
 
 ## Post-Deploy Actions
 
-| Type | Script / Command | Target | Required | Notes |
-|------|-----------------|--------|----------|-------|
-| — | None | — | — | No post-deploy actions required |
+| Type | Script / Command | Target | Required | Notes                           |
+| ---- | ---------------- | ------ | -------- | ------------------------------- |
+| —    | None             | —      | —        | No post-deploy actions required |
 
 <!-- Replace the "None" row above with actual actions if this release requires them:
 | Data migration | `npx tsx scripts/backfill-x.ts "[CONN_STRING]"` | Prod DB | Yes | [description] |
@@ -355,6 +381,7 @@ Create `compliance/pending-releases/RELEASE-TICKET-REQ-XXX.md`:
 ---
 
 ## Reviewer Checklist
+
 - [ ] Code matches requirement
 - [ ] Test evidence present and all-pass
 - [ ] Security evidence present and clean
@@ -369,15 +396,16 @@ Create `compliance/pending-releases/RELEASE-TICKET-REQ-XXX.md`:
 ---
 
 ## Audit Trail
-| Date | Action | Actor | Notes |
-|------|--------|-------|-------|
-| [date] | Requirement created | [who] | Risk: [level] |
-| [date] | Implementation completed | [who] | [details] |
-| [date] | AI code reviewed | [reviewer] | [files] |
-| [date] | Tests passed | [who] | E2E + SAST: clean |
-| [date] | UAT verification passed | [who] | Health + smoke + feature verified |
-| [date] | Post-deploy actions | [who] | [Completed / None required] |
-| [date] | Submitted for review | [who] | PR #[number] |
+
+| Date   | Action                   | Actor      | Notes                             |
+| ------ | ------------------------ | ---------- | --------------------------------- |
+| [date] | Requirement created      | [who]      | Risk: [level]                     |
+| [date] | Implementation completed | [who]      | [details]                         |
+| [date] | AI code reviewed         | [reviewer] | [files]                           |
+| [date] | Tests passed             | [who]      | E2E + SAST: clean                 |
+| [date] | UAT verification passed  | [who]      | Health + smoke + feature verified |
+| [date] | Post-deploy actions      | [who]      | [Completed / None required]       |
+| [date] | Submitted for review     | [who]      | PR #[number]                      |
 ```
 
 ### Step 9: Commit Compliance Docs and Push
@@ -389,6 +417,7 @@ Commit compliance documents and push immediately. Heavy CI gates (E2E, TypeScrip
 If using DevAudit, commit only compliance documents (RTM, release ticket, test scope, AI notes, security summary). Binary evidence (JSON results, screenshots) is stored in DevAudit, not git.
 
 **Before committing, verify all required artifacts exist:**
+
 - [ ] `compliance/evidence/REQ-XXX/test-scope.md`
 - [ ] `compliance/evidence/REQ-XXX/test-plan.md`
 - [ ] `compliance/evidence/REQ-XXX/test-execution-summary.md`
@@ -412,6 +441,7 @@ git push origin develop
 ```
 
 If NOT using DevAudit (git-based evidence):
+
 ```bash
 git add compliance/RTM.md compliance/pending-releases/RELEASE-TICKET-REQ-XXX.md compliance/evidence/REQ-XXX/
 git commit -m "compliance: [REQ-XXX] evidence compiled - awaiting review"
@@ -531,11 +561,11 @@ The script:
 
 Required environment variables for the scripted path:
 
-| Var | What it is | Where to set |
-|---|---|---|
-| `DEVAUDIT_USER_TOKEN` | Personal Access Token (`mctok_…`) attributed to the running user | Issue at `/settings/tokens`; store as a repo secret for CI or `.env` for local |
-| `DEVAUDIT_API_KEY` | Project-scoped API key (existing) | Already set for evidence uploads |
-| `DEVAUDIT_BASE_URL` | DevAudit URL | Resolved by CI templates; locally read from `sdlc-config.json devaudit.base_url` |
+| Var                   | What it is                                                       | Where to set                                                                     |
+| --------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `DEVAUDIT_USER_TOKEN` | Personal Access Token (`mctok_…`) attributed to the running user | Issue at `/settings/tokens`; store as a repo secret for CI or `.env` for local   |
+| `DEVAUDIT_API_KEY`    | Project-scoped API key (existing)                                | Already set for evidence uploads                                                 |
+| `DEVAUDIT_BASE_URL`   | DevAudit URL                                                     | Resolved by CI templates; locally read from `sdlc-config.json devaudit.base_url` |
 
 #### Step 11b — Approve
 
@@ -594,7 +624,7 @@ upload-evidence:
   uses: metasession-dev/devaudit/.github/workflows/upload-evidence.yml@main
   with:
     project-slug: your-project-slug
-    release-version: v2026.03.27       # or use date-based auto-generation
+    release-version: v2026.03.27 # or use date-based auto-generation
     environment: uat
   secrets:
     SUPABASE_URL: ${{ secrets.META_COMPLY_SUPABASE_URL }}
@@ -602,6 +632,7 @@ upload-evidence:
 ```
 
 This automatically:
+
 - Creates the release in DevAudit if it doesn't exist (status: `draft`)
 - Uploads compliance source documents (RTM, test plan, test cases, test summary report)
 - Syncs `known_requirements` from RTM.md for completeness tracking
@@ -612,10 +643,12 @@ This automatically:
 Copy these from `sdlc/files/ci/` into your project's `.github/workflows/`:
 
 **`check-release-approval.yml`** (renamed from `check-uat-approval.yml` in sdlc-v1.22.0) — Release Approval Gate on PRs to main:
+
 - Blocks merge until the release is approved in DevAudit (`uat_approved` / `release_approved` / downstream statuses)
 - Add as a required status check on the `main` branch protection rule
 
 **`post-deploy-prod.yml`** — Production evidence capture after merge to main:
+
 - Runs production smoke tests
 - Uploads production evidence to DevAudit (environment: production)
 - Marks the release as `released`

--- a/SDLC/Implementation_Plan_TEMPLATE.md
+++ b/SDLC/Implementation_Plan_TEMPLATE.md
@@ -1,10 +1,10 @@
 ---
-title: "Implementation plan — REQ-XXX"
-requirement_id: "REQ-XXX"
-risk_class: "REPLACE — HIGH | MEDIUM | LOW"
-change_type: "REPLACE — feat | fix | refactor | perf | chore | docs | ci | build | test | compliance | revert"
-authored_by: "REPLACE — operator / agent"
-authored_at: "REPLACE — YYYY-MM-DD"
+title: 'Implementation plan — REQ-XXX'
+requirement_id: 'REQ-XXX'
+risk_class: 'REPLACE — HIGH | MEDIUM | LOW'
+change_type: 'REPLACE — feat | fix | refactor | perf | chore | docs | ci | build | test | compliance | revert'
+authored_by: 'REPLACE — operator / agent'
+authored_at: 'REPLACE — YYYY-MM-DD'
 ---
 
 > ⚠️ **STARTER TEMPLATE — REPLACE EVERY `REPLACE` MARKER BEFORE COMMITTING.**
@@ -21,24 +21,29 @@ authored_at: "REPLACE — YYYY-MM-DD"
 
 **Closes clauses** (every implementation plan satisfies all four):
 
-| Clause | What this plan must contain |
-|---|---|
-| **ISO 29119 §3.4** Test Plan | Acceptance criteria + the strategy for verifying each one. Reference the per-REQ `test-plan.md` if it lives separately. |
-| **ISO 27001 A.8.25** Secure development life cycle | Threat model + secure-design considerations (auth, data handling, dependencies, secrets). |
+| Clause                                                    | What this plan must contain                                                                                                                                       |
+| --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **ISO 29119 §3.4** Test Plan                              | Acceptance criteria + the strategy for verifying each one. Reference the per-REQ `test-plan.md` if it lives separately.                                           |
+| **ISO 27001 A.8.25** Secure development life cycle        | Threat model + secure-design considerations (auth, data handling, dependencies, secrets).                                                                         |
 | **GDPR Art. 25** Data protection by design and by default | Per-purpose data flows; minimisation; lawful basis; retention. **Required for any REQ that processes personal data; explicit "no personal data" callout if not.** |
-| **EU AI Act Art. 11** Technical documentation (Annex IV) | When the REQ touches AI / model behaviour: model provenance, prompt sources, oversight path. **Explicit "no AI in scope" callout if not.** |
+| **EU AI Act Art. 11** Technical documentation (Annex IV)  | When the REQ touches AI / model behaviour: model provenance, prompt sources, oversight path. **Explicit "no AI in scope" callout if not.**                        |
 
 Each section below maps to one (or more) of these clauses. Don't delete sections — mark with "N/A — <reason>" if the clause genuinely doesn't apply.
 
 ## 1. Goal + acceptance criteria
 
-> *Closes ISO 29119 §3.4 — test plan*
+> _Closes ISO 29119 §3.4 — test plan_
 
 - **Goal:** REPLACE — one sentence describing what this REQ delivers, no jargon.
 - **Acceptance criteria:**
-  - AC1 — REPLACE
-  - AC2 — REPLACE
-  - …
+
+| AC  | Description                                | SRS item it traces to                                                                   |
+| --- | ------------------------------------------ | --------------------------------------------------------------------------------------- |
+| AC1 | REPLACE — one-line behavioural description | REQ-AREA-NNN (existing) / REQ-AREA-NNN (new — propose stub) / `@srs-deferred: <reason>` |
+| AC2 | REPLACE                                    | REPLACE                                                                                 |
+| …   |                                            |                                                                                         |
+
+> **SRS-ID column populated by the `requirements-aligner` skill** at Stage 1 plan APPROVAL. The skill fuzzy-matches each AC against `docs/SRS.md`, proposes new `REQ-AREA-NNN` stubs for behaviour the SRS doesn't yet describe, and flags stale items. Plan APPROVAL blocks (configurable per `sdlc-config.json:requirements_aligner.block_on_stage_1`, ramp-up mode default-on for legacy projects) until every AC has either an existing SRS item, a new SRS-ID stub added in this cycle, or an explicit `@srs-deferred` annotation. See [`requirements-aligner` skill](../skills/requirements-aligner/SKILL.md).
 
 ## 2. Scope
 
@@ -47,12 +52,12 @@ Each section below maps to one (or more) of these clauses. Don't delete sections
 
 ## 3. Threat model + security considerations
 
-> *Closes ISO 27001 A.8.25 — secure development life cycle*
+> _Closes ISO 27001 A.8.25 — secure development life cycle_
 
-| Threat | Likelihood | Impact | Mitigation |
-|---|---|---|---|
-| REPLACE — e.g. SQL injection via X param | REPLACE | REPLACE | REPLACE |
-| REPLACE — e.g. unauthenticated access to Y route | REPLACE | REPLACE | REPLACE |
+| Threat                                           | Likelihood | Impact  | Mitigation |
+| ------------------------------------------------ | ---------- | ------- | ---------- |
+| REPLACE — e.g. SQL injection via X param         | REPLACE    | REPLACE | REPLACE    |
+| REPLACE — e.g. unauthenticated access to Y route | REPLACE    | REPLACE | REPLACE    |
 
 **Secrets / credentials:** REPLACE — does this REQ handle any? If yes, how stored, rotated, scoped?
 
@@ -60,7 +65,7 @@ Each section below maps to one (or more) of these clauses. Don't delete sections
 
 ## 4. Data protection (GDPR Art. 25)
 
-> *Closes GDPR Art. 25 — data protection by design*
+> _Closes GDPR Art. 25 — data protection by design_
 
 **Personal data processed by this REQ:** REPLACE — yes / no.
 
@@ -78,11 +83,11 @@ If **yes**, fill in:
   - Is a DPIA required? REPLACE — yes (file under `compliance/governance/dpia-<reqid>.md`) / no / N/A
 - **Cross-border transfers:** REPLACE — none / specify mechanism
 
-If **no**, write: *"N/A — this REQ does not process personal data. <Why — e.g. UI-only change, internal-routing refactor, dev-tooling.>"*
+If **no**, write: _"N/A — this REQ does not process personal data. <Why — e.g. UI-only change, internal-routing refactor, dev-tooling.>"_
 
 ## 5. AI / model considerations (EU AI Act Art. 11)
 
-> *Closes EUAIA Art. 11 — technical documentation*
+> _Closes EUAIA Art. 11 — technical documentation_
 
 **AI / ML in scope for this REQ:** REPLACE — yes / no.
 
@@ -96,7 +101,7 @@ If **yes**, fill in:
 - **Cross-references:**
   - Is `compliance/governance/ai-disclosure.md` updated? REPLACE — yes / no / N/A
 
-If **no**, write: *"N/A — this REQ does not introduce or change AI behaviour. <Why.>"*
+If **no**, write: _"N/A — this REQ does not introduce or change AI behaviour. <Why.>"_
 
 ## 6. Rollback plan
 


### PR DESCRIPTION
## Summary

Bumps the SDLC sync to **devaudit 0.1.42** ([DevAudit-Installer #123](https://github.com/metasession-dev/DevAudit-Installer/pull/123)).

Ships the new **`requirements-aligner` skill** — Phase 2A of the SoT-alignment skill family. The skill catches SRS drift at:

- **Stage 1 plan APPROVAL** — populates the SRS-ID column on the implementation plan AC table; flags missing or stale SRS items. Advisory by default (`block_on_stage_1: false`, `ramp_up_runs: 5`).
- **Stage 3 evidence pack** — drops `compliance/evidence/REQ-XXX/srs-alignment.md` as Tier 3 evidence (uploads as the new `srs_alignment` evidence type).

Companion META-COMPLY-side `srs_alignment` evidence type is already live on `develop` ([#439](https://github.com/metasession-dev/devaudit/pull/439)). v1 ships as an orphan registry entry per the framework-registry-auditor review — the artefact is visible in the Documents tab + audit-pack export but doesn't close a specific framework clause in this release; operator sign-off in the file body carries the audit value.

## Files changed

- `.claude/skills/requirements-aligner/SKILL.md` (new)
- `.claude/skills/sdlc-implementer/SKILL.md` — delegation contracts at Phase 1 + Phase 3
- `SDLC/Implementation_Plan_TEMPLATE.md` — AC table now has an SRS-ID column
- `SDLC/3-compile-evidence.md` — SRS-ID cross-reference table format added

## Test plan

- [ ] CI on `develop` after merge passes (TypeScript / Semgrep / dep-audit / E2E / build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)