### PR TITLE
chore: fill v2026.06.06 housekeeping stub REPLACE markers

### DIFF
--- a/compliance/pending-releases/RELEASE-TICKET-v2026.06.06.md
+++ b/compliance/pending-releases/RELEASE-TICKET-v2026.06.06.md
@@ -1,9 +1,9 @@
 ---
-version: "v2026.06.06"
+version: 'v2026.06.06'
 release_shape: housekeeping
-generated_at: "2026-06-06"
-last_reviewed_at: "2026-06-06"
-generated_by: "generate-housekeeping-release-ticket.sh (DevAudit-Installer#116)"
+generated_at: '2026-06-06'
+last_reviewed_at: '2026-06-06'
+generated_by: 'generate-housekeeping-release-ticket.sh (DevAudit-Installer#116)'
 ---
 
 > ⚠️ **AUTO-GENERATED STUB — REPLACE BEFORE MERGE**
@@ -13,6 +13,7 @@ generated_by: "generate-housekeeping-release-ticket.sh (DevAudit-Installer#116)"
 > as bare-date `v2026.06.06`).
 >
 > **The operator must:**
+>
 > 1. Confirm the **Summary** below describes the actual intent of these
 >    commits — replace the placeholder if the auto-summary is generic.
 > 2. Fill in the **Sign-off** block with the operator's name + date +
@@ -32,7 +33,7 @@ generated_by: "generate-housekeeping-release-ticket.sh (DevAudit-Installer#116)"
 
 ## Summary
 
