### PR TITLE
chore: re-enable e2e-regression auto-triggers post-#117

### DIFF
--- a/.github/workflows/e2e-regression.yml
+++ b/.github/workflows/e2e-regression.yml
@@ -23,17 +23,14 @@ on:
         required: false
         type: string
         default: ''
-  # Auto-triggers DISABLED during #117 (WhatsApp + customer-facing
-  # backlog). Operator policy: "delivery" = when #117 as a whole closes,
-  # not when each intermediate REQ-XXX inside #117 ships. Until then:
-  #   - workflow_dispatch with `specs` for targeted iteration (above)
-  #   - workflow_dispatch with empty `specs` for the one-time full pack
-  #     at #117 close (manual op)
-  # Re-enable both blocks below by uncommenting once #117 closes.
-  # pull_request:
-  #   branches: [main]
-  # schedule:
-  #   - cron: '0 2 * * *' # nightly 02:00 UTC
+  # Auto-triggers re-enabled 2026-06-06 — #117 (WhatsApp + customer-facing
+  # backlog) CLOSED with the v2026.06.05 bundle shipping REQ-066/069/070/
+  # 071/072/073. workflow_dispatch with `specs` remains available for
+  # targeted iteration loops during in-flight REQ work.
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 2 * * *' # nightly 02:00 UTC
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Why

`#117` (WhatsApp + customer-facing backlog umbrella) closed with the v2026.06.05 bundle shipping REQ-066/069/070/071/072/073. Per the operator policy documented in `.github/workflows/e2e-regression.yml`'s comments — _"delivery = when #117 as a whole closes, not when each intermediate REQ-XXX inside #117 ships"_ — the nightly cron + `pull_request → main` auto-triggers are now appropriate to restore.

## What

Uncomments two stanzas in `.github/workflows/e2e-regression.yml`:

```yaml
  pull_request:
    branches: [main]
  schedule:
    - cron: '0 2 * * *'  # nightly 02:00 UTC
```

Plus rewrites the preceding comment block to document the re-enable date + reasoning. `workflow_dispatch` with `specs` input remains in place for in-flight REQ fix-and-verify loops.

## Side benefit

The 7 new specs from the v2026.06.05 bundle (REQ-069 webhook signature/idempotency, REQ-070 rewards cancel-reversal, REQ-071 public API authenticated contracts, REQ-072 Socket.IO `order-status-update`, REQ-073 admin destructive ops) will start running in the nightly + on every `develop → main` PR — covering the integration gap noted in this morning's pack-status check ("not yet validated as part of a full regression").

Companion: manual `workflow_dispatch` full regression triggered against develop in parallel (independent of this PR; doesn't need it to land first).

## Risk

**LOW** — workflow file change only. Zero production code change. The triggers being re-enabled were the original design — this restores the pre-#117 cadence.

## Gates

| Gate | Actual |
|---|---|
| `tsc --noEmit` | exit 0 (unchanged — no code) |
| Compliance Validation | n/a (no REQ tag; housekeeping commit type `chore:`) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)