### PR TITLE
test: REQ-075 AC1 reads service list, not raw Mongo [REQ-075]

### DIFF
--- a/e2e/admin/main-categories-config.spec.ts
+++ b/e2e/admin/main-categories-config.spec.ts
@@ -102,11 +102,14 @@ test.describe('REQ-075 — main-category registry (REQ-MENUMGT-005)', () => {
 
   test('AC1 — create persists slug + label + order under main-categories key', async () => {
     const label = `e2e-req075 Snacks ${Date.now()}`;
-    const before = await readRegistry();
+    // Read the service-layer view (which respects the default seed when
+    // the SystemSettings doc hasn't been persisted yet) rather than the
+    // raw Mongo doc — pre-REQ-075 envs may have a doc with empty value.
+    const beforeList = await MainCategoryService.list();
     const expectedOrder =
-      before.length === 0
+      beforeList.length === 0
         ? 0
-        : Math.max(...before.map((c) => c.order ?? 0)) + 1;
+        : Math.max(...beforeList.map((c) => c.order ?? 0)) + 1;
 
     const created = await MainCategoryService.create({ label }, ADMIN_USER_ID);
     seededSlugs.push(created.slug);


### PR DESCRIPTION
Follow-up fix to PR #326.

## Summary

The new `e2e/admin/main-categories-config.spec.ts` AC1 test computed `expectedOrder` from a direct Mongo read of `systemsettings.value`, which is empty in environments that haven't persisted the registry doc yet. `MainCategoryService.create` reads through `getMainCategories` which seeds the default `food` + `drinks` pair when no doc exists, so the service returned `order=2` while the test expected `0`.

One-line fix: switch the pre-computation to `MainCategoryService.list()` so the test sees the same view the service does.

## Test plan

- [x] `e2e/admin/main-categories-config.spec.ts` against UAT — **4/4 ACs + 3 auth-setup pass (24.1s wall-clock)**
- [x] `e2e/api/public-contracts-authenticated.spec.ts` REQ-071 envelope assertion against UAT — pass
- [x] `npx tsc --noEmit` → exit 0

Ref: REQ-075

🤖 Generated with [Claude Code](https://claude.com/claude-code)