### PR TITLE
test: REQ-076 E2E selector fixes for CI [REQ-076]

### DIFF
--- a/e2e/admin/by-main-category-report-export.spec.ts
+++ b/e2e/admin/by-main-category-report-export.spec.ts
@@ -165,18 +165,12 @@ test.describe('REQ-076 — Per-main-category report exports (REQ-MENUMGT-006)', 
 async function pickSyntheticDate(
   page: import('@playwright/test').Page
 ): Promise<void> {
+  // Trigger's accessible name is the current date range (e.g.
+  // "Jun 09, 2026 - Jun 09, 2026") — match by 4-digit year.
   const trigger = page
-    .locator('button')
-    .filter({ hasText: /Pick a date|Pick date|Today|—/ })
+    .getByRole('button', { name: /\d{4}|Pick a date/ })
     .first();
-  try {
-    await trigger.click({ timeout: 2000 });
-  } catch {
-    await page
-      .getByRole('button', { name: /pick a date|calendar/i })
-      .first()
-      .click({ timeout: 2000 });
-  }
+  await trigger.click({ timeout: 5000 });
   const targetCaption = 'January 2020';
   for (let i = 0; i < 200; i += 1) {
     const captionVisible = await page

--- a/e2e/admin/by-main-category-report.spec.ts
+++ b/e2e/admin/by-main-category-report.spec.ts
@@ -195,27 +195,15 @@ async function pickDateRange(
   startISO: string,
   endISO: string
 ): Promise<void> {
-  // The shadcn DateRangePicker renders a button with a calendar icon.
-  // It usually shows current placeholder; click to open the Calendar.
+  // The shadcn DateRangePicker trigger's accessible name is the
+  // currently-displayed date range (e.g. "Jun 09, 2026 - Jun 09, 2026"),
+  // not a static "Pick a date" placeholder. Match by 4-digit year inside
+  // the button text, with a fallback on the placeholder string for an
+  // empty initial state.
   const trigger = page
-    .locator('button')
-    .filter({ hasText: /Pick a date|Pick date|Today|—/ })
+    .getByRole('button', { name: /\d{4}|Pick a date/ })
     .first();
-  // Fallback: any button inside the controls block (the only popover
-  // trigger near the selector is the date picker).
-  let clicked = false;
-  try {
-    await trigger.click({ timeout: 2000 });
-    clicked = true;
-  } catch {
-    // try a more specific locator anchored on the calendar icon
-    await page
-      .getByRole('button', { name: /pick a date|calendar/i })
-      .first()
-      .click({ timeout: 2000 });
-    clicked = true;
-  }
-  if (!clicked) throw new Error('Could not open DateRangePicker calendar');
+  await trigger.click({ timeout: 5000 });
 
   // Navigate to target month — click "Go to previous month" button until
   // the displayed caption matches the target. react-day-picker exposes

--- a/e2e/admin/main-category-report-access-control.spec.ts
+++ b/e2e/admin/main-category-report-access-control.spec.ts
@@ -211,9 +211,10 @@ async function loginAs(
     .first()
     .or(page.locator('input[name="password"]').first());
   await passwordField.fill(admin.password);
-  // Submit via the visible button
+  // Submit — button label is "Login" (one word) on the admin form;
+  // allow optional space and either variant.
   await page
-    .getByRole('button', { name: /sign in|log in/i })
+    .getByRole('button', { name: /^log\s*in$|^sign\s*in$/i })
     .first()
     .click();
   // Wait for the dashboard or redirect

--- a/e2e/admin/main-category-report-permissions-ui.spec.ts
+++ b/e2e/admin/main-category-report-permissions-ui.spec.ts
@@ -80,19 +80,17 @@ test.describe('REQ-076 — Admin Main-Category Report Access editor (REQ-MENUMGT
     // Currently unrestricted (from beforeAll seed). Untick.
     const unrestricted = page.getByTestId('unrestricted-checkbox');
     await unrestricted.click();
-    // Now per-main checkboxes are enabled. Tick food + drinks.
-    const foodCheckbox = page
+    // Now per-main checkboxes are enabled. Tick food + drinks via the
+    // Radix Checkbox's button role — simpler + more robust than the
+    // testid-wrapper-then-child-button chain (which was flaky in CI).
+    await page
       .getByTestId('main-category-checkbox-food')
       .locator('button[role="checkbox"]')
-      .first()
-      .or(page.getByTestId('main-category-checkbox-food').locator('button'));
-    await foodCheckbox.click();
-    const drinksCheckbox = page
+      .click();
+    await page
       .getByTestId('main-category-checkbox-drinks')
       .locator('button[role="checkbox"]')
-      .first()
-      .or(page.getByTestId('main-category-checkbox-drinks').locator('button'));
-    await drinksCheckbox.click();
+      .click();
 
     // Save
     await page.getByRole('button', { name: /save changes/i }).click();
@@ -127,13 +125,11 @@ test.describe('REQ-076 — Admin Main-Category Report Access editor (REQ-MENUMGT
     // previous test, click to toggle off.
     await page
       .getByTestId('main-category-checkbox-food')
-      .locator('button')
-      .first()
+      .locator('button[role="checkbox"]')
       .click();
     await page
       .getByTestId('main-category-checkbox-drinks')
-      .locator('button')
-      .first()
+      .locator('button[role="checkbox"]')
       .click();
 
     await page.getByRole('button', { name: /save changes/i }).click();


### PR DESCRIPTION
Follow-up to [#333](https://github.com/metasession-dev/wawagardenbar-app/pull/333) + [#337](https://github.com/metasession-dev/wawagardenbar-app/pull/337). Fixes 4 selector / regex misses in the REQ-076 specs that the CI run on release PR [#336](https://github.com/metasession-dev/wawagardenbar-app/pull/336) (run [27175638309](https://github.com/metasession-dev/wawagardenbar-app/actions/runs/27175638309)) surfaced.

Zero application defects — all 4 are test-bugs.

## Failures fixed

| Spec | Root cause | Fix |
|---|---|---|
| `by-main-category-report.spec.ts` AC2 | DateRangePicker trigger's accessible name is the current date range (e.g. `"Jun 09, 2026 - Jun 09, 2026"`), not a static "Pick a date" placeholder | Match by 4-digit year inside the button text |
| `by-main-category-report-export.spec.ts` AC7 | Same as above | Same fix |
| `main-category-report-access-control.spec.ts` AC4 / AC5 | Admin login renders `Login` (one word); regex `/sign in\|log in/i` needs a space | Switch to `/^log\s*in$\|^sign\s*in$/i` |
| `main-category-report-permissions-ui.spec.ts` AC6 | Fragile `testid → button[role=checkbox] → .or(testid → button)` chain; the `.or()` fallback resolved before the first locator | Use the direct `button[role="checkbox"]` locator (same selector Spec 4 uses) |

## Pre-existing failures NOT addressed

The same CI run also flagged 12 pre-existing failures already triaged in [#330](https://github.com/metasession-dev/wawagardenbar-app/issues/330):
- 4 timeouts (express-tip-capture, dashboard-revenue, express-order-report, reconciliation)
- 2 missing CI secrets (payments/webhook-signature-rejection, webhook-idempotency-replay)
- 2 seed-data gaps (admin-order-inventory-delta.sale-point, .over-sell)
- 2 REQ-064 support-ticket regressions
- 2 Daily Report tips (close-tab-tip-capture, daily-report-payments)

This PR does not touch those; they're orthogonal and tracked separately.

## Test plan

- [x] `npx tsc --noEmit` → exit 0
- [ ] CI on this PR runs the smoke gate (informational; not on the regression project per #334-not-yet-merged state)
- [ ] Once merged: release PR #336 picks up the new develop tip + E2E re-runs; the 4 REQ-076 specs run green

Ref: REQ-076

🤖 Generated with [Claude Code](https://claude.com/claude-code)