### PR TITLE
feat: per-row portions toggle on main categories form [REQ-075]

### DIFF
--- a/components/features/admin/main-categories-form.tsx
+++ b/components/features/admin/main-categories-form.tsx
@@ -326,7 +326,12 @@ function MainCategoryRow({
   isPending: boolean;
   onUpdate: (
     slug: string,
-    patch: { label?: string; isEnabled?: boolean; icon?: string },
+    patch: {
+      label?: string;
+      isEnabled?: boolean;
+      icon?: string;
+      portionsEnabled?: boolean;
+    },
     successMessage: string
   ) => void;
   onRename: (slug: string) => void;
@@ -345,7 +350,7 @@ function MainCategoryRow({
         <GripVertical className="h-5 w-5" />
       </div>
 
-      <div className="grid flex-1 gap-4 md:grid-cols-4 items-center">
+      <div className="grid flex-1 gap-4 md:grid-cols-5 items-center">
         <div className="space-y-1">
           <Label className="text-xs text-muted-foreground">Slug</Label>
           <div className="font-mono text-sm flex items-center gap-2">
@@ -416,6 +421,30 @@ function MainCategoryRow({
           />
           <Label className="text-xs font-normal text-muted-foreground">
             {cat.isEnabled ? 'Visible' : 'Hidden'}
+          </Label>
+        </div>
+
+        {/* REQ-075 — Portions toggle controls whether the Add / Edit
+            Menu Item forms surface the Half / Quarter portion section
+            for items under this main category. Customer-facing pages
+            honour the item's stored portionOptions flags regardless,
+            so toggling this off doesn't strip portions from existing
+            items — only hides the form section for new edits. */}
+        <div className="flex items-center gap-2">
+          <Switch
+            checked={cat.portionsEnabled === true}
+            onCheckedChange={(checked) =>
+              onUpdate(
+                cat.slug,
+                { portionsEnabled: checked },
+                `Portions ${checked ? 'enabled' : 'disabled'} for "${cat.label}"`
+              )
+            }
+            disabled={isPending}
+            data-testid={`portions-toggle-${cat.slug}`}
+          />
+          <Label className="text-xs font-normal text-muted-foreground">
+            {cat.portionsEnabled === true ? 'Portions on' : 'Portions off'}
           </Label>
         </div>
 


### PR DESCRIPTION
Follow-up to PR #326 — closes the per-row Portions toggle gap I flagged during operator review.

## Summary

The Main Categories settings form exposed the `portionsEnabled` flag only in the **Add new main category** sub-form. There was no per-row toggle on existing rows, so flipping the flag on `food` / `drinks` after creation required a code change or a DB write.

This PR adds a Switch in each `MainCategoryRow` next to the existing enabled/disabled toggle. The grid widens from `md:grid-cols-4` to `md:grid-cols-5`.

The update path was already wired end-to-end (`updateMainCategoryAction` + `MainCategoryService.update` both accept `portionsEnabled` in the patch), so this is a pure UI plumb.

## Semantics — unchanged

The flag continues to gate **only** the admin Add / Edit Menu Item form's Portion Options section:
- ON → the form shows Half Portion (50%) / Quarter Portion (25%) with surcharge fields
- OFF → that section is hidden

Customer-facing pages (`menu-item.tsx`, `menu-item-detail-modal.tsx`) honour each item's stored `portionOptions` flags regardless of the registry. Disabling portions on a main category does **not** strip half-portion config from existing items — it just hides the form section for future edits.

## Test plan

- [x] `npx tsc --noEmit` → exit 0
- [ ] Manual UAT: open `/dashboard/settings`, flip the new Portions toggle on `food`, navigate to `/dashboard/menu/new`, confirm the Portion Options block disappears under Main Category = Food. Flip it back, confirm the block returns.

Ref: REQ-075

🤖 Generated with [Claude Code](https://claude.com/claude-code)