### PR TITLE
fix: rename relocates menu-categories sub-cats via lean read [REQ-075]

### DIFF
--- a/__tests__/services/main-category-service.test.ts
+++ b/__tests__/services/main-category-service.test.ts
@@ -33,9 +33,14 @@ const mockUpdateMany = vi.fn();
 
 const mockFindOne = vi.fn();
 const mockFindOneAndUpdate = vi.fn();
+// `MainCategoryService` reads SystemSettings via `findOne().lean()` (fix
+// for the rename-loses-link bug). The mock returns a chainable whose
+// `.lean()` resolves to whatever the test set on `mockFindOne`.
 vi.mock('@/models/system-settings-model', () => ({
   default: {
-    findOne: (...args: unknown[]) => mockFindOne(...args),
+    findOne: (...args: unknown[]) => ({
+      lean: () => mockFindOne(...args),
+    }),
     findOneAndUpdate: (...args: unknown[]) => mockFindOneAndUpdate(...args),
   },
 }));
@@ -199,6 +204,44 @@ describe('REQ-075 — MainCategoryService', () => {
       expect(
         finalListUpdate.find((c: { slug: string }) => c.slug === 'food')
       ).toBeUndefined();
+    });
+
+    // Regression: the rename relocates 'food' → 'meals' inside the
+    // 'menu-categories' SystemSettings doc. Old impl mutated the
+    // Mongoose-Mixed wrapper in place + assumed `$set: { value: ... }`
+    // would persist the deletion; that left sub-categories under the
+    // old slug while the registry had been renamed, breaking the
+    // MenuCategoriesForm tab for the new slug.
+    it('writes a $set with the new slug key and without the old slug key', async () => {
+      mockFindOne.mockResolvedValueOnce({
+        key: 'menu-categories',
+        value: {
+          food: [
+            { value: 'starters', label: 'Starters', order: 1, isEnabled: true },
+            {
+              value: 'main-courses',
+              label: 'Main Courses',
+              order: 2,
+              isEnabled: true,
+            },
+          ],
+          drinks: [{ value: 'wine', label: 'Wine', order: 1, isEnabled: true }],
+        },
+      });
+
+      await MainCategoryService.rename('food', 'meals', ADMIN);
+
+      const menuCatsWriteCall = mockFindOneAndUpdate.mock.calls.find(
+        (c) => c[0]?.key === 'menu-categories'
+      );
+      expect(menuCatsWriteCall).toBeDefined();
+      const nextValue = menuCatsWriteCall![1].$set.value;
+      expect(nextValue.food).toBeUndefined();
+      expect(Array.isArray(nextValue.meals)).toBe(true);
+      expect(nextValue.meals).toHaveLength(2);
+      expect(nextValue.meals[0].value).toBe('starters');
+      // Drinks unchanged.
+      expect(nextValue.drinks).toHaveLength(1);
     });
 
     it('rejects identical old/new slug', async () => {

--- a/components/features/admin/menu-categories-form.tsx
+++ b/components/features/admin/menu-categories-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useForm, useFieldArray, type ArrayPath } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
@@ -90,6 +90,20 @@ export function MenuCategoriesForm({
     resolver: zodResolver(menuSettingsSchema),
     defaultValues: defaults,
   });
+
+  // After a Main Category rename / add / delete via the sibling
+  // MainCategoriesForm, `revalidatePath` re-renders the page with a new
+  // `initialSettings` + `mainCategories` prop. RHF's internal state
+  // doesn't auto-sync to changed `defaultValues`, so we explicitly reset
+  // — otherwise a "Save Categories" submit after a rename would clobber
+  // the relocated keys with the form's stale snapshot.
+  useEffect(() => {
+    form.reset(defaults);
+    if (enabled.length > 0 && !enabled.some((m) => m.slug === activeTab)) {
+      setActiveTab(enabled[0].slug);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [defaults, enabled]);
 
   async function onSubmit(data: MenuSettingsFormValues) {
     setIsSubmitting(true);

--- a/services/main-category-service.ts
+++ b/services/main-category-service.ts
@@ -93,14 +93,13 @@ export class MainCategoryService {
       mainCategory: slug,
     });
 
+    // `.lean()` returns a POJO; without it Mongoose's Mixed wrapper can
+    // make nested arrays fail `Array.isArray()`, masking real refs.
     const menuCatsSetting = await SystemSettingsModel.findOne({
       key: 'menu-categories',
-    });
-    const menuCats =
-      (menuCatsSetting?.value as Record<string, unknown[]>) || {};
-    const subCategories = Array.isArray(menuCats[slug])
-      ? menuCats[slug].length
-      : 0;
+    }).lean<{ value?: Record<string, unknown[]> }>();
+    const sub = menuCatsSetting?.value?.[slug];
+    const subCategories = Array.isArray(sub) ? sub.length : 0;
 
     return { menuItems, subCategories };
   }
