### PR TITLE
test: REQ-076 seed helper assigns synthetic phone to avoid E11000 [REQ-076]

### DIFF
--- a/e2e/helpers/main-category-report-seed.ts
+++ b/e2e/helpers/main-category-report-seed.ts
@@ -309,9 +309,17 @@ export async function seedAdminWithReportAccess(
   const username = `${prefix}-${Date.now().toString(36)}`;
 
   return withDb(async (db) => {
+    // `phone` has a unique index on UAT (users.phone_1). Multiple
+    // seeded admins with `phone: null` collide on E11000. Generate
+    // a synthetic E.164-shaped phone per admin (a Nigeria-prefixed
+    // 13-char string derived from username) to avoid the clash.
+    // Real e2e admins from scripts/seed-e2e-admins.ts have phones
+    // assigned the same way.
+    const syntheticPhone = `+234${Date.now().toString().slice(-9)}${Math.floor(Math.random() * 10)}`;
     const result = await db.collection('users').insertOne({
       username,
       email: `${username}@e2e-req076.local`,
+      phone: syntheticPhone,
       password: hashed,
       firstName: 'E2E',
       lastName: 'REQ-076',


### PR DESCRIPTION
Follow-up to [PR #333](https://github.com/metasession-dev/wawagardenbar-app/pull/333) (REQ-076). One-line fix to the seed helper added in that PR.

## Symptom

`e2e/helpers/main-category-report-seed.ts:seedAdminWithReportAccess` inserts admin documents without setting `phone`. The `users` collection has a unique index on `phone` — multiple inserts collide on `{ phone: null }` with `E11000 ... phone_1 dup key: { phone: null }`. The REQ-076 access-control + permissions-ui specs both seed multiple admins, so they fail at insert.

## Fix

Assign each seeded admin a synthetic Nigerian-format phone derived from `Date.now()` + a random suffix. Matches the convention used by the real e2e admins seeded by `scripts/seed-e2e-admins.ts`.

## Why this is its own PR

Surfaced when probing the REQ-076 specs locally before learning E2E gates run in CI, not local-against-UAT (per the new `feedback_run_e2e_in_ci` memory + [#334](https://github.com/metasession-dev/wawagardenbar-app/issues/334)). Landing ahead of the release PR [#336](https://github.com/metasession-dev/wawagardenbar-app/pull/336) `develop → main` so CI has a clean run on the regression project.

## Test plan

- [x] `npx tsc --noEmit` → exit 0
- [x] Local diff confirmed — 1 file, +8 lines
- [ ] Once merged: develop CI green; release PR #336 picks up the new develop tip; e2e-regression.yml runs the 4 new REQ-076 specs without the phone-collision E11000

Ref: REQ-076

🤖 Generated with [Claude Code](https://claude.com/claude-code)