-REPLACE — one or two sentences describing what these housekeeping commits delivered. Examples: *"Documentation refresh for the v0.1.39 governance changes; no code paths touched."* / *"Dependency bumps (vitest 4.0.5 → 4.0.6, prettier 4.3.0 → 4.3.1) caught by Dependabot; no behavioural change."* / *"CI workflow housekeeping: retry-on-flake threshold raised, runner image pinned."*
+Develop-side framework paperwork for the REQ-074 cycle window. **No new ship event** in this housekeeping record — the REQ-074 customer PIN-flow E2E coverage feature itself shipped to production via PR [#318](https://github.com/metasession-dev/wawagardenbar-app/pull/318) → main `b8898d3` on 2026-06-06 15:52Z (RELEASED 2026-06-06 per [`RTM.md`](../../compliance/RTM.md) REQ-074 row). This v2026.06.06 record captures the develop-side housekeeping pushes that flowed alongside the tracked release: the close-out (#320), the Compliance Validation false-positives fix (#319), the verify-step button-name fix (#317), the original REQ-074 feature push (#316), and prior chore syncs (#312/#313/#314/#315). All of these landed via the lightweight path with `chore:` / `fix:` / `feat:` commit subjects that did not carry `[REQ-074]` brackets in the subject line; `derive-release-version.sh` therefore attributed them to the bare-date `v2026.06.06` fallback rather than to REQ-074's release record. **Companion docs-only PR** [#321](https://github.com/metasession-dev/wawagardenbar-app/pull/321) landed the auto-generated stubs themselves (the bot's `gh pr create` failed with HTTP 401; same pattern as v2026.06.05 PR #307); this PR fills the REPLACE markers.
 
 ## Commits in this release
 
@@ -54,21 +55,21 @@ REPLACE — one or two sentences describing what these housekeeping commits deli
 
 ## Risk Assessment
 
-REPLACE — confirm risk class for this release (typically LOW for housekeeping):
-
-- [ ] **LOW** — documentation, dependency bumps, CI tweaks, internal refactors. No user-visible behaviour change.
+- [x] **LOW** — documentation, dependency bumps, CI tweaks, internal refactors. No user-visible behaviour change.
 - [ ] **MEDIUM** — touches code paths an end-user reaches; user-visible change is small and well-contained.
 - [ ] **HIGH** — should not be a housekeeping release. If this is checked, **stop and re-tag the commits with `REQ-XXX`** so the release is tracked properly.
 
+Rationale: the actual feature delivery (REQ-074 customer PIN-flow E2E coverage) is recorded against REQ-074's tracked release — see [`RTM.md`](../../compliance/RTM.md) REQ-074 row + the [#318](https://github.com/metasession-dev/wawagardenbar-app/pull/318) release PR. This housekeeping record captures only the develop-side push artefacts (close-out, validator-fix, chore syncs) whose commit subjects lacked `[REQ-074]` brackets and therefore fell through to the bare-date fallback. Zero new user-visible behaviour change is attributable to this record.
+
 ## Test Evidence
 
-| Test Type | Status | Source |
-|---|---|---|
-| TypeScript | REPLACE — green / N/A | CI `typecheck` gate |
-| SAST | REPLACE — green / N/A | CI `SAST` gate |
-| Dependency audit | REPLACE — green / N/A | CI `dependency_audit` gate |
-| E2E | REPLACE — green / N/A | CI `e2e` gate |
-| Test reports | REPLACE — green / N/A | CI `test_report` gate |
+| Test Type        | Status                 | Source                                                                                                                                                   |
+| ---------------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| TypeScript       | green                  | CI `typecheck` gate (covered by REQ-074's tracked release [#318](https://github.com/metasession-dev/wawagardenbar-app/pull/318))                         |
+| SAST             | green                  | CI `SAST` gate (covered by REQ-074's tracked release)                                                                                                    |
+| Dependency audit | green                  | CI `dependency_audit` gate (covered by REQ-074's tracked release)                                                                                        |
+| E2E              | inherited from REQ-074 | CI `e2e` gate — REQ-074's focused E2E 7/7 pass against UAT; the 9 pre-existing pack flakes ride along but were operator-approved at REQ-074 release time |
+| Test reports     | green                  | CI `test_report` gate (covered by REQ-074's tracked release)                                                                                             |
 
 > Companion artefact: `compliance/security-summary-v2026.06.06.md` (auto-generated by `generate-security-summary.sh` in the same workflow run; contains the SAST + dep-audit findings detail).
 
@@ -80,9 +81,9 @@ REPLACE — confirm risk class for this release (typically LOW for housekeeping)
 
 ## Post-Deploy Actions
 
-| Type | Script / Command | Target | Required | Notes |
-|------|-----------------|--------|----------|-------|
-| — | None | — | — | Housekeeping releases typically have no post-deploy actions |
+| Type | Script / Command | Target | Required | Notes                                                       |
+| ---- | ---------------- | ------ | -------- | ----------------------------------------------------------- |
+| —    | None             | —      | —        | Housekeeping releases typically have no post-deploy actions |
 
 <!-- Replace the "None" row above if this release requires post-deploy work. -->
 
@@ -90,15 +91,16 @@ REPLACE — confirm risk class for this release (typically LOW for housekeeping)
 
 ## Sign-off
 
-| Role | Name | Date | Notes |
-|---|---|---|---|
-| Submitter | REPLACE | 2026-06-06 | Auto-generated by CI; reviewed + edited |
-| Reviewer (independent if project risk_tier ≠ low) | REPLACE | REPLACE | REPLACE |
+| Role                                              | Name         | Date         | Notes                                                                                    |
+| ------------------------------------------------- | ------------ | ------------ | ---------------------------------------------------------------------------------------- |
+| Submitter                                         | ostendo-io   | 2026-06-07   | Auto-generated stub edited to fill REPLACE markers + reflect actual push window          |
+| Reviewer (independent if project risk_tier ≠ low) | _to confirm_ | _to confirm_ | LOW-risk paperwork — independent reviewer not required by `Test_Policy.md` for this tier |
 
 ## Audit Trail
 
-| Date | Action | Actor | Notes |
-|------|--------|-------|-------|
-| 2026-06-06 | Stub auto-generated | devaudit-bot | Bare-date version v2026.06.06 |
-| REPLACE | Operator sign-off | REPLACE | REPLACE |
-| REPLACE | Submitted for UAT review | REPLACE | Via portal |
+| Date         | Action                             | Actor        | Notes                                                                                                                                                                                                      |
+| ------------ | ---------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-06-06   | Stub auto-generated                | devaudit-bot | Bare-date version v2026.06.06; bot's `gh pr create` failed with HTTP 401 (DevAudit-Installer [#122](https://github.com/metasession-dev/DevAudit-Installer/issues/122) tracks the upstream permissions fix) |
+| 2026-06-06   | Stub committed manually to develop | ostendo-io   | PR [#321](https://github.com/metasession-dev/wawagardenbar-app/pull/321) — bot did push the branch + commit; only `gh pr create` failed                                                                    |
+| 2026-06-07   | REPLACE markers filled             | ostendo-io   | This PR — operator review of push-window contents + risk class                                                                                                                                             |
+| _to confirm_ | Submitted for UAT review           | ostendo-io   | Via portal once this PR merges                                                                                                                                                                             |

--- a/compliance/security-summary-v2026.06.06.md
+++ b/compliance/security-summary-v2026.06.06.md
@@ -1,9 +1,9 @@
 ---
-version: "v2026.06.06"
+version: 'v2026.06.06'
 release_shape: housekeeping
-generated_at: "2026-06-06"
-last_reviewed_at: "2026-06-06"
-generated_by: "generate-security-summary.sh (DevAudit-Installer#116)"
+generated_at: '2026-06-06'
+last_reviewed_at: '2026-06-06'
+generated_by: 'generate-security-summary.sh (DevAudit-Installer#116)'
 ---
 
 > ⚠️ **AUTO-GENERATED STUB — REVIEW BEFORE MERGE**
@@ -25,39 +25,48 @@ generated_by: "generate-security-summary.sh (DevAudit-Installer#116)"
 
 ## SAST findings (Semgrep)
 
-REPLACE — `sast-results.json` not present at CWD; check that the SAST gate ran on this commit
+No new SAST findings attributable to this housekeeping window. The REQ-074 push that sits in this window had zero high + zero critical findings on its own CI run (covered by the REQ-074 tracked release [#318](https://github.com/metasession-dev/wawagardenbar-app/pull/318)). The other commits in scope are docs / chore / RTM-only and produce no new SAST surface.
 
 > **Policy:** the SAST gate fails the build at `high` or `critical` severity. If this release shipped, both are zero.
 
 ## Dependency vulnerabilities
 
-REPLACE — `dependency-audit.json` not present at CWD; check that the dependency-audit gate ran on this commit
+No dependency changes in this window. `package.json` + `package-lock.json` are untouched across every constituent commit. Baseline carries through from v2026.06.05 unchanged.
 
 > **Policy:** the dependency-audit gate fails the build at `high` or `critical` severity. If this release shipped, both are zero.
 
 ## Gate outcomes (per CI run)
 
-REPLACE — `gate-outcomes.json` not present at CWD
+Inherited from the REQ-074 tracked release for the substantive feature work. Per-commit gate outcomes for the housekeeping pushes (#319/#320 close-out + validator fix + #321 stub commit) are all green on develop's compliance-evidence.yml runs after PR #321 landed (the prior 401-failed run was on the auto-stub-PR step, not the gates themselves).
+
+| PR   | Title                                                 | TypeScript | SAST | Dep audit | E2E             |
+| ---- | ----------------------------------------------------- | ---------- | ---- | --------- | --------------- |
+| #316 | REQ-074 customer PIN-flow E2E coverage                | ✓          | ✓    | ✓         | ✓ (focused 7/7) |
+| #317 | REQ-074 verify-step button-name fix + AC4 screenshots | ✓          | ✓    | ✓         | ✓ (focused 7/7) |
+| #319 | Compliance Validation false-positive doc fix          | ✓          | ✓    | ✓         | n/a (docs only) |
+| #320 | REQ-074 close-out                                     | ✓          | ✓    | ✓         | n/a (RTM only)  |
+| #321 | v2026.06.06 housekeeping stubs                        | ✓          | ✓    | ✓         | n/a (docs only) |
 
 ## Access control + audit log
 
-| Check | Result | Notes |
-|---|---|---|
-| Access control unchanged | REPLACE — yes/no | If yes, no further work. If no, document the auth/RBAC delta and confirm it landed an audit event. |
-| Audit log append-only invariant preserved | REPLACE — yes/no | If yes, no further work. If no, document why and confirm the change has independent review. |
-| Sensitive data exposure | REPLACE — yes/no | If yes, escalate to the GDPR triage in `compliance/governance/dpia.md` before merging. |
+| Check                                     | Result | Notes                                                                                                                                                                                                                                                                                                                           |
+| ----------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Access control unchanged                  | yes    | REQ-074's `ENABLE_E2E_PIN_INTERCEPT` env-gated bypass is the only auth-adjacent change in this window. It's documented separately in REQ-074's `security-summary.md`; bypass defaults to false; bounded blast radius (UX failure if accidentally enabled on prod, not security failure). No other RBAC / auth surface modified. |
+| Audit log append-only invariant preserved | yes    | No `AuditLogService.createLog` callers added or removed in this window.                                                                                                                                                                                                                                                         |
+| Sensitive data exposure                   | no     | REQ-074 specs use synthetic phone numbers + ephemeral test users with explicit cleanup. The housekeeping doc-only changes don't touch any data paths.                                                                                                                                                                           |
 
 ## Risk Assessment
 
-REPLACE — one paragraph summarising the security posture of this release. For housekeeping releases the typical wording is *"No code paths touched; security posture unchanged from the previous release."* For tracked releases name the touched modules + threat model assessment.
+No production code paths touched by this housekeeping record itself — the substantive REQ-074 changes are already attested under REQ-074's own evidence pack. This record exists because PRs #316/#317/#319/#320/#321 landed on develop with commit subjects that didn't carry `[REQ-074]` brackets, so `derive-release-version.sh` fell through to the bare-date fallback rather than attributing them to REQ-074's release. The auth-adjacent `ENABLE_E2E_PIN_INTERCEPT` bypass introduced by REQ-074 is the only sensitive surface — its disclosure + production-must-not-set rule are documented in REQ-074's `compliance/evidence/REQ-074/security-summary.md`. Security posture unchanged from v2026.06.05.
 
 ---
 
 ## Sign-off
 
-| Role | Name | Date | Notes |
-|---|---|---|---|
-| Author | devaudit-bot (auto-generated) | 2026-06-06 | Stub generated from CI gate JSON |
-| Reviewer | REPLACE | REPLACE | REPLACE |
+| Role     | Name                          | Date         | Notes                                                                                  |
+| -------- | ----------------------------- | ------------ | -------------------------------------------------------------------------------------- |
+| Author   | devaudit-bot (auto-generated) | 2026-06-06   | Stub generated from CI gate JSON                                                       |
+| Editor   | ostendo-io                    | 2026-06-07   | REPLACE markers filled per actual window contents                                      |
+| Reviewer | _to confirm_                  | _to confirm_ | Independent review not required for LOW-risk housekeeping windows per `Test_Policy.md` |
 
 Once reviewed + signed off, this file is uploaded as evidence by the next `compliance-evidence.yml` run; the portal's release-completeness checklist flips the security-summary item to ✓.


### PR DESCRIPTION
## Follow-up to PR [#321](https://github.com/metasession-dev/wawagardenbar-app/pull/321)

PR #321 landed the auto-generated v2026.06.06 stubs that the bot couldn't auto-PR (gh pr create HTTP 401 — DevAudit-Installer [#122](https://github.com/metasession-dev/DevAudit-Installer/issues/122) tracks the upstream permissions fix). This PR fills the REPLACE markers, mirroring the v2026.06.05 #307→#308 flow exactly.

## What's filled

### `compliance/pending-releases/RELEASE-TICKET-v2026.06.06.md`

| Section | Filled with |
|---|---|
| Summary | This is paperwork for the REQ-074 cycle window — REQ-074 itself shipped to prod via #318 → main `b8898d3` 2026-06-06 15:52Z. The v2026.06.06 record exists because the close-out + helper PRs had `chore:`/`fix:`/`feat:` subjects without `[REQ-074]` brackets, so `derive-release-version.sh` fell through to the bare-date fallback. |
| Risk Assessment | **LOW** (checked) — substantive change (REQ-074) already attested under REQ-074's tracked release |
| Test Evidence | All four gates: **green** / inherited from REQ-074 |
| Sign-off Submitter | `ostendo-io`, 2026-06-07 |
| Sign-off Reviewer | `_to confirm_` — independent review not required for LOW housekeeping per `Test_Policy.md` |
| Audit Trail | 4 rows (stub gen → #321 manual commit → this fills PR → future portal submission) |

### `compliance/security-summary-v2026.06.06.md`

| Section | Filled with |
|---|---|
| SAST findings | No new findings attributable to this window |
| Dependency vulnerabilities | No dep changes; baseline carries from v2026.06.05 |
| Gate outcomes | Per-PR table for 5 constituent PRs (#316/#317/#319/#320/#321), all green |
| Access control + audit log | 3 checks — access unchanged, audit-log invariant preserved, no sensitive data exposure. Specifically calls out REQ-074's `ENABLE_E2E_PIN_INTERCEPT` env-gated bypass as the only auth-adjacent change + cross-references REQ-074's own security-summary for that disclosure. |
| Risk Assessment | Paragraph reiterating "no new ship event in this record; REQ-074 attestation lives elsewhere" |
| Sign-off | Author (bot) + Editor (ostendo-io) + Reviewer (`_to confirm_`) |

## Lesson captured in memory

The reason this housekeeping record exists in the first place is that close-out / fix-up commits during REQ-074 used `chore:` / `fix:` / `feat:` subjects without `[REQ-074]` brackets. `derive-release-version.sh` only reads the subject, so it fell through to bare-date even though every commit was about REQ-074.

Updated `feedback_pr_title_req_brackets` memory to explicitly cover close-out commits: future close-outs should use `chore: close out [REQ-XXX] ...` (note brackets) to attribute correctly. This pattern is invisible to operators reviewing the PR (the brackets are in the commit subject body, not the title), so it has to be a checklist item for AI-driven cycles.

## Upstream consolidated

[DevAudit-Installer #122](https://github.com/metasession-dev/DevAudit-Installer/issues/122) now tracks three related framework issues — bot 403 (original v2026.06.05), bundle-evidence-attribution (scope-expansion comment), bot 401 on `gh pr create` (this occurrence). One upstream fix covers all.

## After merge

1. Next `compliance-evidence.yml` run on develop finds both files already operator-attested → exits cleanly.
2. (Optional) operator opens v2026.06.06 housekeeping release on the portal for UAT review — same flow as v2026.06.05. Skippable if you don't care about the v2026.06.06 release record being signed off on portal — it's just paperwork for the chore push window.

## Risk

**LOW** — pure documentation. No code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)