### PR TITLE
fix: admin-login preserves mainCategoryReportAccess permission [REQ-076]

### DIFF
--- a/app/actions/auth/admin-login.ts
+++ b/app/actions/auth/admin-login.ts
@@ -64,6 +64,17 @@ export async function adminLoginAction(
         // login without needing a data backfill; only an explicit
         // toggle-off in the permissions editor sets this to false.
         incidentsAccess: admin.permissions.incidentsAccess !== false,
+        // REQ-076 — per-user main-category report access. Three valid
+        // shapes: undefined / null (back-compat, see all mains), [] (no
+        // access), or a slug array (restricted subset). Preserve the
+        // exact shape from the DB so the helper's resolution table
+        // distinguishes between "unrestricted" and "explicit deny-all".
+        ...(Array.isArray(admin.permissions.mainCategoryReportAccess)
+          ? {
+              mainCategoryReportAccess:
+                admin.permissions.mainCategoryReportAccess,
+            }
+          : {}),
       };
       console.log(
         '[Login] Saving permissions to session:',

--- a/e2e/admin/by-main-category-report-export.spec.ts
+++ b/e2e/admin/by-main-category-report-export.spec.ts
@@ -186,8 +186,11 @@ async function pickSyntheticDate(
       .click({ timeout: 1500 })
       .catch(() => {});
   }
-  // single-day: click "1" twice
-  await page.getByRole('gridcell', { name: '1', exact: true }).first().click();
-  await page.getByRole('gridcell', { name: '1', exact: true }).first().click();
+  // Calendar day buttons have accessible names like
+  // "Wednesday, January 1st, 2020", not just "1". Match by the full
+  // ordinal date string. Single-day range = click same day twice.
+  const dayButton = /January 1st, 2020/;
+  await page.getByRole('button', { name: dayButton }).first().click();
+  await page.getByRole('button', { name: dayButton }).first().click();
   await page.keyboard.press('Escape');
 }

--- a/e2e/admin/by-main-category-report.spec.ts
+++ b/e2e/admin/by-main-category-report.spec.ts
@@ -228,26 +228,40 @@ async function pickDateRange(
       });
   }
 
-  // Click day from
-  const dayFrom = String(new Date(startISO).getUTCDate());
-  await page
-    .getByRole('gridcell', { name: dayFrom, exact: true })
-    .first()
-    .click();
+  // Calendar day buttons have accessible names like
+  // "Wednesday, January 1st, 2020", not just the day number. Match
+  // each day-button by the full date string suffix.
+  const fromDate = new Date(startISO);
+  const toDate = new Date(endISO);
+  const fromLong = fromDate.toLocaleString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+  // The button text uses ordinal day ("1st", "2nd", …); compose by
+  // index. The regex is anchored on month + year + an ordinal day.
+  const ordinal = (n: number) => {
+    const s = ['th', 'st', 'nd', 'rd'];
+    const v = n % 100;
+    return n + (s[(v - 20) % 10] || s[v] || s[0]);
+  };
+  const fromButton = new RegExp(
+    `${fromDate.toLocaleString('en-US', { month: 'long' })} ${ordinal(fromDate.getUTCDate())}, ${fromDate.getUTCFullYear()}`
+  );
+  await page.getByRole('button', { name: fromButton }).first().click();
 
   if (startISO !== endISO) {
-    const dayTo = String(new Date(endISO).getUTCDate());
-    await page
-      .getByRole('gridcell', { name: dayTo, exact: true })
-      .first()
-      .click();
+    const toButton = new RegExp(
+      `${toDate.toLocaleString('en-US', { month: 'long' })} ${ordinal(toDate.getUTCDate())}, ${toDate.getUTCFullYear()}`
+    );
+    await page.getByRole('button', { name: toButton }).first().click();
   } else {
     // Single-day range: click the same day twice
-    await page
-      .getByRole('gridcell', { name: dayFrom, exact: true })
-      .first()
-      .click();
+    await page.getByRole('button', { name: fromButton }).first().click();
   }
