### PR TITLE
chore: devaudit update to 0.1.44 (rolls in 0.1.43)

### DIFF
--- a/.claude/skills/adr-author/SKILL.md
+++ b/.claude/skills/adr-author/SKILL.md
@@ -1,0 +1,267 @@
+---
+name: adr-author
+description: Catch the moment a tracked change makes an architecturally significant decision and either draft the canonical `docs/ADR/ADR-NNN-<slug>.md` artefact or document why no ADR was needed. Runs at Stage 1 (plan APPROVAL) and Stage 3 (evidence pack) of the SDLC. Decides "is this REQ architecturally significant?" via a calibrated heuristic (new third-party dependency, new database/cache/queue, new external service, pattern change spanning >3 files, HIGH/CRITICAL risk class), drafts a Context/Decision/Consequences/Alternatives/Status stub when warranted, allocates the next `ADR-NNN` ID, injects an ADR-NNN reference into the implementation plan, and produces a per-REQ `compliance/evidence/REQ-XXX/architecture-decision.md` artefact. Use when invoking on a single REQ ("draft an ADR for REQ-066", "does this REQ need an ADR?", "is the architectural decision documented?"); when `sdlc-implementer` delegates at Stage 1 plan-approval or Stage 3 evidence-compilation; when an operator asks for ADR-worthiness judgement on an in-flight branch. Do NOT use for authoring full ADR prose end-to-end (the operator edits the stub to canonical wording); for supersession-lifecycle handling (deferred to Phase B); for cross-link maintenance between ADRs and risk-register entries (that's `risk-register-keeper`); for framework-clause mapping of the `architecture_decision` evidence type (that's META-COMPLY's `framework-registry-auditor`).
+---
+
+# ADR Author
+
+Catches the moment a tracked REQ makes an architecturally significant decision that should produce a persistent record — and either drafts the ADR or documents why no ADR was needed. Sibling of [`requirements-aligner`](../requirements-aligner/SKILL.md) and `risk-register-keeper` in the SoT-alignment skill family.
+
+The skill is **Phase A scope** (per [DevAudit-Installer#120](https://github.com/metasession-dev/DevAudit-Installer/issues/120)): Stage 1 + Stage 3 hooks only. Supersession-lifecycle, stale-decision detection, and cross-link maintenance between ADRs and other SoT artefacts all defer to Phase B — the v1 surface is the safest enforcement points.
+
+## What this skill owns
+
+| Artefact                                                                         | Lives at                   | Tier                 |
+| -------------------------------------------------------------------------------- | -------------------------- | -------------------- |
+| `docs/ADR/ADR-NNN-<slug>.md` (the SoT, project-spanning)                         | Top-level project docs     | 2 (project strategy) |
+| `compliance/evidence/REQ-XXX/architecture-decision.md` (per-REQ Tier 3 evidence) | Per-REQ evidence directory | 3 (per-REQ)          |
+
+The skill does **not** own the canonical ADR prose. It drafts a stub the operator edits to publication-grade wording. Inventing decision rationale without operator review is exactly the kind of silent-drift this skill exists to prevent.
+
+## Scope
+
+**In scope**
+
+- Phase 1 (Stage-1 hook) — judge "is this REQ architecturally significant?" → if yes, allocate `ADR-NNN` + draft Context/Decision/Consequences/Alternatives/Status stub → inject ADR-NNN reference into implementation plan's _Architecture Decisions_ section.
+- Phase 2 (Stage-3 hook) — drop `compliance/evidence/REQ-XXX/architecture-decision.md` pointing at the ADR file (or recording the no-ADR rationale).
+- Per-REQ ADR-worthiness audit (operator invocation).
+
+**Out of scope**
+
+- Drafting canonical ADR prose end-to-end — the skill drafts a stub; the operator authors final wording.
+- Supersession lifecycle — when ADR-007 supersedes ADR-003, both stay on disk; ADR-003's status flips to `Superseded by ADR-007`. Deferred to Phase B.
+- Stale-decision detection — when the file referenced by ADR-007's _Decision_ section is heavily modified in a new REQ without producing a new ADR. Deferred to Phase B.
+- Cross-link maintenance to SRS items (`requirements-aligner`'s domain) or risk-register entries (`risk-register-keeper`'s domain) — the skills cross-reference each other in their stubs but Phase B owns the bidirectional consistency.
+- Framework-clause mapping of the `architecture_decision` evidence type — that's META-COMPLY's `framework-registry-auditor`.
+
+## The workflow
+
+Five phases. Phase 0 routes; Phases 1–2 are the SDLC stage hooks; Phase 3 is the utility audit; Phase 4 reports.
+
+### Phase 0 — Route
+
+Determine what's being decided:
+
+- **Stage-1 plan APPROVAL** — `sdlc-implementer` (or operator) says _"check ADR-worthiness for REQ-XXX before approving the plan"_ / _"does this need an ADR?"_ → Phase 1.
+- **Stage-3 evidence pack** — `sdlc-implementer` (or operator) says _"drop the architecture-decision.md for REQ-XXX"_ → Phase 2.
+- **Per-REQ ad-hoc audit** — operator says _"is REQ-XXX's architectural decision documented?"_ / _"audit ADR-worthiness across this branch"_ → Phase 3.
+
+The skill does not fire spontaneously. The parent skill (`sdlc-implementer`) invokes it at Stages 1 + 3 per the parent's SKILL.md delegation contract.
+
+### Phase 1 — Stage-1 plan APPROVAL hook
+
+Input: the REQ's `compliance/plans/REQ-XXX/implementation-plan.md` plus the working-tree diff.
+
+**Step 1 — Read the file list + diff.** Identify which files the REQ touches.
+
+**Step 2 — Apply the ADR-worthiness decision tree.** The skill judges _architectural significance_ via these signals — any one matching ⇒ ADR warranted:
+
+| Signal                                         | Examples                                                                            | Verdict                 |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------- | ----------------------- |
+| New third-party runtime dependency             | adding `redis`, `bull`, a new ORM, a new auth provider package                      | ADR                     |
+| New external service                           | introducing Stripe, Twilio, a new SaaS integration                                  | ADR                     |
+| New database / cache / queue tier              | adding Redis alongside Postgres, swapping MongoDB for Postgres                      | ADR                     |
+| Pattern change spanning > 3 files              | moving from REST handlers to RPC, swapping auth flow across the API surface         | ADR                     |
+| Schema-level data model change                 | new tables that other tables FK to, fundamental relationship changes                | ADR                     |
+| Risk classification HIGH or CRITICAL           | per `Test_Policy.md` §Risk-Based Testing                                            | ADR (operator confirms) |
+| File-path signal                               | `sdlc-config.json:adr_author.file_paths_signal_architecture` matches a touched file | ADR (operator confirms) |
+| Bug fix touching ≤ 3 files in `app/` or `lib/` | a typo, a copy edit, a null-guard, a one-place validation                           | no ADR                  |
+| Single-file refactor                           | extracting one function, renaming one variable                                      | no ADR                  |
+| Styling tweak                                  | CSS-only, Tailwind class shuffle                                                    | no ADR                  |
+| Dependency bump                                | `npm update foo` with no API change                                                 | no ADR                  |
+| Documentation                                  | `docs/`, `README.md`, doc-comments                                                  | no ADR                  |
+
+**Step 3 — Branch on verdict:**
+
+- **ADR warranted** → Phase 1 Step 4 (draft the stub).
+- **No ADR** → Phase 1 Step 7 (inject the no-ADR rationale).
+- **Ambiguous** → surface a candidate verdict + reasoning to the operator and ask. The operator can confirm or override. Do NOT silently default.
+
+**Step 4 — Allocate the next `ADR-NNN`.** Scan `docs/ADR/` for the max-existing `ADR-NNN` (zero-padded to three digits where the project's convention has it) and propose `+1`. If `docs/ADR/` doesn't exist yet, create it + allocate `ADR-001`. The skill does NOT support cross-branch ID coordination — if two parallel branches both consume the same next-free ID, the git merge on the directory is the canonical conflict signal. Re-run the skill post-merge to re-allocate.
+
+**Step 5 — Draft the stub `docs/ADR/ADR-NNN-<slug>.md`.** The slug is a kebab-case fragment of the decision (max 6 words). Format:
+
+```markdown
+---
+adr_id: 'ADR-NNN'
+status: 'Proposed'
+date: 'YYYY-MM-DD'
+authored_by: 'REPLACE — operator / agent'
+related_reqs: ['REQ-XXX']
+supersedes: []
+superseded_by: null
+---
+
+# ADR-NNN: <decision title>
+
+## Status
+
+**Proposed** (DRAFT — operator to flip to _Accepted_ on plan APPROVAL)
+
+## Context
+
+REPLACE — what forces (constraints, requirements, tradeoffs) motivate this decision? Two or three sentences. Reference REQ-XXX and any SRS items it traces to.
+
+## Decision
+
+REPLACE — the choice made. One paragraph. Specific (not "we will use a queue" — "we will use Redis Streams as the queue substrate; consumers are FastAPI workers using `redis-py` ≥ 5.x").
+
+## Consequences
+
+REPLACE — what follows. List both **good** and **bad** consequences honestly.
+
+- **Good:** REPLACE
+- **Bad:** REPLACE
+- **Neutral / tradeoffs:** REPLACE
+
+## Alternatives considered
+
+REPLACE — what other paths were on the table and why they were ruled out. At least one alternative; "we considered nothing else" is almost never honest.
+
+- **Alternative 1:** REPLACE — ruled out because REPLACE
+- **Alternative 2:** REPLACE — ruled out because REPLACE
+
+## Cross-references
+
+- Implementation plan: `compliance/plans/REQ-XXX/implementation-plan.md`
+- SRS items: REPLACE — list `REQ-AREA-NNN` items this decision affects, from `requirements-aligner` output
+- Risk register: REPLACE — list `RISK-NNN` entries this decision touches, from `risk-register-keeper` output (when that skill exists)
+- Supersedes / superseded-by: REPLACE — fill if this ADR replaces a prior one
+```
+
+The stub is **draft-quality**; the operator edits each REPLACE marker before flipping the status from _Proposed_ to _Accepted_.
+
+**Step 6 — Inject ADR-NNN reference into the implementation plan.** The plan's _Architecture Decisions_ section (converted from inline bullets to ADR-NNN references in this PR — see `Implementation_Plan_TEMPLATE.md`) gets a row added:
+
+```markdown
+## Architecture decisions
+
+- **ADR-NNN — <decision title>** — Proposed by `adr-author` skill. Draft at `docs/ADR/ADR-NNN-<slug>.md`. Operator edits + flips status to _Accepted_ before plan APPROVAL.
+```
+
+**Step 7 — No-ADR rationale.** When the verdict is _no ADR_, the plan's _Architecture decisions_ section gets:
+
+```markdown
+## Architecture decisions
+
+- **No ADR needed** — REPLACE one-line rationale. Examples: "Bug fix touching only `lib/services/order-service.ts:applyDiscount` — no structural change." / "CSS-only adjustment to dashboard layout — no behavioural or dependency change." / "Dependency bump from `foo@1.2.3` to `foo@1.2.5` (patch-level, no API change)."
+```
+
+The annotation is visible audit evidence that the _question was asked and answered_ — auditors examine the negative case as well as the positive.
+
+**Step 8 — Block plan APPROVAL** until each REQ has either:
+
+- (a) an ADR file in this PR (status: Proposed → Accepted by operator), OR
+- (b) an explicit "No ADR needed — <rationale>" annotation.
+
+The block is configurable via `sdlc-config.json` — see _Configuration_ below. Per the [#119 review](https://github.com/metasession-dev/DevAudit-Installer/issues/119#issuecomment-4631840651) defaults, advisory-with-strong-recommend in v1 (`block_on_stage_1: false`).
+
+### Phase 2 — Stage-3 evidence pack hook
+
+Input: the REQ's implementation plan (post-approval) and the working-tree diff.
+
+**Step 1 — Generate `compliance/evidence/REQ-XXX/architecture-decision.md`.** Format:
+
+```markdown
+---
+req: REQ-XXX
+generated_by: adr-author
+generated_at: <ISO timestamp>
+---
+
+# Architecture decision — REQ-XXX
+
+## Outcome
+
+REPLACE — one of:
+
+- "**Produced ADR-NNN:** <title> (`docs/ADR/ADR-NNN-<slug>.md`)" — when an ADR was authored in this cycle
+- "**No ADR needed** — <rationale>" — when the no-ADR branch was taken
+
+## Detail
+
+When **Produced ADR-NNN**:
+
+- **ADR file:** `docs/ADR/ADR-NNN-<slug>.md`
+- **Status:** Accepted (operator-confirmed during plan APPROVAL)
+- **Summary:** REPLACE — one sentence from the ADR's _Decision_ section
+- **Affected files:** REPLACE — the file-path signals that triggered the verdict
+- **Cross-references:** REPLACE — SRS items, risk-register entries
+
+When **No ADR needed**:
+
+- **Rationale:** REPLACE — one-line description copied from the plan's _Architecture decisions_ section
+- **Signals examined:** REPLACE — which signals from the decision tree were checked + how each scored
+
+## Operator sign-off
+
+I have reviewed the ADR-worthiness verdict above and confirm:
+
+- [ ] The verdict (ADR or no-ADR) matches the actual scope of this REQ.
+- [ ] If ADR: the file at `docs/ADR/ADR-NNN-<slug>.md` is edited from stub to canonical prose and status is Accepted.
+- [ ] If no-ADR: the rationale is specific enough that an auditor reading this in 12 months would agree.
+
+**Reviewer:** <operator-name>
+**Date:** <YYYY-MM-DD>
+```
+
+**Step 2 — Tag for upload.** The CI's `compliance-evidence.yml` uploads this file as `evidence_type=architecture_decision` (added to META-COMPLY's `EVIDENCE_TYPE_REGISTRY` in the paired sub-PR). The framework-coverage matrix maps this to clauses per `framework-registry-auditor`'s review — see the META-COMPLY-side PR for the final clause attributions (v1 may ship orphan-by-design if the auditor rejects proposed mappings; see [`requirements-aligner`](../requirements-aligner/SKILL.md) for the precedent).
+
+**Step 3 — Hand-off back to `sdlc-implementer`.** The skill's job ends at the artefact + the operator sign-off. The parent orchestrator continues with the rest of Stage 3.
+
+### Phase 3 — Per-REQ ad-hoc audit
+
+Same logic as Phase 1's Step 2 + Step 3, but produces a markdown report rather than blocking. Useful when an operator asks _"does REQ-XXX need an ADR?"_ outside the SDLC orchestration flow, or runs _"audit ADR-worthiness across this branch"_ to surface gaps.
+
+### Phase 4 — Report
+
+- For Phase 1 — the plan's injected section + the block/allow decision.
+- For Phase 2 — the artefact path + summary line.
+- For Phase 3 — markdown report (per-REQ verdict + reasoning).
+
+## Configuration (sdlc-config.json)
+
+```json
+{
+  "adr_author": {
+    "enabled": true,
+    "block_on_stage_1": false,
+    "block_on_stage_3": true,
+    "file_paths_signal_architecture": [
+      "lib/services/",
+      "lib/repositories/",
+      "prisma/schema.prisma",
+      "infra/"
+    ]
+  }
+}
+```
+
+Per the [#119 review](https://github.com/metasession-dev/DevAudit-Installer/issues/119#issuecomment-4631840651) defaults:
+
+- `block_on_stage_1: false` — advisory at Stage 1 by default. Operators flip to `true` once the heuristic is calibrated on the project (i.e. the skill's ADR/no-ADR verdicts have agreed with operator judgement on the last N runs).
+- `block_on_stage_3: true` — the per-REQ evidence pack is the hard gate (the Stage 3 artefact is what actually lands as evidence; missing it leaks).
+- `file_paths_signal_architecture` — list of file paths/prefixes that should signal an architectural change when touched. Defaults cover the common load-bearing surfaces; operators add project-specific paths (e.g. `infra/terraform/`, `app/auth/`).
+
+## Principles
+
+**Don't author the ADR prose.** The skill drafts a stub the operator edits to publication-grade wording. Inventing decision rationale without operator review is exactly the kind of silent-drift this skill exists to prevent.
+
+**Calibrate, don't presume.** The decision tree above is a starting heuristic, not a hard rule. When a verdict surfaces on the edge — say a single-file change that introduces a new dependency — surface the candidate verdict + reasoning and ask. The operator can confirm or override. False-positive ADRs (drafting noise the team has to edit-and-delete) are worse than false-negative no-ADRs (the operator catches the gap in review and asks for one).
+
+**Block at Stage 3, advise at Stage 1.** The implementation plan can carry "No ADR needed — <rationale>" and ship. The evidence pack cannot — the per-REQ `architecture-decision.md` artefact must exist before Stage 3 completes. Symmetric with `requirements-aligner` per the [#119 review](https://github.com/metasession-dev/DevAudit-Installer/issues/119#issuecomment-4631840651).
+
+**Sibling-skill awareness.** When this skill drafts an ADR, cross-link the SRS items the decision affects (from `requirements-aligner`'s output) and the risk-register entries the decision touches (from `risk-register-keeper` when that skill ships). The three SoT-alignment skills work together; each produces its own per-REQ Tier 3 artefact but they share the per-REQ context. v1 carries the cross-references as inline references the operator fills in; Phase B will own bidirectional consistency.
+
+**The negative case is audit evidence too.** A "No ADR needed — <rationale>" annotation is what an auditor examines to confirm the question was asked. An empty _Architecture decisions_ section is the silent-drift failure mode. Always inject one or the other; never leave the section unannotated.
+
+## References
+
+- [DevAudit-Installer#120](https://github.com/metasession-dev/DevAudit-Installer/issues/120) — the issue this skill closes, with the case study + the locked Phase A scope.
+- `sdlc-implementer/SKILL.md` Phase 1 + Phase 3 — the parent-skill invocation contract.
+- `sdlc/files/_common/Implementation_Plan_TEMPLATE.md` — _Architecture decisions_ section converted from inline bullets to ADR-NNN reference list in this PR (companion change).
+- `sdlc/files/_common/1-plan-requirement.md` — stage-1 doc updated to point at the skill (companion change).
+- `sdlc/files/_common/skills/requirements-aligner/SKILL.md` — sibling skill (same SoT-alignment family); see for the symmetric shape (Stage 1 + Stage 3 hooks; advisory-then-blocking enforcement).
+- Sibling skill (forthcoming): `risk-register-keeper` (DevAudit-Installer#121).
+- Meta-reviewer (META-COMPLY): `framework-registry-auditor` reviews the `architecture_decision` evidence type's clause mappings before the META-COMPLY sub-PR opens. Per the [#119 sequencing](https://github.com/metasession-dev/DevAudit-Installer/issues/119#issuecomment-4631840651).
+- Existing ADRs in the framework itself: `DevAudit-Installer/docs/ADR/ADR-001-polyglot-sdlc-architecture.md`, `docs/devaudit-cli/ADR-001-language-and-distribution.md` — the pattern this skill maintains.

--- a/.claude/skills/governance-doc-author/SKILL.md
+++ b/.claude/skills/governance-doc-author/SKILL.md
@@ -7,25 +7,27 @@ description: Author or refresh one of the project's governance documents — RoP
 
 Author or refresh a single governance document so it correctly closes the framework clauses it's meant to satisfy. Five document classes covered:
 
-| Document | Tier | File | Upload path | Closes |
-|---|---|---|---|---|
-| **RoPA** | 2 | `compliance/governance/ropa.md` | **Portal Upload form** (type `ropa`) — CI does NOT auto-upload since v0.1.39 | `GDPR.Art-30` |
-| **DPIA** | 2 | `compliance/governance/dpia.md` (or `dpia-<reqid>.md`) | **Portal Upload form** (type `dpia`) — CI does NOT auto-upload since v0.1.39 | `GDPR.Art-35` |
-| **AI Use Disclosure** | 2 | `compliance/governance/ai-disclosure.md` | **Portal Upload form** (type `ai_disclosure`) — CI does NOT auto-upload since v0.1.39 | `EUAIA.Art-13` |
-| **Periodic Security Review Schedule** | 2 | `SDLC/Periodic_Security_Review_Schedule.md` | **Portal Upload form** (type `compliance_document`) | `ISO27001.A.12.1` schedule expectation (quarterly runs close it via `periodic_review` evidence — see Phase 6) |
-| **Incident Report (project-level template)** | 3 | `compliance/governance/incident-report.md` | **CI auto-upload** via `compliance-evidence.yml` | `ISO29119.3.5.4` baseline; conditionals via [[incident-classification]] |
+| Document                                     | Tier | File                                                   | Upload path                                                                           | Closes                                                                                                        |
+| -------------------------------------------- | ---- | ------------------------------------------------------ | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| **RoPA**                                     | 2    | `compliance/governance/ropa.md`                        | **Portal Upload form** (type `ropa`) — CI does NOT auto-upload since v0.1.39          | `GDPR.Art-30`                                                                                                 |
+| **DPIA**                                     | 2    | `compliance/governance/dpia.md` (or `dpia-<reqid>.md`) | **Portal Upload form** (type `dpia`) — CI does NOT auto-upload since v0.1.39          | `GDPR.Art-35`                                                                                                 |
+| **AI Use Disclosure**                        | 2    | `compliance/governance/ai-disclosure.md`               | **Portal Upload form** (type `ai_disclosure`) — CI does NOT auto-upload since v0.1.39 | `EUAIA.Art-13`                                                                                                |
+| **Periodic Security Review Schedule**        | 2    | `SDLC/Periodic_Security_Review_Schedule.md`            | **Portal Upload form** (type `compliance_document`)                                   | `ISO27001.A.12.1` schedule expectation (quarterly runs close it via `periodic_review` evidence — see Phase 6) |
+| **Incident Report (project-level template)** | 3    | `compliance/governance/incident-report.md`             | **CI auto-upload** via `compliance-evidence.yml`                                      | `ISO29119.3.5.4` baseline; conditionals via [[incident-classification]]                                       |
 
-Each doc has a starter template under `sdlc/files/_common/governance/*.md.template` (installed on demand via `devaudit bootstrap-governance` since v0.1.36). This skill does NOT regenerate the template — it walks the operator through *filling it in* against the project's actual state.
+Each doc has a starter template under `sdlc/files/_common/governance/*.md.template` (installed on demand via `devaudit bootstrap-governance` since v0.1.36). This skill does NOT regenerate the template — it walks the operator through _filling it in_ against the project's actual state.
 
 ## Scope
 
 **In scope**
+
 - Authoring or refreshing one (or more) of the five governance docs above.
 - Gathering source data from the codebase / CI runs / git history.
 - Confirming framework attribution before commit.
 - Driving the commit + push → portal upload (manual for Tier 1/2, CI auto for Tier 3) → portal verification loop.
 
 **Out of scope**
+
 - Incident response itself — that path is the `e2e-test-engineer` skill's defect-filing flow plus `incident-export.yml` on issue close.
 - Test execution evidence — handled by `e2e-test-engineer`.
 - Implementation plans for individual REQs — handled by the `sdlc-implementer` skill's Phase 1 against `Implementation_Plan_TEMPLATE.md`.
@@ -39,13 +41,14 @@ Six phases. Phase 0 is a routing step; phases 1–5 are per-document.
 
 Determine which document the operator needs. Ask if ambiguous; otherwise infer from the trigger phrase.
 
-- *"create / refresh the RoPA"* → Phase 1 with doc = ROPA
-- *"write / update a DPIA"* → Phase 1 with doc = DPIA (ask: tied to a specific HIGH-risk REQ, or project-wide?)
-- *"AI use disclosure"* / *"document our AI use"* → Phase 1 with doc = AI_DISCLOSURE
-- *"periodic security review schedule"* / *"how often do we review"* → Phase 1 with doc = REVIEW_SCHEDULE
-- *"incident-report template"* → Phase 1 with doc = INCIDENT_TEMPLATE (and remind the operator that per-incident reports come from `incident-export.yml`, not this skill)
+- _"create / refresh the RoPA"_ → Phase 1 with doc = ROPA
+- _"write / update a DPIA"_ → Phase 1 with doc = DPIA (ask: tied to a specific HIGH-risk REQ, or project-wide?)
+- _"AI use disclosure"_ / _"document our AI use"_ → Phase 1 with doc = AI_DISCLOSURE
+- _"periodic security review schedule"_ / _"how often do we review"_ → Phase 1 with doc = REVIEW_SCHEDULE
+- _"incident-report template"_ → Phase 1 with doc = INCIDENT_TEMPLATE (and remind the operator that per-incident reports come from `incident-export.yml`, not this skill)
+- _"register a new risk"_ / _"open a risk-register entry"_ / _"document a control gap"_ → **delegate to the [`risk-register-keeper` skill](../risk-register-keeper/SKILL.md)** (DevAudit-Installer#121, v0.1.44+). The risk register is a separate SoT (`compliance/risk-register.md`) with its own lifecycle (OPEN / MITIGATED / ACCEPTED / CLOSED) and stage hooks (Stage 1 / incident close / Stage 3). This skill does not maintain it.
 
-When the trigger is *"GDPR.Art-30 is MISSING on the matrix, what do I upload?"* and similar — route to the matching doc above.
+When the trigger is _"GDPR.Art-30 is MISSING on the matrix, what do I upload?"_ and similar — route to the matching doc above. When the trigger is about per-REQ risks or control gaps — route to `risk-register-keeper`.
 
 ### Phase 1 — Confirm the starter exists
 
@@ -61,7 +64,7 @@ Each doc class has different inputs. Read what's needed; don't ask the operator 
   - Read `app/`, `lib/`, `prisma/schema.prisma` (or equivalent) to enumerate processing activities.
   - For each, infer: data categories, recipients (third-party SDKs / services), retention (DB triggers, env vars naming retention windows), lawful basis where reasonable.
   - Read `.env.example` for third-party service names.
-  - Ask the operator to confirm purposes (you can guess the technical surface; the *purpose* is a business decision).
+  - Ask the operator to confirm purposes (you can guess the technical surface; the _purpose_ is a business decision).
 
 - **DPIA**
   - Project-wide DPIA → same source data as RoPA, plus a risk identification pass against Art. 35(3) triggers (large-scale special category, systematic monitoring, automated decisions with legal effect).
@@ -92,13 +95,13 @@ Each doc class has different inputs. Read what's needed; don't ask the operator 
 
 For each clause the doc closes, confirm the corresponding section of the doc is non-stub:
 
-| Doc | Clause | Section that must be non-stub |
-|---|---|---|
-| ROPA | GDPR.Art-30 | §Controller + ≥1 §Processing activities row with all fields filled |
-| DPIA | GDPR.Art-35 | All six sections (description / necessity / risks / measures / consultation / sign-off) |
-| AI_DISCLOSURE | EUAIA.Art-13 | All six checklist items in the template's Framework checklist |
-| REVIEW_SCHEDULE | ISO27001.A.12.1 | A schedule entry per control area + a named reviewer per cadence |
-| INCIDENT_TEMPLATE | ISO29119.3.5.4 baseline | §1–§8 of the template are skeletal but coherent (per-incident files inherit the shape) |
+| Doc               | Clause                  | Section that must be non-stub                                                           |
+| ----------------- | ----------------------- | --------------------------------------------------------------------------------------- |
+| ROPA              | GDPR.Art-30             | §Controller + ≥1 §Processing activities row with all fields filled                      |
+| DPIA              | GDPR.Art-35             | All six sections (description / necessity / risks / measures / consultation / sign-off) |
+| AI_DISCLOSURE     | EUAIA.Art-13            | All six checklist items in the template's Framework checklist                           |
+| REVIEW_SCHEDULE   | ISO27001.A.12.1         | A schedule entry per control area + a named reviewer per cadence                        |
+| INCIDENT_TEMPLATE | ISO29119.3.5.4 baseline | §1–§8 of the template are skeletal but coherent (per-incident files inherit the shape)  |
 
 If any required section is still stub, **do not commit**. Surface the gap in the Phase 5 report, ask the operator for the missing input.
 
@@ -118,10 +121,10 @@ Tier 1/2 docs (RoPA, DPIA, AI Disclosure, Periodic Security Review Schedule) and
 
 These are **two different artefacts** and the skill must not conflate them:
 
-| Artefact | What | Closes | Cadence | Skill responsibility |
-|---|---|---|---|---|
-| **Periodic_Security_Review_Schedule.md** | The *plan* — which controls get reviewed, how often, by whom | `ISO27001.A.12.1` (the schedule presence) | Once, refresh annually | **In scope.** Author / refresh via this skill. |
-| **periodic-review.md** | The *execution evidence* — this quarter's actual review | `ISO27001.A.12.1` + `SOC2.CC4.1` (effectiveness evidence) | Quarterly | **Out of scope.** Auto-generated by `periodic-review.yml`; the operator fills in the 60% operator-fill section per the PR body's checklist. |
+| Artefact                                 | What                                                         | Closes                                                    | Cadence                | Skill responsibility                                                                                                                        |
+| ---------------------------------------- | ------------------------------------------------------------ | --------------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Periodic_Security_Review_Schedule.md** | The _plan_ — which controls get reviewed, how often, by whom | `ISO27001.A.12.1` (the schedule presence)                 | Once, refresh annually | **In scope.** Author / refresh via this skill.                                                                                              |
+| **periodic-review.md**                   | The _execution evidence_ — this quarter's actual review      | `ISO27001.A.12.1` + `SOC2.CC4.1` (effectiveness evidence) | Quarterly              | **Out of scope.** Auto-generated by `periodic-review.yml`; the operator fills in the 60% operator-fill section per the PR body's checklist. |
 
 If the operator asks for "the periodic review", clarify which they mean. If they want the quarterly execution, point them at the open auto-PR (or, if cron hasn't fired yet, suggest `gh workflow run periodic-review.yml`).
 
@@ -139,7 +142,7 @@ When Phase 5 commits successfully, append a short narrator update in the final r
 
 **Don't invent.** If you can't derive a value from the codebase / CI / git, ask the operator. Never guess at lawful basis, retention windows, controller contacts, or AI provider names.
 
-**Framework checklist is load-bearing.** The portal's matrix uses the *presence* of the doc to flip COVERED; auditors use the *content* to decide if that's defensible. Tick boxes only when they're actually true.
+**Framework checklist is load-bearing.** The portal's matrix uses the _presence_ of the doc to flip COVERED; auditors use the _content_ to decide if that's defensible. Tick boxes only when they're actually true.
 
 **Confirm before destructive or public actions.** Same as the e2e-test-engineer principle. Diff, confirm, commit. The operator approves the doc going to GitHub before push.
 

--- a/.claude/skills/risk-register-keeper/SKILL.md
+++ b/.claude/skills/risk-register-keeper/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: risk-register-keeper
+description: Maintain `compliance/risk-register.md` as the authoritative project-spanning record of risks across the SDLC lifecycle. Runs at Stage 1 (MEDIUM/HIGH risk classification — open RISK-NNN entries for risks the REQ introduces), at incident-close (residual risk after an incident), and at Stage 3 (per-REQ evidence pack). Owns the canonical risk row (description, inherent likelihood × impact, mitigations planned, residual likelihood × impact, owner, review-due, framework cross-references), allocates the next `RISK-NNN` per project, replaces the implementation plan's inline Risks/Considerations bullets with RISK-NNN reference list, and produces `compliance/evidence/REQ-XXX/risk-assessment.md` summarising which entries this REQ opened, mitigated, or accepted. Use when invoking on a single REQ ("draft a risk-register entry for REQ-XXX", "is the risk register up to date for this branch?"); when `sdlc-implementer` delegates at Stage 1 for MEDIUM/HIGH classifications or Stage 3 for the evidence artefact; when an incident closes and the residual-risk entry needs drafting; when a `solo_with_gap` approval mode requires the documented control-gap entry. Do NOT use for authoring canonical risk-treatment language (the operator owns the final wording); for periodic-review re-validation of accepted risks (deferred to Phase B); for full STRIDE/LINDDUN threat modelling (deferred to Phase B; consider folding into a separate `threat-modeller` skill if volume justifies); for framework-clause mapping of the `risk_assessment` evidence type (that's META-COMPLY's `framework-registry-auditor`).
+---
+
+# Risk Register Keeper
+
+Maintains `compliance/risk-register.md` as the authoritative record of project risks across the SDLC lifecycle. Sibling of [`requirements-aligner`](../requirements-aligner/SKILL.md) (owns `docs/SRS.md`) and [`adr-author`](../adr-author/SKILL.md) (owns `docs/ADR/`) in the SoT-alignment skill family.
+
+The skill is **Phase A scope** (per [DevAudit-Installer#121](https://github.com/metasession-dev/DevAudit-Installer/issues/121) and the [#119 review](https://github.com/metasession-dev/DevAudit-Installer/issues/119#issuecomment-4631840651)): Stage 1 + post-incident + Stage 3 hooks. Periodic-review re-validation, audit-pack inclusion, and STRIDE/LINDDUN threat modelling all defer to Phase B.
+
+## What this skill owns
+
+| Artefact                                                                   | Lives at                       | Tier                 |
+| -------------------------------------------------------------------------- | ------------------------------ | -------------------- |
+| `compliance/risk-register.md` (the SoT, project-spanning)                  | Top-level compliance directory | 2 (project strategy) |
+| `compliance/evidence/REQ-XXX/risk-assessment.md` (per-REQ Tier 3 evidence) | Per-REQ evidence directory     | 3 (per-REQ)          |
+
+The skill does **not** own the canonical risk-treatment language (operator decision — risk acceptance has legal + audit consequences). It allocates `RISK-NNN` IDs, drafts canonical row stubs the operator edits, and cross-references the register entries from per-REQ artefacts.
+
+## Scope
+
+**In scope**
+
+- Phase 1 (Stage-1 hook, MEDIUM/HIGH only by default) — read implementation plan + diff → identify risks → allocate `RISK-NNN` → draft canonical rows → replace plan's Risks/Considerations bullets with RISK-NNN reference list.
+- Phase 2 (post-incident hook) — read closed `incident`-labelled report → draft residual-risk entry → cross-link incident report ↔ register entry.
+- Phase 3 (Stage-3 hook) — drop `compliance/evidence/REQ-XXX/risk-assessment.md` with this REQ's RISK-NNN summary.
+- Phase 4 (`solo_with_gap` approval) — when project's `sdlc-config.json:approval.mode = 'solo_with_gap'`, refuse merge unless the documented control-gap RISK-NNN entry exists.
+- Per-REQ ad-hoc audit (operator invocation).
+
+**Out of scope**
+
+- Authoring canonical risk-treatment prose — the skill drafts stubs; the operator owns final language. Risk acceptance has legal + audit consequences; the operator's sign-off is the audit value.
+- Periodic-review re-validation — Phase B, paired with `governance-doc-author`'s periodic-review schedule.
+- Audit-pack inclusion — Phase B, pairs with portal audit-pack export.
+- STRIDE / LINDDUN threat modelling sub-domain — deferred; if volume justifies, graduates to a separate `threat-modeller` skill.
+- Framework-clause mapping of the `risk_assessment` evidence type — that's META-COMPLY's `framework-registry-auditor`.
+- CVSS-aware scoring — defaults to a `likelihood × impact` 3×3 matrix per `0-project-setup.md`. CVSS deferred.
+
+## The workflow
+
+Six phases. Phase 0 routes; Phases 1–4 are the SDLC stage hooks; Phase 5 is the utility audit; Phase 6 reports.
+
+### Phase 0 — Route
+
+Determine what's being assessed:
+
+- **Stage-1 plan APPROVAL (MEDIUM/HIGH risk)** — `sdlc-implementer` (or operator) says _"draft risk-register entries for REQ-XXX"_ / _"this is HIGH risk, what goes in the register?"_ → Phase 1.
+- **Incident close** — operator (or CI workflow) says _"incident-report-N.md just exported, draft the residual-risk entry"_ → Phase 2.
+- **Stage-3 evidence pack** — `sdlc-implementer` (or operator) says _"drop the risk-assessment.md for REQ-XXX"_ → Phase 3.
+- **`solo_with_gap` approval check** — operator says _"approval mode is solo_with_gap, is the control-gap entry on the register?"_ → Phase 4.
+- **Per-REQ ad-hoc audit** — operator says _"is REQ-XXX's risk record complete?"_ / _"audit the register against this branch"_ → Phase 5.
+
+The skill does not fire spontaneously. The parent skill (`sdlc-implementer`) invokes it at Stage 1 for MEDIUM/HIGH classifications + Stage 3 per the parent's SKILL.md delegation contract. `incident-export.yml` invokes it at incident close per its workflow definition.
+
+### Phase 1 — Stage-1 plan APPROVAL hook (MEDIUM/HIGH only)
+
+Input: the REQ's `compliance/plans/REQ-XXX/implementation-plan.md` plus the working-tree diff. Triggered only when the orchestrator's risk classification is **MEDIUM or HIGH** by default (LOW skipped); configurable via `sdlc-config.json:risk_register_keeper.block_on_stage_1`.
+
+**Step 1 — Read the implementation plan's Threat model + Security considerations section** (`Implementation_Plan_TEMPLATE.md` §4) and the diff scope.
+
+**Step 2 — Identify discrete risks.** Each risk is something an auditor could examine independently:
+
+- A specific attack surface the change exposes (e.g. "SQL injection via the order-id query param").
+- A specific control gap the change introduces (e.g. "no rate limit on /api/auth/forgot-password").
+- A specific dependency-introduced concern (e.g. "Redis adopted as cache — no encryption at rest by default").
+- A specific data-handling decision (e.g. "payment card last-4 stored in app DB").
+
+**Step 3 — For each risk, allocate `RISK-NNN` and draft the canonical row.** Scan `compliance/risk-register.md` for max-existing ID + 1. If the register doesn't exist yet, bootstrap it from `sdlc/files/_common/governance/risk-register.md.template`.
+
+Format per row (markdown table inside the register):
+
+```markdown
+### RISK-NNN — <one-line title>
+
+- **Status:** OPEN
+- **Opened:** YYYY-MM-DD (REQ-XXX)
+- **Owner:** <operator>
+- **Description:** REPLACE — what the risk is, in operator-readable terms (2-3 sentences).
+- **Inherent likelihood × impact:** REPLACE (low × medium = 2 / medium × medium = 4 / etc — per 3×3 matrix in 0-project-setup.md)
+- **Mitigations applied in this REQ:** REPLACE — list controls landing in this PR
+- **Residual likelihood × impact:** REPLACE (post-mitigation)
+- **Framework cross-references:** REPLACE — ISO27001.A.X.Y / SOC2.CC3.2 / GDPR.Art-32 (as applicable)
+- **Review due:** YYYY-MM-DD (default 365d for ACCEPTED + MITIGATED; OPEN reviews monthly)
+- **Cross-links:** REQ-XXX implementation plan; ADR-NNN (if produced by adr-author); incident-report-N (if post-incident)
+```
+
+**Step 4 — Replace the implementation plan's Risks/Considerations bullets with RISK-NNN references.** The plan's §4 (Threat model) gets a new sub-section:
+
+```markdown
+### Risk register entries
+
+This REQ opens / touches the following entries in `compliance/risk-register.md`:
+
+- **RISK-NNN — <title>** — Status: OPEN. Opened by `risk-register-keeper`. Operator edits the canonical row + signs off the residual rating before plan APPROVAL.
+- **RISK-NNN — <title>** — Status: MITIGATED. Controls landing in this PR close the residual.
+```
+
+For **deferred** risks (the operator decides the surface doesn't merit a register entry — typically LOW-impact + LOW-likelihood combination), the row carries `@risk-deferred: <reason>` so the deferral is visible.
+
+**Step 5 — Block plan APPROVAL** (configurable) until each MEDIUM/HIGH risk has either a RISK-NNN entry OR an explicit `@risk-deferred` annotation with rationale.
+
+### Phase 2 — Post-incident hook
+
+Triggered when `incident-export.yml` exports a closed `incident`-labelled GitHub issue to `compliance/governance/incident-report-N.md` (DevAudit-Installer v0.1.31 WS4+).
+
+**Step 1 — Read the incident report.** Severity classification, root cause, controls applied, residual concern.
+
+**Step 2 — Draft a residual-risk entry.** Status branches:
+
+| Outcome of incident                                                           | Status    | What the entry records                                                  |
+| ----------------------------------------------------------------------------- | --------- | ----------------------------------------------------------------------- |
+| Controls landed alongside the fix; residual risk now LOW                      | MITIGATED | What was wrong, what landed, what's checked going forward               |
+| Controls deferred (fix-forward shipped but follow-up work tracked)            | OPEN      | Same, plus follow-up issue reference + deadline                         |
+| Risk judged tolerable post-incident (e.g. one-off external dependency outage) | ACCEPTED  | What was wrong, why acceptance is defensible, when re-validation is due |
+
+**Step 3 — Cross-link both directions.** The register entry references `incident-report-N.md`; the incident report file's frontmatter gets a `risk_register_entry: RISK-NNN` line so the audit trail is bidirectional.
+
+### Phase 3 — Stage-3 evidence pack hook
+
+Input: the REQ's implementation plan (post-approval) and the working-tree diff.
+
+**Step 1 — Generate `compliance/evidence/REQ-XXX/risk-assessment.md`.** Format:
+
+```markdown
+---
+req: REQ-XXX
+generated_by: risk-register-keeper
+generated_at: <ISO timestamp>
+---
+
+# Risk assessment — REQ-XXX
+
+## Summary
+
+This REQ opened / mitigated / accepted the following entries in `compliance/risk-register.md`:
+
+| RISK-NNN | Title   | Status this cycle                                      | Residual L × I |
+| -------- | ------- | ------------------------------------------------------ | -------------- |
+| RISK-NNN | <title> | OPEN (opened in this REQ)                              | medium × low   |
+| RISK-NNN | <title> | MITIGATED (controls landed in this REQ)                | low × low      |
+| RISK-NNN | <title> | ACCEPTED (re-validated, no change required this cycle) | low × medium   |
+
+## Framework cross-references
+
+Risks above map to the following framework clauses:
+
+- ISO27001.A.X.Y — RISK-NNN
+- SOC2.CC3.2 — RISK-NNN (Risk identification and assessment)
+- GDPR.Art-32 — RISK-NNN (Security of processing) — if applicable
+
+## Operator sign-off
+
+I have reviewed the risk register entries above and confirm:
+
+- [ ] Each entry's residual rating is defensible given the controls landing in this REQ.
+- [ ] No risk was downgraded without evidence (control demonstrated effective via tests).
+- [ ] OPEN entries have follow-up tracking (issue / deadline / next-review-due).
+
+**Reviewer:** <operator-name>
+**Date:** <YYYY-MM-DD>
+```
+
+**Step 2 — Tag for upload.** The CI's `compliance-evidence.yml` uploads this file as `evidence_type=risk_assessment` (added to META-COMPLY's `EVIDENCE_TYPE_REGISTRY` in the paired sub-PR). The framework-coverage matrix attribution depends on `framework-registry-auditor`'s review — see the META-COMPLY-side PR for final clause closures.
+
+**Step 3 — Hand-off back to `sdlc-implementer`.** The skill's job ends at the artefact + operator sign-off.
+
+### Phase 4 — `solo_with_gap` approval check
+
+When `sdlc-config.json:approval.mode = 'solo_with_gap'` and a release is about to be approved, the skill verifies the documented control-gap RISK-NNN entry exists in the register.
+
+**Step 1 — Read `sdlc-config.json:approval.mode`.** If not `solo_with_gap`, exit (no check needed).
+
+**Step 2 — Grep the register for a control-gap entry.** Look for an entry whose Framework cross-references include `SOC2.CC8.1` and whose description references `solo_with_gap` or equivalent ("self-approval", "single-actor release").
+
+**Step 3 — If absent, draft one.** Status: ACCEPTED (operator-acknowledged trade-off). Description: "Project operates in solo_with_gap approval mode — release submitter approves their own release. This is a documented control gap relative to SOC2 CC8.1 four-eyes ideal. Compensating controls: <list — typically: CI gates green, MFA on release operator, monthly audit log review>."
+
+**Step 4 — Refuse approval until the entry is signed off** by the operator. The control gap must be deliberately acknowledged, not silently inherited.
+
+### Phase 5 — Per-REQ ad-hoc audit
+
+Same logic as Phase 1's Step 2 + Step 3, but produces a markdown report rather than blocking. Useful when an operator asks _"is REQ-XXX's risk record complete?"_ outside the SDLC orchestration flow.
+
+### Phase 6 — Report
+
+- For Phase 1 — the plan's injected sub-section + the block/allow decision.
+- For Phase 2 — the new register entry + cross-link confirmation.
+- For Phase 3 — the artefact path + summary line.
+- For Phase 4 — the gap-entry confirmation + approval-blocking decision.
+- For Phase 5 — markdown report per REQ.
+
+## Configuration (sdlc-config.json)
+
+```json
+{
+  "risk_register_keeper": {
+    "enabled": true,
+    "block_on_stage_1": false,
+    "block_on_stage_3": true,
+    "scoring": "likelihood-impact",
+    "auto_open_on_high_risk_req": true,
+    "auto_open_on_closed_incident": true,
+    "stage_1_min_risk_class": "MEDIUM"
+  }
+}
+```
+
+Per the [#119 review](https://github.com/metasession-dev/DevAudit-Installer/issues/119#issuecomment-4631840651) defaults:
+
+- `block_on_stage_1: false` — advisory at Stage 1 by default. Flip to `true` once the project's register is populated enough that the check is reliably surfacing real risks (not false-positives on sparse coverage).
+- `block_on_stage_3: true` — per-REQ `risk-assessment.md` artefact is the hard gate.
+- `scoring: 'likelihood-impact'` — default 3×3 matrix per `0-project-setup.md`. CVSS-aware scoring (Phase B) deferred.
+- `stage_1_min_risk_class: 'MEDIUM'` — LOW REQs skip the Stage-1 hook (the orchestrator's classification already decided no register entry is warranted). MEDIUM/HIGH trigger.
+- `auto_open_on_closed_incident: true` — fire Phase 2 on every `incident-export.yml` close. Set to `false` for projects with high incident volume + dedicated risk-management process.
+
+## Principles
+
+**Don't author canonical risk-treatment language.** The skill drafts stubs; the operator owns the final wording. Risk acceptance has legal + audit consequences; the operator's sign-off carries the audit value. Inventing canonical risk-treatment prose without operator review is exactly the kind of silent acceptance this skill exists to prevent.
+
+**Calibrate, don't over-trigger.** Not every change introduces a register-worthy risk. A typo fix doesn't. A CSS tweak doesn't. The `stage_1_min_risk_class` default skips LOW REQs precisely for this reason. False-positive register entries (drafting noise the team has to edit-and-delete) dilute the register's audit value.
+
+**The negative case is audit evidence too.** An `@risk-deferred: <rationale>` annotation in the plan's Risks-register-entries sub-section proves the operator considered the surface and decided no entry was needed. Auditors examine the negative case as well as the positive — empty/silent is the failure mode, not "considered + deferred with rationale".
+
+**Status semantics are load-bearing.** OPEN = active and unmitigated. MITIGATED = controls landed and demonstrated effective. ACCEPTED = operator-acknowledged trade-off with periodic re-validation. CLOSED = no longer relevant. Don't flip OPEN → CLOSED to make the register green for an audit — auditors check the audit log.
+
+**Sibling-skill awareness.** When this skill opens a RISK-NNN that maps to an SRS item, cross-link the SRS-ID (from `requirements-aligner`). When the risk relates to an architectural decision, cross-link the ADR-NNN (from `adr-author`). The three SoT-alignment skills work together; each produces its own per-REQ Tier 3 artefact but they share the per-REQ context.
+
+**`solo_with_gap` is a deliberate trade-off, not a silent override.** The framework supports solo-dev projects via `solo_with_gap` approval mode — but only on the explicit basis that the control gap is documented in the risk register. Phase 4 enforces this; the alternative is silently inheriting a SOC 2 CC8.1 gap that an auditor will flag.
+
+## References
+
+- [DevAudit-Installer#121](https://github.com/metasession-dev/DevAudit-Installer/issues/121) — the issue this skill closes, with the case study + locked Phase A scope.
+- `sdlc-implementer/SKILL.md` Phase 1 + Phase 3 — the parent-skill invocation contract.
+- `sdlc/files/_common/governance/risk-register.md.template` — starter template installed via `devaudit bootstrap-governance`.
+- `sdlc/files/_common/Implementation_Plan_TEMPLATE.md` — §4 Threat model gets a new "Risk register entries" sub-section in this PR (companion change).
+- `sdlc/files/_common/1-plan-requirement.md` — stage-1 doc updated to point at the skill (companion change).
+- `sdlc/files/_common/skills/requirements-aligner/SKILL.md` — sibling skill (same SoT-alignment family); see for the symmetric shape.
+- `sdlc/files/_common/skills/adr-author/SKILL.md` — sibling skill (same family).
+- `sdlc/files/_common/skills/governance-doc-author/SKILL.md` — Phase 0 routing cross-links to this skill ("register a new risk" vs "draft a ROPA / DPIA / incident-report").
+- Meta-reviewer (META-COMPLY): `framework-registry-auditor` reviews the `risk_assessment` evidence type's clause mappings before the META-COMPLY sub-PR opens.
+- Approval mode reference: `sdlc-config.example.json:approval.mode` — `dual_actor` vs `solo_with_gap` vs `auto_low_risk`.

--- a/.claude/skills/sdlc-implementer/SKILL.md
+++ b/.claude/skills/sdlc-implementer/SKILL.md
@@ -165,9 +165,10 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
 
 6. **Invoke `requirements-aligner` to populate the SRS-ID column on the AC table.** The plan's "Acceptance criteria" table carries an SRS-ID column per AC; `requirements-aligner` fuzzy-matches each AC against `docs/SRS.md` and proposes new `REQ-AREA-NNN` stubs, flags stale items, or annotates `@srs-deferred`. Don't author the SRS-ID column inline — call via the standard Claude Code Skill mechanism (`Skill(name: "requirements-aligner", …)`). Block plan APPROVAL until every AC has a resolved SRS-ID per the skill's Phase 1 contract (configurable via `sdlc-config.json:requirements_aligner.block_on_stage_1`; ramp-up mode default-on for legacy projects).
 7. **Invoke `adr-author` to decide ADR-worthiness + draft the ADR if needed.** The plan's "Architecture decisions" section is no longer authored inline as bullets — `adr-author` applies its decision tree (new third-party dependency / new database/cache/queue / new external service / pattern change spanning >3 files / HIGH-CRITICAL risk class / file-path signals from `sdlc-config.json:adr_author.file_paths_signal_architecture`), allocates the next `ADR-NNN`, drafts a Context/Decision/Consequences/Alternatives/Status stub at `docs/ADR/ADR-NNN-<slug>.md`, and injects either _"Produced ADR-NNN: <title>"_ or _"No ADR needed — <rationale>"_ into the plan's section. Call via the standard Claude Code Skill mechanism (`Skill(name: "adr-author", …)`). Configurable via `sdlc-config.json:adr_author.block_on_stage_1`; advisory by default in v1.
-8. **Update `compliance/RTM.md`** with the new entry: REQ-XXX, title, risk class, linked issue, linked test cases (placeholder).
-9. **Post plan summary as an issue comment.** Format: TL;DR; Risk class + signals; Acceptance criteria (with SRS-IDs); Architectural decisions (ADR-NNN reference or no-ADR rationale); Technical approach (one paragraph); Dependencies; Test scope.
-10. **Checkpoint** — pause for human approval **iff** risk class is HIGH or CRITICAL. LOW and MEDIUM pass through to Phase 2 automatically. The checkpoint can be forced on for all classes via the `--require-plan-approval` flag (or `DEVAUDIT_REQUIRE_PLAN_APPROVAL=1` env var) for orgs that want it always-on.
+8. **Invoke `risk-register-keeper` for MEDIUM/HIGH risk classifications.** The plan's "Threat model" / Risks section is no longer authored as orphan bullets — when risk class is MEDIUM or HIGH (LOW skipped by default per `sdlc-config.json:risk_register_keeper.stage_1_min_risk_class`), `risk-register-keeper` reads the plan + diff, identifies discrete risks the change introduces, allocates `RISK-NNN` per project, drafts canonical rows in `compliance/risk-register.md`, and injects the RISK-NNN reference list into the plan's "Risk register entries" sub-section. The skill also enforces the `solo_with_gap` control-gap entry exists for projects in that approval mode. Call via the standard Claude Code Skill mechanism (`Skill(name: "risk-register-keeper", …)`). Configurable via `sdlc-config.json:risk_register_keeper.block_on_stage_1`; advisory by default in v1.
+9. **Update `compliance/RTM.md`** with the new entry: REQ-XXX, title, risk class, linked issue, linked test cases (placeholder).
+10. **Post plan summary as an issue comment.** Format: TL;DR; Risk class + signals; Acceptance criteria (with SRS-IDs); Architectural decisions (ADR-NNN reference or no-ADR rationale); Risk register entries (RISK-NNN list); Technical approach (one paragraph); Dependencies; Test scope.
+11. **Checkpoint** — pause for human approval **iff** risk class is HIGH or CRITICAL. LOW and MEDIUM pass through to Phase 2 automatically. The checkpoint can be forced on for all classes via the `--require-plan-approval` flag (or `DEVAUDIT_REQUIRE_PLAN_APPROVAL=1` env var) for orgs that want it always-on.
 
 ### Phase 2 — Implement and test (SDLC stage 2)
 
@@ -201,15 +202,17 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
 
 1. **Invoke `requirements-aligner` to drop the per-REQ SRS-alignment artefact.** The skill's Phase 2 produces `compliance/evidence/REQ-XXX/srs-alignment.md` — the per-REQ trace from each AC to its SRS item, with an operator sign-off block. The artefact uploads with `evidence_type=srs_alignment` (visible in Documents tab + audit-pack export; v1 orphan-by-design per META-COMPLY framework-registry-auditor). Call via the standard Skill mechanism; don't inline the alignment logic.
 2. **Invoke `adr-author` to drop the per-REQ architecture-decision artefact.** The skill's Phase 2 produces `compliance/evidence/REQ-XXX/architecture-decision.md` — either _"Produced ADR-NNN: <title>"_ with the file pointer, or _"No ADR needed — <rationale>"_. Operator sign-off block at the bottom. The artefact uploads with `evidence_type=architecture_decision`; clause attribution per the META-COMPLY framework-registry-auditor review. Call via the standard Skill mechanism.
-3. **Re-run the full test pack** with artefact capture:
+3. **Invoke `risk-register-keeper` to drop the per-REQ risk-assessment artefact.** The skill's Phase 3 produces `compliance/evidence/REQ-XXX/risk-assessment.md` — a summary table of RISK-NNN entries this REQ opened / mitigated / accepted, framework cross-references, and an operator sign-off block. The artefact uploads with `evidence_type=risk_assessment`; clause attribution per the META-COMPLY framework-registry-auditor review. Call via the standard Skill mechanism.
+4. **Re-run the full test pack** with artefact capture:
    - `npm run test:e2e -- --reporter=html` (produces `playwright-report/`)
    - `npx vitest run --coverage` (produces `coverage/`)
-4. **Organise artefacts** under `compliance/evidence/REQ-XXX/` with date-prefixed naming:
+5. **Organise artefacts** under `compliance/evidence/REQ-XXX/` with date-prefixed naming:
 
    ```
    compliance/evidence/REQ-XXX/
    ├── srs-alignment.md                  ← produced in step 1 by requirements-aligner
    ├── architecture-decision.md          ← produced in step 2 by adr-author
+   ├── risk-assessment.md                ← produced in step 3 by risk-register-keeper
    ├── YYYY-MM-DD_e2e-results.json
    ├── YYYY-MM-DD_playwright-report/
    ├── YYYY-MM-DD_traces/                ← per-test trace.zip + error-context.md
@@ -219,7 +222,7 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
 
    Copy Playwright's `test-results/` folder verbatim into `YYYY-MM-DD_traces/` so trace-by-test-name is available for audit without walking the HTML report's hash-name index. For HIGH/CRITICAL releases the traces are part of the audit trail — _"what state was the page in when test X failed and was overridden?"_ answers in one `ls` instead of an HTML-report walk.
 
-5. **Upload each artefact to the portal**:
+6. **Upload each artefact to the portal**:
    ```bash
    devaudit push <project-slug> REQ-XXX <evidence-type> <file> \
      --release "v$(date +%Y.%m.%d)" --create-release-if-missing \
@@ -227,9 +230,9 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
      --git-sha "$(git rev-parse HEAD)" \
      --branch "$(git rev-parse --abbrev-ref HEAD)"
    ```
-   Evidence types: `screenshot`, `e2e_result`, `test_report`, `audit_log`, `compliance_document`, `manual_upload`, `srs_alignment` (from step 1), `architecture_decision` (from step 2).
-6. **Verify uploads landed.** `gh api` or `curl` against `https://devaudit.metasession.co/projects/<slug>/requirements/REQ-XXX/evidence` should show every artefact.
-7. **Update `compliance/RTM.md`** with portal links for each evidence row.
+   Evidence types: `screenshot`, `e2e_result`, `test_report`, `audit_log`, `compliance_document`, `manual_upload`, `srs_alignment` (from step 1), `architecture_decision` (from step 2), `risk_assessment` (from step 3).
+7. **Verify uploads landed.** `gh api` or `curl` against `https://devaudit.metasession.co/projects/<slug>/requirements/REQ-XXX/evidence` should show every artefact.
+8. **Update `compliance/RTM.md`** with portal links for each evidence row.
 
 ### Phase 4 — Submit for UAT review (SDLC stage 4)
 

--- a/.claude/skills/sdlc-implementer/SKILL.md
+++ b/.claude/skills/sdlc-implementer/SKILL.md
@@ -164,9 +164,10 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
    **Don't delete sections** — mark with `N/A — <reason>` if a clause genuinely doesn't apply (e.g. UI-only change with no personal-data scope). Empty stubs commit-then-upload as placeholder evidence and break the audit trail.
 
 6. **Invoke `requirements-aligner` to populate the SRS-ID column on the AC table.** The plan's "Acceptance criteria" table carries an SRS-ID column per AC; `requirements-aligner` fuzzy-matches each AC against `docs/SRS.md` and proposes new `REQ-AREA-NNN` stubs, flags stale items, or annotates `@srs-deferred`. Don't author the SRS-ID column inline — call via the standard Claude Code Skill mechanism (`Skill(name: "requirements-aligner", …)`). Block plan APPROVAL until every AC has a resolved SRS-ID per the skill's Phase 1 contract (configurable via `sdlc-config.json:requirements_aligner.block_on_stage_1`; ramp-up mode default-on for legacy projects).
-7. **Update `compliance/RTM.md`** with the new entry: REQ-XXX, title, risk class, linked issue, linked test cases (placeholder).
-8. **Post plan summary as an issue comment.** Format: TL;DR; Risk class + signals; Acceptance criteria (with SRS-IDs); Technical approach (one paragraph); Dependencies; Test scope.
-9. **Checkpoint** — pause for human approval **iff** risk class is HIGH or CRITICAL. LOW and MEDIUM pass through to Phase 2 automatically. The checkpoint can be forced on for all classes via the `--require-plan-approval` flag (or `DEVAUDIT_REQUIRE_PLAN_APPROVAL=1` env var) for orgs that want it always-on.
+7. **Invoke `adr-author` to decide ADR-worthiness + draft the ADR if needed.** The plan's "Architecture decisions" section is no longer authored inline as bullets — `adr-author` applies its decision tree (new third-party dependency / new database/cache/queue / new external service / pattern change spanning >3 files / HIGH-CRITICAL risk class / file-path signals from `sdlc-config.json:adr_author.file_paths_signal_architecture`), allocates the next `ADR-NNN`, drafts a Context/Decision/Consequences/Alternatives/Status stub at `docs/ADR/ADR-NNN-<slug>.md`, and injects either _"Produced ADR-NNN: <title>"_ or _"No ADR needed — <rationale>"_ into the plan's section. Call via the standard Claude Code Skill mechanism (`Skill(name: "adr-author", …)`). Configurable via `sdlc-config.json:adr_author.block_on_stage_1`; advisory by default in v1.
+8. **Update `compliance/RTM.md`** with the new entry: REQ-XXX, title, risk class, linked issue, linked test cases (placeholder).
+9. **Post plan summary as an issue comment.** Format: TL;DR; Risk class + signals; Acceptance criteria (with SRS-IDs); Architectural decisions (ADR-NNN reference or no-ADR rationale); Technical approach (one paragraph); Dependencies; Test scope.
+10. **Checkpoint** — pause for human approval **iff** risk class is HIGH or CRITICAL. LOW and MEDIUM pass through to Phase 2 automatically. The checkpoint can be forced on for all classes via the `--require-plan-approval` flag (or `DEVAUDIT_REQUIRE_PLAN_APPROVAL=1` env var) for orgs that want it always-on.
 
 ### Phase 2 — Implement and test (SDLC stage 2)
 
@@ -198,15 +199,17 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
 
 ### Phase 3 — Compile evidence (SDLC stage 3)
 
-1. **Invoke `requirements-aligner` to drop the per-REQ SRS-alignment artefact.** The skill's Phase 2 produces `compliance/evidence/REQ-XXX/srs-alignment.md` — the per-REQ trace from each AC to its SRS item, with an operator sign-off block. The artefact uploads with `evidence_type=srs_alignment` and closes `ISO29119.3.4` + `SOC2.CC2.1` for the REQ. Call via the standard Skill mechanism; don't inline the alignment logic.
-2. **Re-run the full test pack** with artefact capture:
+1. **Invoke `requirements-aligner` to drop the per-REQ SRS-alignment artefact.** The skill's Phase 2 produces `compliance/evidence/REQ-XXX/srs-alignment.md` — the per-REQ trace from each AC to its SRS item, with an operator sign-off block. The artefact uploads with `evidence_type=srs_alignment` (visible in Documents tab + audit-pack export; v1 orphan-by-design per META-COMPLY framework-registry-auditor). Call via the standard Skill mechanism; don't inline the alignment logic.
+2. **Invoke `adr-author` to drop the per-REQ architecture-decision artefact.** The skill's Phase 2 produces `compliance/evidence/REQ-XXX/architecture-decision.md` — either _"Produced ADR-NNN: <title>"_ with the file pointer, or _"No ADR needed — <rationale>"_. Operator sign-off block at the bottom. The artefact uploads with `evidence_type=architecture_decision`; clause attribution per the META-COMPLY framework-registry-auditor review. Call via the standard Skill mechanism.
+3. **Re-run the full test pack** with artefact capture:
    - `npm run test:e2e -- --reporter=html` (produces `playwright-report/`)
    - `npx vitest run --coverage` (produces `coverage/`)
-3. **Organise artefacts** under `compliance/evidence/REQ-XXX/` with date-prefixed naming:
+4. **Organise artefacts** under `compliance/evidence/REQ-XXX/` with date-prefixed naming:
 
    ```
    compliance/evidence/REQ-XXX/
    ├── srs-alignment.md                  ← produced in step 1 by requirements-aligner
+   ├── architecture-decision.md          ← produced in step 2 by adr-author
    ├── YYYY-MM-DD_e2e-results.json
    ├── YYYY-MM-DD_playwright-report/
    ├── YYYY-MM-DD_traces/                ← per-test trace.zip + error-context.md
@@ -216,7 +219,7 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
 
    Copy Playwright's `test-results/` folder verbatim into `YYYY-MM-DD_traces/` so trace-by-test-name is available for audit without walking the HTML report's hash-name index. For HIGH/CRITICAL releases the traces are part of the audit trail — _"what state was the page in when test X failed and was overridden?"_ answers in one `ls` instead of an HTML-report walk.
 
-4. **Upload each artefact to the portal**:
+5. **Upload each artefact to the portal**:
    ```bash
    devaudit push <project-slug> REQ-XXX <evidence-type> <file> \
      --release "v$(date +%Y.%m.%d)" --create-release-if-missing \
@@ -224,9 +227,9 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
      --git-sha "$(git rev-parse HEAD)" \
      --branch "$(git rev-parse --abbrev-ref HEAD)"
    ```
-   Evidence types: `screenshot`, `e2e_result`, `test_report`, `audit_log`, `compliance_document`, `manual_upload`, `srs_alignment` (from step 1).
-5. **Verify uploads landed.** `gh api` or `curl` against `https://devaudit.metasession.co/projects/<slug>/requirements/REQ-XXX/evidence` should show every artefact.
-6. **Update `compliance/RTM.md`** with portal links for each evidence row.
+   Evidence types: `screenshot`, `e2e_result`, `test_report`, `audit_log`, `compliance_document`, `manual_upload`, `srs_alignment` (from step 1), `architecture_decision` (from step 2).
+6. **Verify uploads landed.** `gh api` or `curl` against `https://devaudit.metasession.co/projects/<slug>/requirements/REQ-XXX/evidence` should show every artefact.
+7. **Update `compliance/RTM.md`** with portal links for each evidence row.
 
 ### Phase 4 — Submit for UAT review (SDLC stage 4)
 

--- a/.github/workflows/compliance-evidence.yml
+++ b/.github/workflows/compliance-evidence.yml
@@ -34,6 +34,18 @@ jobs:
   upload-compliance-evidence:
     name: Upload Compliance Evidence
     runs-on: ubuntu-latest
+    # Permissions are needed because the "Auto-generate housekeeping stubs"
+    # step pushes a new branch + opens a PR via `gh pr create` when the
+    # current push triggers a housekeeping release (vYYYY.MM.DD) that
+    # doesn't yet have its stub release-ticket on disk. Without these
+    # the github-actions[bot] token gets HTTP 403 on the push + on the PR
+    # create, and the auto-housekeeping path silently leaves a red badge
+    # on every docs-only / chore push. DEVAUDIT_USER_TOKEN remains optional
+    # for orgs with restricted Actions permissions — but is no longer
+    # required for the default-config flow. See DevAudit-Installer#122.
+    permissions:
+      contents: write # push the auto-PR branch
+      pull-requests: write # gh pr create
     env:
       DEVAUDIT_BASE_URL_VAR: ${{ vars.DEVAUDIT_BASE_URL }}
       DEVAUDIT_API_KEY: ${{ secrets.DEVAUDIT_API_KEY }}

--- a/SDLC/1-plan-requirement.md
+++ b/SDLC/1-plan-requirement.md
@@ -113,7 +113,9 @@ Create `compliance/evidence/REQ-XXX/implementation-plan.md`:
 
 ## Risks / Considerations
 
-- [Anything that could go wrong or needs special attention]
+> Populated by the [`risk-register-keeper` skill](../skills/risk-register-keeper/SKILL.md) at Stage 1 for MEDIUM/HIGH risk REQs (LOW skipped by default per `sdlc-config.json:risk_register_keeper.stage_1_min_risk_class`). The skill identifies discrete risks the change introduces, allocates `RISK-NNN` per project, drafts canonical rows in `compliance/risk-register.md`, and injects the RISK-NNN reference list here (replacing the inline bullets). Don't author this section inline as bullets — the persistent risk record lives in `compliance/risk-register.md`, not buried in the plan.
+
+- RISK-NNN — <title> (`compliance/risk-register.md`) — Operator edits canonical row + signs off residual rating before APPROVAL — OR — @risk-deferred — <rationale>
 
 ## Post-Deploy Actions
 

--- a/SDLC/1-plan-requirement.md
+++ b/SDLC/1-plan-requirement.md
@@ -25,7 +25,7 @@ description: Define a new requirement in the RTM, classify risk, create implemen
 
 ### Step 1: Identify the GitHub Issue
 
-Every tracked change starts from a GitHub Issue. The issue provides the *what* and *why*; the RTM provides the compliance audit trail.
+Every tracked change starts from a GitHub Issue. The issue provides the _what_ and _why_; the RTM provides the compliance audit trail.
 
 - If the user references an issue number (e.g., `#123`): fetch its title, description, and labels using `gh issue view 123`.
 - If the user describes work without an issue: ask **"Is there a GitHub Issue for this, or should we create one?"**
@@ -42,11 +42,11 @@ The next ID is one higher (e.g., if the last is REQ-007, use REQ-008).
 
 ### Step 3: Classify Risk Level
 
-| Risk Level | Criteria |
-|---|---|
-| **Low** | Internal tools, no regulated data, no auth changes |
+| Risk Level | Criteria                                                         |
+| ---------- | ---------------------------------------------------------------- |
+| **Low**    | Internal tools, no regulated data, no auth changes               |
 | **Medium** | Touches PII, user-facing features, API changes, new dependencies |
-| **High** | Security, payments, RBAC, data handling, authentication |
+| **High**   | Security, payments, RBAC, data handling, authentication          |
 
 AI involvement raises risk by one level when touching Medium or High categories. See Test Policy for the full risk matrix.
 
@@ -68,11 +68,12 @@ mkdir -p compliance/evidence/REQ-XXX
 
 ### Step 6: Implementation Plan (MEDIUM/HIGH Risk — Required)
 
-For MEDIUM and HIGH risk requirements, create an implementation plan before defining test scope. The implementation plan defines *what code changes are needed* — the test scope is then derived from it.
+For MEDIUM and HIGH risk requirements, create an implementation plan before defining test scope. The implementation plan defines _what code changes are needed_ — the test scope is then derived from it.
 
 **Skip this step** for LOW risk requirements — proceed directly to Step 7.
 
 **6a. Explore the codebase:**
+
 - Understand existing patterns, models, services, and API routes relevant to the change
 - Identify files that will be created, modified, or affected
 
@@ -89,25 +90,33 @@ Create `compliance/evidence/REQ-XXX/implementation-plan.md`:
 **Date:** [YYYY-MM-DD]
 
 ## Approach
+
 [1-3 sentences describing the overall approach]
 
 ## Files to Create
+
 - `path/to/new-file.ts` — [purpose]
 
 ## Files to Modify
+
 - `path/to/existing-file.ts` — [what changes and why]
 
 ## Architecture Decisions
-- [Key decision 1 and rationale]
-- [Key decision 2 and rationale]
+
+> Populated by the [`adr-author` skill](../skills/adr-author/SKILL.md) at Stage 1 plan APPROVAL. The skill applies a decision tree (new third-party dependency / new database, cache, or queue / new external service / pattern change spanning > 3 files / HIGH-CRITICAL risk) and either drafts `docs/ADR/ADR-NNN-<slug>.md` + injects "Produced ADR-NNN: <title>" here, or injects "No ADR needed — <one-line rationale>" so the question is visibly asked and answered. Don't author this section inline as bullets — the persistent decision lives in `docs/ADR/`, not buried in the plan.
+
+- ADR-NNN — <title> (`docs/ADR/ADR-NNN-<slug>.md`) — Operator edits stub + flips to _Accepted_ before APPROVAL — OR — No ADR needed — <rationale>
 
 ## Dependencies
+
 - [New packages needed, or "None"]
 
 ## Risks / Considerations
+
 - [Anything that could go wrong or needs special attention]
 
 ## Post-Deploy Actions
+
 - [Data migrations, backfill scripts, schema changes — or "None"]
 - [If any: create script in `scripts/`, document exact command and target environment]
 ```
@@ -115,6 +124,7 @@ Create `compliance/evidence/REQ-XXX/implementation-plan.md`:
 ### WAIT CHECKPOINT: Implementation Plan Review
 
 **Present the implementation plan to the developer.** Summarize:
+
 - Approach and rationale
 - Files to create/modify
 - Architecture decisions
@@ -275,6 +285,7 @@ EOF
 ### WAIT CHECKPOINT: Test Scope Review
 
 **Present the test scope to the developer.** Summarize:
+
 - Risk classification and rationale
 - Test approach (which additional testing applies)
 - Acceptance criteria
@@ -330,6 +341,7 @@ EOF
 ### WAIT CHECKPOINT: Test Plan Review
 
 **Present the test plan to the developer.** Summarize:
+
 - Tests to add, update, and remove
 - How acceptance criteria map to specific tests
 - Any non-functional testing required

--- a/SDLC/Implementation_Plan_TEMPLATE.md
+++ b/SDLC/Implementation_Plan_TEMPLATE.md
@@ -50,7 +50,23 @@ Each section below maps to one (or more) of these clauses. Don't delete sections
 - **In scope:** REPLACE — list every file / module / surface the change touches.
 - **Out of scope:** REPLACE — adjacent areas the change deliberately leaves alone.
 
-## 3. Threat model + security considerations
+## 3. Architecture decisions
+
+> _Populated by the [`adr-author` skill](../skills/adr-author/SKILL.md) at Stage 1 plan APPROVAL._
+
+Either an ADR-NNN reference list (when the skill judges the REQ architecturally significant) OR an explicit "no ADR" rationale. **Don't author this section inline as bullets** — the `adr-author` skill applies its decision tree and either drafts a `docs/ADR/ADR-NNN-<slug>.md` stub the operator edits, or annotates the no-ADR case.
+
+When **ADR warranted**:
+
+- **ADR-NNN — <decision title>** — Drafted by `adr-author`. File at `docs/ADR/ADR-NNN-<slug>.md`. Operator edits stub to canonical prose + flips status to _Accepted_ before plan APPROVAL.
+
+When **No ADR needed**:
+
+- **No ADR needed** — REPLACE one-line rationale. Examples: "Bug fix touching only `lib/services/order-service.ts:applyDiscount` — no structural change." / "CSS-only adjustment — no behavioural or dependency change." / "Patch-level dependency bump with no API change."
+
+The negative case is audit evidence too — auditors examine "no ADR — <rationale>" to confirm the question was asked. Never leave this section empty.
+
+## 4. Threat model + security considerations
 
 > _Closes ISO 27001 A.8.25 — secure development life cycle_
 
@@ -63,7 +79,7 @@ Each section below maps to one (or more) of these clauses. Don't delete sections
 
 **Dependencies introduced:** REPLACE — list new npm/pip packages; flag any with known CVEs or transitive concerns.
 
-## 4. Data protection (GDPR Art. 25)
+## 5. Data protection (GDPR Art. 25)
 
 > _Closes GDPR Art. 25 — data protection by design_
 
@@ -85,7 +101,7 @@ If **yes**, fill in:
 
 If **no**, write: _"N/A — this REQ does not process personal data. <Why — e.g. UI-only change, internal-routing refactor, dev-tooling.>"_
 
-## 5. AI / model considerations (EU AI Act Art. 11)
+## 6. AI / model considerations (EU AI Act Art. 11)
 
 > _Closes EUAIA Art. 11 — technical documentation_
 
@@ -103,13 +119,13 @@ If **yes**, fill in:
 
 If **no**, write: _"N/A — this REQ does not introduce or change AI behaviour. <Why.>"_
 
-## 6. Rollback plan
+## 7. Rollback plan
 
 - **Reversible via:** REPLACE — git revert / migration down / config flip / etc.
 - **Data implications of rollback:** REPLACE — any data written by the new code that an older version can't read?
 - **Notification path if rollback during a release:** REPLACE — who hears, how quickly?
 
-## 7. Verification
+## 8. Verification
 
 How the team will know the REQ is correct in production:
 
@@ -118,7 +134,7 @@ How the team will know the REQ is correct in production:
 - **Manual smoke after deploy:** REPLACE — bullet-list, or "none" with reason
 - **Monitoring / alerting:** REPLACE — what dashboards / alerts the change adds or relies on
 
-## 8. Sign-off
+## 9. Sign-off
 
 - **Plan reviewer (eng):** REPLACE — name + date
 - **Plan reviewer (security / DPO):** REPLACE — when GDPR or threat-model sections are non-trivial; otherwise "N/A"

--- a/SDLC/Implementation_Plan_TEMPLATE.md
+++ b/SDLC/Implementation_Plan_TEMPLATE.md
@@ -79,6 +79,17 @@ The negative case is audit evidence too — auditors examine "no ADR — <ration
 
 **Dependencies introduced:** REPLACE — list new npm/pip packages; flag any with known CVEs or transitive concerns.
 
+### Risk register entries
+
+> _Populated by the [`risk-register-keeper` skill](../skills/risk-register-keeper/SKILL.md) for MEDIUM/HIGH risk REQs at Stage 1 plan APPROVAL. The persistent risk record lives in [`compliance/risk-register.md`](../../risk-register.md); this section references the RISK-NNN entries this REQ opened, mitigated, or accepted._
+
+When **risk class is MEDIUM or HIGH**, expect a list like:
+
+- **RISK-NNN — <title>** — Status: OPEN. Opened by `risk-register-keeper`. Operator edits canonical row + signs off residual rating before plan APPROVAL.
+- **RISK-NNN — <title>** — Status: MITIGATED. Controls landing in this PR close the residual.
+
+When **risk class is LOW** OR no register-worthy risk is identified, write: _"@risk-deferred: <one-line rationale>"_ — the negative case is audit evidence too. Don't leave this section empty.
+
 ## 5. Data protection (GDPR Art. 25)
 
 > _Closes GDPR Art. 25 — data protection by design_


### PR DESCRIPTION
## Summary

Bumps the SDLC sync to **devaudit 0.1.44** (rolls forward from the in-flight 0.1.43 commit on the same branch). Three things land:

### 1. `adr-author` skill (DevAudit-Installer#124, v0.1.43)

Catches the moment a tracked REQ makes an architecturally significant decision that should produce `docs/ADR/ADR-NNN-<slug>.md`. Stage 1 + Stage 3 hooks. Closes `ISO27001.A.8.25` per framework-registry-auditor verdict.

### 2. `risk-register-keeper` skill (DevAudit-Installer#125, v0.1.44)

Maintains `compliance/risk-register.md` as the project-spanning risk SoT.

- **Stage 1 hook** (MEDIUM/HIGH only by default): identifies discrete risks, allocates `RISK-NNN`, drafts canonical rows (inherent + residual L×I, mitigations, owner, review-due, framework cross-references), injects RISK-NNN reference list into the plan.
- **Post-incident hook**: drafts residual-risk entry on every `incident-export.yml` close, cross-links bidirectionally with the incident-report-N.md file.
- **Stage 3 hook**: produces `compliance/evidence/REQ-XXX/risk-assessment.md`. Uploads as `evidence_type=risk_assessment`. Closes `SOC2.CC3.2` per the framework-registry-auditor verdict.
- **Phase 4 enforcement**: for projects in `approval.mode=solo_with_gap`, refuses release approval unless the documented `SOC2.CC8.1` control-gap entry exists on the register.

### 3. `compliance-evidence.yml` YAML permissions fix (#122, v0.1.43)

Adds `permissions: { contents: write, pull-requests: write }` to the upload-compliance-evidence job — closes the HTTP 403 on docs-only / chore pushes that triggered a bare-date release.

## All six skills now synced

`e2e-test-engineer`, `governance-doc-author`, `sdlc-implementer`, `requirements-aligner`, `adr-author`, `risk-register-keeper`.

The SoT-alignment skill family (requirements-aligner + adr-author + risk-register-keeper) closes the drift gap between code and the project's three SoT documents (`docs/SRS.md`, `docs/ADR/`, `compliance/risk-register.md`) at edit time.

## Test plan

- [ ] CI on `develop` after merge passes (TypeScript / Semgrep / dep-audit / E2E / build)
- [ ] First docs-only push fires `compliance-evidence.yml` successfully (no HTTP 403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)