@@ -275,27 +274,44 @@ export class MainCategoryService {
     );
 
     // Step 2: relocate sub-categories in 'menu-categories' SystemSettings.
+    //
+    // NOTE: read via `.lean()` so `value` comes back as a plain JS object
+    // (POJO) — without it, Mongoose hydrates `value` as a Mixed wrapper
+    // whose nested arrays don't pass `Array.isArray()` and whose in-place
+    // mutations don't always re-serialize cleanly for `$set`. The old
+    // implementation could silently no-op step 2, leaving sub-categories
+    // pinned to `oldSlug` after the registry had been renamed to
+    // `newSlug` — making the MenuCategoriesForm tab for the new slug
+    // appear empty (the "menu categories lost the link" symptom).
     let subCategoriesMoved = 0;
-    const menuCatsSetting = await SystemSettingsModel.findOne({
+    const menuCatsSettingLean = await SystemSettingsModel.findOne({
       key: 'menu-categories',
-    });
-    if (menuCatsSetting && menuCatsSetting.value) {
-      const menuCats = menuCatsSetting.value as Record<string, unknown[]>;
-      if (Array.isArray(menuCats[oldSlug])) {
-        subCategoriesMoved = menuCats[oldSlug].length;
-        menuCats[newSlug] = menuCats[oldSlug];
-        delete menuCats[oldSlug];
+    }).lean<{ value?: Record<string, unknown[]> }>();
+
+    if (menuCatsSettingLean?.value) {
+      const sourceList = menuCatsSettingLean.value[oldSlug];
+      if (Array.isArray(sourceList) && sourceList.length > 0) {
+        subCategoriesMoved = sourceList.length;
+        // Build the post-rename value as a fresh POJO clone — don't
+        // mutate the read result + assume Mongoose will serialize it
+        // back correctly.
+        const nextValue: Record<string, unknown[]> = {
+          ...menuCatsSettingLean.value,
+          [newSlug]: sourceList,
+        };
+        delete nextValue[oldSlug];
+
         await SystemSettingsModel.findOneAndUpdate(
           { key: 'menu-categories' },
           {
             $set: {
-              value: menuCats,
+              value: nextValue,
               updatedBy: new Types.ObjectId(adminUserId),
               updatedAt: new Date(),
             },
             $push: {
               changeHistory: {
-                value: menuCats,
+                value: nextValue,
                 changedBy: new Types.ObjectId(adminUserId),
                 changedAt: new Date(),
                 reason: `Main category rename ${oldSlug} → ${newSlug}`,


### PR DESCRIPTION
Follow-up to PR #326 — fixes a bug surfaced during operator UAT walkthrough.

## Symptom

After renaming a Main Category slug via `MainCategoriesForm`, the Menu Categories form's tab for the new slug appeared empty — sub-categories had **lost the link** to the renamed main category.

## Root cause

Two coupled bugs:

### 1. Service layer — `MainCategoryService.rename` step 2

`SystemSettingsModel.findOne({ key: 'menu-categories' })` without `.lean()` returns a Mongoose-Mixed-wrapped document. Nested arrays inside `value` fail `Array.isArray(menuCats[oldSlug])`, so the relocation block silently no-oped. The registry got renamed but sub-categories stayed under the old slug → `MenuCategoriesForm` tab for the new slug renders empty.

Fix: read with `.lean()` to get a POJO, then build the post-rename value as a fresh clone (`{ ...value, [newSlug]: list }` + delete old key) instead of mutating the Mongoose-Mixed wrapper. Same fix applied to `referenceCount` which had the same vulnerability (could under-count refs and let a delete proceed that should have been blocked).

### 2. UI layer — `MenuCategoriesForm` stale form state

React Hook Form's `defaultValues` are captured once at mount. After a rename triggers `revalidatePath`, the page re-renders with fresh `initialSettings` + `mainCategories` props but RHF's internal state stays stale. A subsequent "Save Categories" submit would write the pre-rename snapshot back, clobbering the relocated key — a second silent corruption path.

Fix: `useEffect` calls `form.reset(defaults)` when the memoised defaults change; also re-points `activeTab` if the previously active main category was renamed away.

## Test plan

- [x] New regression vitest case at `__tests__/services/main-category-service.test.ts` pins the rename write payload (asserts `value.food` is gone, `value.meals` carries the relocated sub-cats). 19 → 20 cases.
- [x] `npx vitest run __tests__/services/main-category-service.test.ts` → 20/20 pass
- [x] `npx tsc --noEmit` → exit 0
- [x] Focused E2E against UAT: 4/4 ACs + 3 auth-setup pass (24.6s wall-clock)
- [ ] Operator UAT walkthrough confirms the rename → menu-categories tab shows sub-cats under the new slug

Ref: REQ-075

🤖 Generated with [Claude Code](https://claude.com/claude-code)