+  // Suppress unused variable warning — keep fromLong reference for
+  // future debugging if the regex changes.
+  void fromLong;
 
   // Close the calendar popover
   await page.keyboard.press('Escape');

--- a/e2e/admin/main-category-report-access-control.spec.ts
+++ b/e2e/admin/main-category-report-access-control.spec.ts
@@ -200,6 +200,17 @@ async function loginAs(
 ): Promise<void> {
   await page.goto('/admin/login');
   await page.waitForLoadState('networkidle');
+  // Dismiss the cookie consent banner if it's intercepting clicks on
+  // the Login button. It renders as a button "Got it" near the form;
+  // .catch() makes the dismissal best-effort.
+  await page
+    .getByRole('button', { name: /^got it$/i })
+    .first()
+    .click({ timeout: 1500 })
+    .catch(() => {
+      /* banner absent or already dismissed */
+    });
+
   // Username field — locate by label OR by name attribute
   const usernameField = page
     .getByLabel(/username|email/i)


### PR DESCRIPTION
Follow-up to [#333](https://github.com/metasession-dev/wawagardenbar-app/pull/333) (REQ-076). CI run [27189865796](https://github.com/metasession-dev/wawagardenbar-app/actions/runs/27189865796) on release PR [#336](https://github.com/metasession-dev/wawagardenbar-app/pull/336) surfaced a **production defect** in the RBAC layer, plus 3 ancillary E2E selector misses.

## 🚨 Production defect

`app/actions/auth/admin-login.ts:53-67` whitelists the permission fields when copying the DB record onto the session cookie. My new `mainCategoryReportAccess` field was **not in the whitelist** — silently stripped during login.

**Effect**: restricted admins (e.g. `mainCategoryReportAccess: ['drinks']` set on the user document) logged in successfully, but `session.permissions` arrived without the restriction. `getAllowedMainCategoriesForReports` then saw `undefined` and routed to the back-compat **see-all-mains** branch. The RBAC gate was **silently broken** in production.

Unit tests pin `getAllowedMainCategoriesForReports` correctly (9 cases); the gap was at the session-copy layer that the unit tests don't cover. The E2E spec is what caught it — the same scenario the spec was designed to verify.

**Fix**: spread the field onto `session.permissions` only when it's a real array. Preserves the three valid shapes:

- `undefined` → field absent from session (back-compat "see all")
- `[]` → explicit empty array (deny all)
- `['food']` → restricted subset

Keeps cookie size small by omitting the field when not used.

## Ancillary E2E selector misses

Same CI run also flagged 3 selector bugs in the new specs:

| Spec | Issue | Fix |
|---|---|---|
| Spec 1 + 3 | Calendar day buttons have accessible names like `"Wednesday, January 1st, 2020"`, not `"1"` | Compute the regex from the target ISO date |
| Spec 4 | `Got it` cookie consent banner intercepts the Login button click | Best-effort dismiss before clicking Login |

Spec 5 timeout was investigated — the editor section DOES render (per page snapshot); the production bug above explains its assertion failure (the saved permission `['food', 'drinks']` round-trip would have failed because the session-copy drops the field before re-render reads it back).

## Test plan

- [x] `npx tsc --noEmit` → exit 0
- [ ] Once merged: release PR #336 picks up the new develop tip + E2E re-runs; expect all 4 REQ-076 specs to pass (session now preserves the field; calendar + cookie selectors fixed)

## Risk

**MEDIUM** — touches the admin-login session payload. Mitigation: change is additive (spread only when array present); doesn't alter the existing 9 boolean permissions in the session; back-compat preserved for any admin without the field.

## Related

- [#333](https://github.com/metasession-dev/wawagardenbar-app/pull/333) — original REQ-076 feature
- [#337](https://github.com/metasession-dev/wawagardenbar-app/pull/337) + [#338](https://github.com/metasession-dev/wawagardenbar-app/pull/338) — earlier follow-up fixes (seed helper phone + selectors)
- [#336](https://github.com/metasession-dev/wawagardenbar-app/pull/336) — release PR awaiting clean CI

Ref: REQ-076

🤖 Generated with [Claude Code](https://claude.com/claude-code)