### PR TITLE
chore: devaudit update to v0.1.52 (bundles B + C)

### DIFF
--- a/.claude/skills/e2e-test-engineer/SKILL.md
+++ b/.claude/skills/e2e-test-engineer/SKILL.md
@@ -10,14 +10,18 @@ Maintain or bootstrap a project's e2e and visual regression test suite. Given an
 ## Scope
 
 **In scope**
+
 - End-to-end tests (UI-driven, user-flow level) in any framework.
 - Visual regression tests in any tool.
 - Maintaining an existing test pack — adding, updating, retiring tests.
 - Bootstrapping a new e2e suite when none exists, including framework selection, structure, configuration, a starter smoke test, and (optionally) CI integration.
 
 **Out of scope**
+
 - Unit, component, or API-only tests.
 - Performance, load, or accessibility audits, unless the project's e2e pack already includes them — in which case follow its lead.
+
+**Transport-layer specs that live in `e2e/`** (Node `fetch` against webhooks, `MongoClient` queries, `socket.io-client` assertions) ARE in scope — they exercise the deployed system end-to-end, just at the transport boundary rather than the UI. Their evidence form is `test-execution-summary.md`, not `evidenceShot` (see _Specs with no page object_ below). The "API-only tests" exclusion above means **unit-level** API contract tests that exercise a route handler in isolation, not transport-boundary integration tests against the running system.
 
 ## The workflow
 
@@ -29,10 +33,10 @@ Three things must be in hand before designing tests: the **test stack**, the **c
 
 **Detect the test stack** from the repo:
 
-- *E2E framework signals* — `playwright.config.*`, `cypress.config.*`, `wdio.conf.*`, `nightwatch.conf.*`, `codecept.conf.*`, `testcafe.config.*`. Failing that, check `package.json` dependencies for `@playwright/test`, `cypress`, `webdriverio`, `puppeteer`, `selenium-webdriver`, or Python equivalents (`pytest-playwright`, `selenium`, `splinter`).
-- *Test location* — common patterns: `e2e/`, `tests/e2e/`, `cypress/e2e/`, `playwright/`, `test/e2e/`, `__tests__/e2e/`.
-- *Visual regression tool* — Playwright or Cypress built-in snapshots, `cypress-image-snapshot`, `cypress-visual-regression`, `percy`, `applitools-eyes-*`, `chromatic`, `backstop.json`, `loki`, `reg-suit`. If none of these are present, the project doesn't do visual regression and you should only add it if the issue explicitly asks for it.
-- *Run command* — search `package.json` scripts for `e2e`, `test:e2e`, `cy:run`, `pw:test`. Failing that, check `Makefile`, `justfile`, `tox.ini`, `pyproject.toml`, CI config. If still unclear, ask.
+- _E2E framework signals_ — `playwright.config.*`, `cypress.config.*`, `wdio.conf.*`, `nightwatch.conf.*`, `codecept.conf.*`, `testcafe.config.*`. Failing that, check `package.json` dependencies for `@playwright/test`, `cypress`, `webdriverio`, `puppeteer`, `selenium-webdriver`, or Python equivalents (`pytest-playwright`, `selenium`, `splinter`).
+- _Test location_ — common patterns: `e2e/`, `tests/e2e/`, `cypress/e2e/`, `playwright/`, `test/e2e/`, `__tests__/e2e/`.
+- _Visual regression tool_ — Playwright or Cypress built-in snapshots, `cypress-image-snapshot`, `cypress-visual-regression`, `percy`, `applitools-eyes-*`, `chromatic`, `backstop.json`, `loki`, `reg-suit`. If none of these are present, the project doesn't do visual regression and you should only add it if the issue explicitly asks for it.
+- _Run command_ — search `package.json` scripts for `e2e`, `test:e2e`, `cy:run`, `pw:test`. Failing that, check `Makefile`, `justfile`, `tox.ini`, `pyproject.toml`, CI config. If still unclear, ask.
 
 **Detect the issue tracker** so you can read the input issue now and file defect issues later:
 
@@ -77,7 +81,7 @@ The bootstrap workflow:
 
 5. **Lay out the directory structure** for the project's expected scale: a top-level test directory (`e2e/` or whatever the framework's installer chose), with subfolders for specs, fixtures, page objects (or fixture-based equivalent), helpers, and visual specs if applicable. Write the structure as a short tree in your reply so the user can see what was created.
 
-6. **Configure for best practice** — base URL pointing at the project's dev server, retries on CI only, parallel workers, an HTML reporter, trace on first retry, `screenshot: 'only-on-failure'` (failure forensics — see *Evidence vs failure forensics* below for per-AC evidence capture), video retention on failure, and (if the framework supports it) auto-starting the dev server before the suite runs. Specifics per framework are in `references/bootstrap.md`.
+6. **Configure for best practice** — base URL pointing at the project's dev server, retries on CI only, parallel workers, an HTML reporter, trace on first retry, `screenshot: 'only-on-failure'` (failure forensics — see _Evidence vs failure forensics_ below for per-AC evidence capture), video retention on failure, and (if the framework supports it) auto-starting the dev server before the suite runs. Specifics per framework are in `references/bootstrap.md`.
 
 7. **Establish the abstraction pattern** — write one Page Object Model (or one fixture, depending on framework idioms) as a worked example so the change's tests in Phase 5 have a template to follow.
 
@@ -87,7 +91,7 @@ The bootstrap workflow:
 
 10. **Offer a CI job** — write the YAML (or equivalent) for the project's CI system, but **do not commit it without confirmation**. Show it inline first. On a **DevAudit** project, `.github/workflows/ci.yml` is generated and marked do-not-edit-manually — don't hand-edit it; instead drive the E2E gate from `sdlc-config.json`. If the suite must run against a **disposable local database** (the rule on any project with no separate test instance — never test against prod), set `e2e_setup_command` (e.g. `supabase start` + load schema + seed) and `e2e_env` (e.g. `E2E_LOCAL=1`, local coords, a dummy email key) so the gate severs production. See [Local-database E2E in CI](https://github.com/metasession-dev/DevAudit-Installer/blob/main/docs/e2e-local-db-ci.md), then `devaudit update` to regenerate.
 
-    **Upload both artefact shapes.** Playwright writes per-test artefacts to *two* places: `test-results/<spec>-<title>[-retryN]/{trace.zip, video.webm, *.png, error-context.md}` — **spec-named**, human-mappable — and `playwright-report/data/<content-hash>.zip` — **hash-named**, indexed by the HTML report. Ensure the project's CI uploads **both** `playwright-report/` (for the HTML viewer) and `test-results/` (for spec-named traces / videos / error-context). If only one is uploaded, propose a small follow-up PR to add the other — it costs ~80 MB of artefact storage and saves the operator from walking the HTML report's hash index to find a specific trace.
+    **Upload both artefact shapes.** Playwright writes per-test artefacts to _two_ places: `test-results/<spec>-<title>[-retryN]/{trace.zip, video.webm, *.png, error-context.md}` — **spec-named**, human-mappable — and `playwright-report/data/<content-hash>.zip` — **hash-named**, indexed by the HTML report. Ensure the project's CI uploads **both** `playwright-report/` (for the HTML viewer) and `test-results/` (for spec-named traces / videos / error-context). If only one is uploaded, propose a small follow-up PR to add the other — it costs ~80 MB of artefact storage and saves the operator from walking the HTML report's hash index to find a specific trace.
 
 11. **Write a short README** in the test directory explaining structure, how to run, how to add new tests, and how to update visual baselines. Future contributors (and the skill itself, on next invocation) will thank you.
 
@@ -107,11 +111,11 @@ You cannot write the right tests without understanding what changed and why. Spe
 
 3. **Read the surrounding app** enough to know how a real user reaches the changed area. Look at routing, navigation, and the one or two most adjacent features.
 
-4. **Write a short mental model** in your reply: *trigger → new behaviour → expected outcomes → likely side-effects*. If anything is ambiguous, ask the user before designing scenarios. Guesses here cascade into bad tests.
+4. **Write a short mental model** in your reply: _trigger → new behaviour → expected outcomes → likely side-effects_. If anything is ambiguous, ask the user before designing scenarios. Guesses here cascade into bad tests.
 
 ### Phase 3 — Design scenarios
 
-The goal is the *minimum* set of scenarios that, if they all pass, would give a reasonable person high confidence the change works as intended and hasn't broken adjacent functionality. "Minimum" is load-bearing: e2e tests are slow to run and expensive to maintain, and a bloated suite gets ignored.
+The goal is the _minimum_ set of scenarios that, if they all pass, would give a reasonable person high confidence the change works as intended and hasn't broken adjacent functionality. "Minimum" is load-bearing: e2e tests are slow to run and expensive to maintain, and a bloated suite gets ignored.
 
 Derive scenarios from these sources, in this order:
 
@@ -127,7 +131,7 @@ Derive scenarios from these sources, in this order:
 
 Resist padding. A new endpoint doesn't need a test that re-verifies login if login is already covered. Match the project's existing depth — if it covers one happy path per feature, don't add six.
 
-For each scenario, write a one-line description. Present the full grouped list to the user before writing any code: *"Here's the coverage I'd propose — anything to add or drop?"*
+For each scenario, write a one-line description. Present the full grouped list to the user before writing any code: _"Here's the coverage I'd propose — anything to add or drop?"_
 
 ### Phase 4 — Reconcile with existing tests
 
@@ -145,6 +149,7 @@ For the area touched by the change, look at what's already there.
 3. **Needs updating** — existing tests where the scenario is still valid but selectors, routes, or assertions have shifted.
 
 Present three lists to the user:
+
 - **To add** — new scenarios not already covered.
 - **To update** — existing tests needing adjustment.
 - **To delete** — genuinely obsolete tests, each with a one-line rationale.
@@ -162,6 +167,7 @@ Write the tests in the project's existing style.
 - **Check `references/common-patterns.md` before writing role-based locators** for component-library UI (shadcn/ui, Radix, MUI, etc.). A short appendix of known framework × library gotchas — `CardTitle` is a `<div>` not a heading; Radix `<Select>` renders two `role="combobox"` nodes; Next.js `<Link>` clicks don't fire network requests — saves a round-trip through a failing selector each time.
 
 For **visual regression** specifically:
+
 - New tests need baseline images. Generate them, but **do not auto-approve** — surface them for the user to verify before they're committed.
 - Use the project's existing breakpoints, viewports, and element-masking conventions.
 
@@ -176,7 +182,7 @@ Run the suite. Strategy:
 3. **For CI-driven verification, ensure the workflow accepts a subset input.** A `workflow_dispatch.inputs.specs` (or equivalent) lets a developer fire a scoped run without local infrastructure. Recommend setting this up if the project doesn't have it — the speed-up (~5–10 min vs ~30–60 min) is the difference between a tractable loop and a hated one.
 4. **For visual regression**, run the project's normal comparison mode against existing baselines.
 
-Triage every failure into one of these buckets *before* taking any action:
+Triage every failure into one of these buckets _before_ taking any action:
 
 **0. Read the page snapshot first.** Modern Playwright writes `test-results/<spec>-<title>[-retryN]/error-context.md` — a markdown accessibility-tree snapshot of the page at failure time. It's enough to triage selector / role / wait-condition failures without extracting the trace zip. Reach for the trace only when the snapshot is ambiguous (e.g. the failure depends on a transition or a network race the snapshot can't show).
 
@@ -191,7 +197,7 @@ Then bucket each failure:
 - **Visual diff — intended** — the snapshot changed because the change intentionally changed the UI. Update the baseline and surface it for user approval.
 - **Visual diff — unintended** — a snapshot changed somewhere the change shouldn't have affected. File it as a regression.
 
-**Then check for missed requirements.** For each numbered acceptance criterion from Phase 2, confirm at least one *passing* test covers it. An AC with no passing test — because no test was written, or because the test fails — is a missed requirement. File it.
+**Then check for missed requirements.** For each numbered acceptance criterion from Phase 2, confirm at least one _passing_ test covers it. An AC with no passing test — because no test was written, or because the test fails — is a missed requirement. File it.
 
 ### Phase 7 — Regression-pack handoff
 
@@ -199,7 +205,7 @@ After Phase 6 succeeds — green run, all ACs proved, defects filed for anything
 
 > **Every `*.spec.ts` (and `*.spec.tsx`) under `tests/e2e/` or `e2e/`.**
 
-There is no `regression/` sub-directory, no `@regression` tag, no manifest file. Being committed and merged to `develop` *is* the graduation step. Once that happens:
+There is no `regression/` sub-directory, no `@regression` tag, no manifest file. Being committed and merged to `develop` _is_ the graduation step. Once that happens:
 
 1. The next CI run (on this branch's PR, or on `develop` after merge) executes the new spec alongside every existing one.
 2. The evidenceShot helper sees `process.env.E2E_NEW_SPECS` (computed by CI as `git diff --diff-filter=A <merge-base>...HEAD`) and tags this branch's captures as `origin: 'feature'`.
@@ -213,7 +219,7 @@ Use whatever tracker integration you found in Phase 1: `gh issue create`, `glab 
 
 Each filed issue needs:
 
-- **Title** — short, specific, describes the symptom not the cause. *"Filter by status shows zero results when status=pending"*, not *"Filter broken"*.
+- **Title** — short, specific, describes the symptom not the cause. _"Filter by status shows zero results when status=pending"_, not _"Filter broken"_.
 - **Steps to reproduce** — numbered, minimal, exact.
 - **Expected vs actual** — on separate lines, no ambiguity.
 - **Environment** — branch, commit SHA, test command, browser/viewport if relevant.
@@ -228,13 +234,13 @@ Every defect filed from Phase 6 becomes `incident_report` evidence when (a) the 
 
 Classify the defect against this table when filing — the canonical version lives at `governance-doc-author/references/incident-classification.md`, mirrored here for the e2e workflow:
 
-| Defect characteristic | Frameworks/clauses attributed |
-|---|---|
-| **Any test failure / defect** (baseline — always) | `ISO29119.3.5.4` Test incident report |
-| **Ops impact** (downtime, persistent errors, perf regression, data corruption) | + `SOC2.CC7.2` System monitoring and incident response |
-| **Security vulnerability** (auth bypass, injection, data exposure) | + `SOC2.CC7.2` + relevant ISO 27001 controls |
-| **Personal data exposed / lost / mishandled** | + `GDPR.Art-33` (always — 72h supervisory notification) + `GDPR.Art-34` (when data subjects need notification) |
-| **AI/ML failure** (model hallucination, biased output, oversight bypass) | + relevant EU AI Act articles (`Art-9` risk, `Art-14` human oversight, `Art-15` accuracy/robustness) |
+| Defect characteristic                                                          | Frameworks/clauses attributed                                                                                  |
+| ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| **Any test failure / defect** (baseline — always)                              | `ISO29119.3.5.4` Test incident report                                                                          |
+| **Ops impact** (downtime, persistent errors, perf regression, data corruption) | + `SOC2.CC7.2` System monitoring and incident response                                                         |
+| **Security vulnerability** (auth bypass, injection, data exposure)             | + `SOC2.CC7.2` + relevant ISO 27001 controls                                                                   |
+| **Personal data exposed / lost / mishandled**                                  | + `GDPR.Art-33` (always — 72h supervisory notification) + `GDPR.Art-34` (when data subjects need notification) |
+| **AI/ML failure** (model hallucination, biased output, oversight bypass)       | + relevant EU AI Act articles (`Art-9` risk, `Art-14` human oversight, `Art-15` accuracy/robustness)           |
 
 **Baseline rule:** the first row is **mandatory**. Even a defect with no specific framework impact STILL produces a valid incident_report attributed to `ISO29119.3.5.4`. Never silently drop the artefact because "it's just a bug".
 
@@ -303,6 +309,15 @@ Wrap up with a summary the user can drop into the PR or ticket:
 - Defects filed — count, with links.
 - Missed requirements — count, with links.
 
+**Then feed the test-design record (devaudit#50).** The Stage 3 `test-execution-summary.md` (generated per `3-compile-evidence.md` Step 1a) carries a `## Test design` section at the top. Before Stage 3 finalises the file, populate that section with the design-time decisions this skill made, so the SDLC has a recorded trace that scope was _decided_, not implicit:
+
+- **Layers planned** — which of `unit | integration | e2e | visual | manual` applied to this REQ
+- **Layers covered** — same list with ✓ or `deferred`
+- **Deferrals** — explicit one-line rationale per deferred layer (`e2e N/A — schema-only, no UI yet` rather than silent absence)
+- **Skill invocation** — _"`e2e-test-engineer` invoked on turn N during Phase 2"_, with a turn pointer the reviewer can verify against the chat transcript
+
+If you authored or modified `e2e/**/*.spec.ts` directly without invoking this skill, that's a delegation gap — the `sdlc-implementer` Phase 2 audit (devaudit#132) will catch it before Phase 3. The honest record is: the skill ran (or didn't), the layers were chosen for stated reasons, and the test-execution-summary attribution points back at the chat turn where the decision happened.
+
 ---
 
 ## Evidence vs failure forensics
@@ -327,7 +342,7 @@ test('AC1: edit dialog opens with fields pre-filled', async ({ page }) => {
 - Call `evidenceShot` **immediately after** the AC-proving assertion, before navigating, closing dialogs, or any further interaction.
 - AC number is a separate argument (`ac: number`) — the helper composes the filename `REQ-XXX-AC<n>-<slug>.png`. The slug describes what the screenshot proves (`edit-dialog-prefilled`), NOT the AC number.
 - Slug is kebab-case lowercase (`[a-z0-9-]+`). Capitalised slugs, underscores, or spaces throw.
-- One **canonical** screenshot per AC; additional stage screenshots are tier-gated — see *Screenshot density per spec role* below.
+- One **canonical** screenshot per AC; additional stage screenshots are tier-gated — see _Screenshot density per spec role_ below.
 - Failure forensics stays untouched (`screenshot: 'only-on-failure'` + `trace: 'on-first-retry'`).
 
 The helper is shipped automatically into `e2e/helpers/evidence.ts` by the SDLC sync (node-stack consumers). Output lands at `compliance/evidence/<REQ-ID>/screenshots/REQ-XXX-AC<n>-<slug>.png` — commit these PNGs as part of the evidence pack so reviewers can corroborate the test-plan AC mapping.
@@ -350,7 +365,7 @@ test('AC7: stock dial completes the transition', async ({ page }) => {
   // Stage screenshots — fire while the spec is a feature artefact;
   // auto-suppress once it graduates into the regression pack.
   await openStockDial(page, item.id);
-  await evidenceShot(page, 'REQ-066', 7, 'dial-open',  { tier: 'feature' });
+  await evidenceShot(page, 'REQ-066', 7, 'dial-open', { tier: 'feature' });
   await advanceDial(page);
   await evidenceShot(page, 'REQ-066', 7, 'in-progress', { tier: 'feature' });
 
@@ -369,9 +384,30 @@ A reasonable default per AC:
 
 When to deviate:
 
-- **Single-shot ACs** (one assertion that's its own proof — e.g. *"the form submits and returns to the list"*) need only the canonical anchor. Don't manufacture stages just to hit the 1–3 band.
+- **Single-shot ACs** (one assertion that's its own proof — e.g. _"the form submits and returns to the list"_) need only the canonical anchor. Don't manufacture stages just to hit the 1–3 band.
 - **Long flows** (>3 meaningful transitions) keep all stages tier `'feature'`. The post-merge regression run still has the canonical anchor to corroborate the AC; the dense journey is on the feature PR for reviewers and in the audit-pack download for that release forever.
 - **Reviewer pushback that evidence feels thin** (single-shot per AC across a HIGH-risk REQ) almost always means tier `'feature'` stages are missing — add them on the feature branch where they actually fire, not after.
+
+### Specs with no page object — transport-layer evidence (devaudit#127)
+
+`evidenceShot` requires a Playwright `page` object. Specs that exercise behaviour at the transport layer — Node `fetch` against HTTP / webhook endpoints, `socket.io-client` connections, direct `MongoClient` queries, gRPC clients — have no `page` and **cannot call `evidenceShot`**. Examples from the wawagardenbar-app regression pack:
+
+- `e2e/payments/webhook-signature-rejection.spec.ts` — HMAC-SHA512 verification via Node `fetch`
+- `e2e/realtime/order-status-broadcast.spec.ts` — `socket.io-client` event assertion
+- `e2e/admin/menu-item-delete.spec.ts` — direct `MongoClient` + service-layer call
+
+These specs are still E2E (they exercise the deployed system end-to-end at the transport boundary), they belong in `e2e/`, and they run alongside UI specs. **Their evidence form is the per-spec entry in `test-execution-summary.md`** — the table of spec → pass/fail → asserted behaviour (signature rejected with HTTP 401, idempotent replay suppressed, broadcast received within Nms, soft-delete cascaded) is the load-bearing proof. The screenshot check is **N/A** for them; the release-completeness "behavioural proof" check is satisfied by the test-execution-summary upload alone.
+
+Discipline for transport specs:
+
+- Name the asserted behaviour in the test title using the same `[REQ-XXX][ACn]` bracket convention UI specs use. Reviewers grep on that.
+- The `test-execution-summary.md` table row should describe what the spec verified in operator-facing terms ("signature mismatch returns 401; payment row unchanged"), not in TypeScript-spec terms ("`expect(response.status).toBe(401)`").
+- If a transport spec _can_ be paired with a thin UI shim that screenshots the user-visible outcome (e.g. an admin dashboard surface that shows the rejected payment as "Failed — signature mismatch"), pair them — that buys back the screenshot evidence at the surface level. Otherwise: transport spec stands alone.
+- The portal's release-detail "screenshots" panel will show zero entries for purely-transport REQs; that's correct. Reviewers cross-reference `test-execution-summary.md` instead.
+
+This is **observation**, not gate-relaxation — these specs satisfy the SDLC evidence requirement; the screenshot mechanism doesn't apply.
+
+A `evidenceTrace(reqId, ac, slug, payload)` helper that writes a JSON sidecar (request/response/ledger shape) was considered as a Phase B; deferred until the portal grows a non-PNG evidence type. Today the test-execution-summary already carries the equivalent information at the table level.
 
 ---
 

--- a/.claude/skills/sdlc-implementer/SKILL.md
+++ b/.claude/skills/sdlc-implementer/SKILL.md
@@ -41,7 +41,79 @@ The orchestrator MUST invoke `e2e-test-engineer` for end-to-end and visual-regre
 - Never transcribe `e2e-test-engineer`'s six-phase workflow into this skill's body.
 - Call via the standard Claude Code Skill mechanism (`Skill(name: "e2e-test-engineer", …)`).
 
+**Structural enforcement (devaudit#132):** the contract is backed by two gates inside Phase 2 — a literal pre-test-work declaration before any `e2e/**/*.spec.ts` edit (step 3) and a mandatory self-audit before Phase 3 (step 9). Both are scripts the orchestrator follows, not prose it can rationalise around. If you find yourself about to skip either, that's the inertia trap the gates exist to interrupt — STOP, run the gate, and you'll usually find the delegation path is obvious from there.
+
 Unit-test and integration-test work stays with this skill until a counterpart unit-test skill ships. The full sub-skill call graph lives at [`references/call-graph.md`](./references/call-graph.md).
+
+## SDLC navigability — LAST/NEXT status sticky (devaudit#131)
+
+Long-running SDLC issues accumulate dozens of comments across multiple Claude Code sessions. The operator returning to the thread should be able to answer two questions in under five seconds:
+
+1. **What just happened?** — the most recent stage completion
+2. **What is the immediate next step?** — the single action the operator (or this skill on resume) should take next
+
+Two surfaces, one convention. Both are mandatory:
+
+### 1. Sticky comment on the REQ issue
+
+At **every stage transition** AND **every operator-action handoff** (waiting for review, waiting for merge, waiting for prod apply), invoke the helper:
+
+```bash
+bash scripts/update-sdlc-status.sh "$ISSUE_NUM" \
+  "<one sentence describing the step just completed>" \
+  "<one sentence describing the immediate next step + actor>"
+```
+
+The helper is idempotent — finds the marker-tagged comment and edits it, or creates one if none exists. So calling it on every transition keeps the same comment current; it never spawns duplicates.
+
+LAST sentence rules:
+
+- One sentence. Name the phase / artefact / outcome.
+- Include load-bearing identifiers — PR numbers, file paths, gate names — so the operator can act without re-scrolling.
+- Past tense.
+
+NEXT sentence rules:
+
+- One sentence. **Always name the actor** (operator action / `sdlc-implementer` auto-continues / waiting for CI / waiting for review).
+- Include the artefact to act on — issue number, PR number, migration path, command to run.
+- If the next step is operator-only and we're paused: say so explicitly. "Operator action — apply Prisma migration 13 to prod, then merge develop→main PR #458."
+
+Examples:
+
+```
+LAST: Phase 1 complete — implementation plan written to compliance/plans/REQ-074/implementation-plan.md (risk class MEDIUM)
+NEXT: Phase 2 — sdlc-implementer auto-continuing
+```
+
+```
+LAST: Phase 4 — release PR #455 opened against develop, CI running
+NEXT: Operator action — review PR #455 + merge when CI green; sdlc-implementer halts here until you ping resume REQ-074
+```
+
+```
+LAST: Phase 5 complete — release v1.2.0 marked Released; post-deploy smoke evidence uploaded
+NEXT: Done — close issue + retire feature branch (sdlc-implementer halts)
+```
+
+### 2. In-chat LAST/NEXT line (Claude Code surface)
+
+Lead every substantive turn with the same two-line shape so the operator can `Ctrl-F NEXT:` in the chat transcript to find the current pointer without re-reading:
+
+```
+**LAST:** <one sentence>
+**NEXT:** <one sentence with actor>
+```
+
+Skip it for trivial turns (acknowledging a "merged" / one-line confirmations / chitchat). It's for SDLC work, not every message. The two surfaces (sticky comment + chat line) should always agree — if they diverge, the comment is canonical (it's what the operator scrolling the issue sees).
+
+### When to update
+
+- After every Phase transition (Phase 0 → 1, 1 → 2, …, 5 → done)
+- On every operator-action handoff (paused for review, paused for merge, paused for prod apply, paused for migration)
+- On the change-request loop (Phase 5 rejection → re-enter Phase 2)
+- On error halt (gate failure exhausted retries, operator-only decision needed)
+
+Do **not** update on every internal step within a phase — that just spams the sticky. The transition + handoff cadence is the right frequency.
 
 ## The workflow
 
@@ -146,6 +218,7 @@ Reached from Phase 0 for non-tracked change-types. The skill drives this end-to-
 
 Reached only on the **tracked** route from Phase 0 (the issue is already fetched and classified).
 
+0. **Initialise SDLC status sticky** on the issue: `bash scripts/update-sdlc-status.sh "$ISSUE_NUM" "Phase 0 complete — classified as tracked SDLC work" "Phase 1 — sdlc-implementer authoring implementation plan"`. From now until the issue closes, the sticky is the always-current pointer to "what's next" — the operator scans it on every return to the issue.
 1. **Confirm the issue scope.** Re-read the `gh issue view <N>` output from Phase 0 — title, body, all comments — with implementation in mind.
 2. **Classify risk** per `Test_Policy.md` §Risk-Based Testing. Emit a one-paragraph rationale citing the signals you used (auth surface, financial calc, data egress, RBAC, AI decisioning, etc.).
 3. **Assign REQ-XXX.** Inspect `compliance/RTM.md` for existing entries; take the next free number. If the issue references an existing REQ, use that instead.
@@ -169,6 +242,7 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
 9. **Update `compliance/RTM.md`** with the new entry: REQ-XXX, title, risk class, linked issue, linked test cases (placeholder).
 10. **Post plan summary as an issue comment.** Format: TL;DR; Risk class + signals; Acceptance criteria (with SRS-IDs); Architectural decisions (ADR-NNN reference or no-ADR rationale); Risk register entries (RISK-NNN list); Technical approach (one paragraph); Dependencies; Test scope.
 11. **Checkpoint** — pause for human approval **iff** risk class is HIGH or CRITICAL. LOW and MEDIUM pass through to Phase 2 automatically. The checkpoint can be forced on for all classes via the `--require-plan-approval` flag (or `DEVAUDIT_REQUIRE_PLAN_APPROVAL=1` env var) for orgs that want it always-on.
+12. **Update SDLC status sticky** before exiting Phase 1: `bash scripts/update-sdlc-status.sh "$ISSUE_NUM" "Phase 1 complete — plan written to compliance/plans/REQ-XXX/implementation-plan.md (risk class <CLASS>)" "Phase 2 — sdlc-implementer auto-continuing"` (or "Operator action — review plan + ping resume" if the HIGH/CRITICAL checkpoint paused).
 
 ### Phase 2 — Implement and test (SDLC stage 2)
 
@@ -178,7 +252,14 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
    - MEDIUM — unit + integration; e2e for any UI-facing change.
    - HIGH — unit + integration + e2e for every user-visible path + at least one negative/abuse test.
    - CRITICAL — HIGH plus targeted security tests (authz bypass attempts, input fuzzing where applicable).
-3. **For any e2e or visual-regression test work in this step, invoke `e2e-test-engineer`** — do not author e2e tests directly. The orchestrator passes the implementation plan + the diff so far to the e2e-test-engineer skill, which derives scenarios, reconciles with the existing pack, and runs the suite.
+3. **E2E delegation gate — pre-test-work declaration (devaudit#132).** Before creating or editing **any** `e2e/**/*.spec.ts` file in this phase, follow these three steps in order. The literal script exists because the "MUST invoke" prose alone has been bypassed by inertia in past runs; the declaration is the structural defence.
+
+   a. Output the single literal line, verbatim: `Delegating e2e test work to e2e-test-engineer.`
+   b. Immediately invoke `Skill(name: "e2e-test-engineer", args: "<the change summary + plan pointer>")`. The change summary is one sentence; the plan pointer is `compliance/plans/REQ-XXX/implementation-plan.md`.
+   c. **Do not author or edit any `e2e/**/\*.spec.ts` file in this skill's own tool calls.\*\* The e2e-test-engineer skill owns spec authoring end-to-end — including the "this AC needs no e2e" decision. If you feel the urge to write a spec inline, that's the inertia trap — STOP and re-invoke the skill.
+
+   When in doubt about whether work qualifies: visual-regression tests, screenshot diffs, browser-driven flows, any file ending in `.spec.ts` under `e2e/`, and any `playwright.config.ts`/`evidence/`/`baselines/` directory all qualify. Unit/integration tests under `tests/unit/`, `tests/integration/`, or stack-equivalent paths stay with this orchestrator.
+
 4. **Implement against the plan.** Reference `compliance/plans/REQ-XXX/implementation-plan.md` as you go. Any deviation from the plan must be noted in the plan itself under a `## Plan deviation` section — never silently diverge.
 5. **Run gates locally, cheap-first.** The gates are not equivalent-cost — `npm run lint` is seconds, `npx playwright test` is 30–60 minutes. Iterate on the fast gates; spend the e2e cost once.
 
@@ -197,6 +278,16 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
 8. **Land the work on `$INTEGRATION_BRANCH`.** Push the feature branch, then:
    - **If `$INTEGRATION_BRANCH` ≠ `$RELEASE_BRANCH`** (develop-first): open a PR `feat/REQ-XXX-<slug> → $INTEGRATION_BRANCH` and merge it once CI is green. This is the **integration hop** — there is no UAT four-eyes gate here (that's the release PR in Phase 4); for MEDIUM+ risk get a peer review on this PR per the project's norms. The push to `$INTEGRATION_BRANCH` is what triggers `ci.yml` to register the release and upload gate evidence.
    - **If `$INTEGRATION_BRANCH` = `$RELEASE_BRANCH`** (trunk-only): do **not** merge to the protected branch here — leave the work on the feature branch; it becomes the release PR's head in Phase 4.
+
+9. **E2E delegation self-audit — mandatory before Phase 3 (devaudit#132).** Run `git diff "$INTEGRATION_BRANCH"...HEAD --name-only` and walk the file list. For **every** entry matching `e2e/**/*.spec.ts`, state out loud one of:
+   - _"Authored via `e2e-test-engineer` skill invocation on turn N."_ — with the turn pointer the operator can verify from the chat transcript.
+   - _"Pre-existing file; only mechanical edits (path renames, import fixes, lint-only) applied directly. No scenario / assertion / selector changes."_ — applies only to non-substantive sweeps where the e2e-test-engineer skill would have nothing to contribute.
+
+   If you cannot place a spec file in either category — STOP. Do not proceed to Phase 3. Revert the direct edits (`git checkout "$INTEGRATION_BRANCH" -- <file>`) and re-do the work via `Skill(name: "e2e-test-engineer", …)`. The audit must be honest: omitting a file or fabricating a turn pointer is worse than the original delegation gap because it pollutes the audit trail with a false attribution.
+
+   This is the post-hoc check that catches anything step 3 missed. If both gates fire (declaration before the spec edit + audit before Phase 3) and you still see a direct authoring path, that's evidence the gates need to be stronger and worth a follow-up issue.
+
+10. **Update SDLC status sticky** before exiting Phase 2: `bash scripts/update-sdlc-status.sh "$ISSUE_NUM" "Phase 2 complete — feat branch landed on $INTEGRATION_BRANCH; all gates green" "Phase 3 — sdlc-implementer auto-continuing (evidence compile)"`.
 
 ### Phase 3 — Compile evidence (SDLC stage 3)
 
@@ -233,6 +324,7 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
    Evidence types: `screenshot`, `e2e_result`, `test_report`, `audit_log`, `compliance_document`, `manual_upload`, `srs_alignment` (from step 1), `architecture_decision` (from step 2), `risk_assessment` (from step 3).
 7. **Verify uploads landed.** `gh api` or `curl` against `https://devaudit.metasession.co/projects/<slug>/requirements/REQ-XXX/evidence` should show every artefact.
 8. **Update `compliance/RTM.md`** with portal links for each evidence row.
+9. **Update SDLC status sticky** before exiting Phase 3: `bash scripts/update-sdlc-status.sh "$ISSUE_NUM" "Phase 3 complete — evidence uploaded; SRS-alignment + ADR + risk-assessment artefacts attached" "Phase 4 — sdlc-implementer auto-continuing (open release PR)"`.
 
 ### Phase 4 — Submit for UAT review (SDLC stage 4)
 
@@ -257,6 +349,7 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
 3. **Apply labels** — `awaiting-uat-review`, `risk:<class>`.
 4. **Comment on the issue**: "Implementation complete. PR #M opened. Evidence on portal: <link>. UAT review requested. Resume with `resume REQ-XXX` once UAT approval is granted on the portal."
 5. **Hard stop.** Phase 4 ends here. Do not proceed to merge; the human's next action is reviewing on the portal.
+6. **Update SDLC status sticky** before halting: `bash scripts/update-sdlc-status.sh "$ISSUE_NUM" "Phase 4 — release PR #<N> opened against $RELEASE_BRANCH; CI running" "Operator action — review PR #<N> + approve UAT release on the portal; sdlc-implementer halts until you ping resume REQ-XXX"`. This is a critical handoff — the sticky must reflect that the agent has stopped + the operator is on the hook.
 
 **When an external gate hangs or fails for unrelated reasons.** A required gate may fail for reasons outside the change's scope — flaky infra, an unrelated regression test that hangs at hour-plus runtime with no log activity, a known-failing suite. When this happens:
 
@@ -278,8 +371,9 @@ Invoked separately by the user after UAT activity on the portal. Trigger: "resum
      - Verify production smoke evidence uploaded (`--environment production`) at `https://devaudit.metasession.co/projects/<slug>/releases/<version>`.
      - Mark release as `Released` via portal API: `PATCH /releases/<version>` with `{"status": "released"}`.
      - Comment on the issue: "Released. Production smoke evidence: <link>."
+     - **Update SDLC status sticky** to the terminal state: `bash scripts/update-sdlc-status.sh "$ISSUE_NUM" "Phase 5 complete — release marked Released; production smoke evidence uploaded" "Done — close issue + retire feature branch (sdlc-implementer halts)"`.
      - Close the issue.
-     - If production smoke fails: do NOT mark as Released. File an `[INCIDENT]` defect issue, page the on-call per the project's incident playbook, follow the rollback plan from the implementation plan.
+     - If production smoke fails: do NOT mark as Released. File an `[INCIDENT]` defect issue, page the on-call per the project's incident playbook, follow the rollback plan from the implementation plan. **Update the sticky** to reflect the incident state: `… "Phase 5 BLOCKED — production smoke failed; INCIDENT issue #N filed" "Operator action — read INCIDENT #N + execute rollback per plan"`.
 
    - **Changes requested** → run change-request loop:
      - Fetch change-request comments from the PR (`gh pr view <M> --comments`) and from the portal release page.
@@ -289,6 +383,7 @@ Invoked separately by the user after UAT activity on the portal. Trigger: "resum
      - Push to the same branch (no force-push). The PR auto-updates.
      - Re-request UAT review on the portal: `POST /api/projects/<slug>/releases/<version>/approval-requests`.
      - Comment on the issue: "Change requests addressed in commits <SHAs>. UAT re-review requested."
+     - **Update SDLC status sticky** for the re-review handoff: `bash scripts/update-sdlc-status.sh "$ISSUE_NUM" "Change-request iteration N applied; PR pushed; re-review requested" "Operator action — re-review on portal; sdlc-implementer halts until you ping resume REQ-XXX"`.
      - Hard stop again. The portal's release-approval state has reset; UAT must explicitly re-approve.
 
    - **Still pending UAT (no approval, no change-request)** → report "UAT review still pending on the portal at <link>" and stop. Do not act.

--- a/.github/workflows/compliance-evidence.yml
+++ b/.github/workflows/compliance-evidence.yml
@@ -290,8 +290,19 @@ jobs:
           # (operator's choice — both layouts are common).
           upload_governance compliance/periodic-review.md             periodic_review
           upload_governance compliance/governance/periodic-review.md  periodic_review
-          upload_governance compliance/incident-report.md             incident_report
-          upload_governance compliance/governance/incident-report.md  incident_report
+          # Incident reports: glob `incident-report*.md` so per-incident
+          # files (e.g. `incident-report-2026-001.md`, written by
+          # incident-export.yml from labelled GitHub issues) all
+          # upload as real evidence. The unedited starter
+          # `incident-report.md` matches the glob too but is skipped
+          # by upload-evidence.sh's central stub guard — so the stub
+          # can never flip ISO29119.3.5.4 to COVERED on its own
+          # (devaudit#133). `*.md` does not match `*.md.template`.
+          shopt -s nullglob
+          for f in compliance/incident-report*.md compliance/governance/incident-report*.md; do
+            upload_governance "$f" incident_report
+          done
+          shopt -u nullglob
 
           # ── Audit-log export (DevAudit-Installer#98 WS2) ──────────────
           # Snapshot the portal's audit log for the rolling 90-day window

--- a/SDLC/1-plan-requirement.md
+++ b/SDLC/1-plan-requirement.md
@@ -131,6 +131,8 @@ Create `compliance/evidence/REQ-XXX/implementation-plan.md`:
 - Files to create/modify
 - Architecture decisions
 - Risks and dependencies
+- **Surface inventory completeness** (MEDIUM/HIGH risk) — every user-touchable surface listed in Section 2's surface-inventory table is either `In scope`, `Already works`, or explicitly `Out of scope (waived)` with a follow-up issue. No surface is silently absent. _(devaudit#152)_
+- **AC form** — the test-scope ACs (drafted in Step 7) can each be phrased in Given/When/Then against the surfaces in scope. If any AC reduces to _"the schema accepts X"_ or _"the resolver returns Y"_, the plan is incomplete — return to Section 2 and expand the surface inventory until every AC has a UI surface that delivers it. _(devaudit#152)_
 
 **Do NOT proceed** until the developer explicitly approves the plan. If the developer requests changes, update `implementation-plan.md` and re-present. For HIGH risk, this review is especially important — it's cheaper to change the plan than to refactor the code.
 
@@ -177,9 +179,22 @@ Standard gates apply. No additional testing beyond universal exit criteria.
 - CI independent verification: all PR checks pass
 - Human code review via PR
 
+### How to write acceptance criteria (devaudit#152)
+
+Phrase each AC as a **user-observable journey**, not a technical-layer assertion. Use the Given/When/Then form:
+
+> **Given** [pre-state + which UI surface the user is on], **When** [named user action with a named control], **Then** [observable change in a named UI surface].
+
+If you can't phrase an AC in Given/When/Then because no UI surface delivers the change to a user, the scope is incomplete — return to the implementation plan's surface inventory (Section 2). LOW risk REQs may keep ACs shorter when the change is genuinely surface-free (refactor / dep bump / infra-only), but the journey form is still preferred when a user surface exists.
+
+Examples:
+
+- ✅ "Given the dependency is updated, When CI runs the universal gates, Then 0 high/critical findings."
+- ❌ "Schema accepts optional `inventoryId` field" — internal mechanic, belongs in `test-plan.md` (this matters even for LOW when the change is user-facing).
+
 ## Acceptance Criteria
 
-- [x] [Criterion 1 — what "done" looks like]
+- [x] [Criterion 1 — what "done" looks like, phrased Given/When/Then where applicable]
 - [x] [Criterion 2]
 EOF
 ```
@@ -218,10 +233,24 @@ How we confirm this meets the business requirement:
 - [e.g., "Verify public page displays new content correctly"]
 - [e.g., "Confirm edits are visible to users within expected time"]
 
+### How to write acceptance criteria (devaudit#152)
+
+Phrase each AC as a **user-observable journey**, not a technical-layer assertion. Use the Given/When/Then form:
+
+> **Given** [pre-state + which UI surface the user is on], **When** [named user action with a named control], **Then** [observable change in a named UI surface] _(plus any audit / downstream UI changes)_.
+
+If you can't phrase an AC in Given/When/Then because no UI surface delivers the change to a user, the scope is incomplete — return to the implementation plan's surface inventory (Section 2).
+
+Examples:
+
+- ✅ "Given Poundo has Ogbono linked, When a staff member opens `/dashboard/orders/express/create-order`, picks Ogbono from the Soup group, and marks the order Complete, Then `/dashboard/inventory/{ogbono}` shows stock decreased by 1 and a new Sale movement row tied to the order ID."
+- ❌ "Schema accepts optional `inventoryId` field (persistence round-trip)" — unit-test contract, belongs in `test-plan.md`, not here.
+- ❌ "Resolver maps selected pairs to inventory link" — internal mechanic, not user value.
+
 ## Acceptance Criteria
 
-- [ ] [Criterion 1]
-- [ ] [Criterion 2]
+- [ ] [Criterion 1 — Given/When/Then]
+- [ ] [Criterion 2 — Given/When/Then]
 - [ ] All additional testing items above pass
 EOF
 ```
@@ -274,10 +303,24 @@ How we confirm this meets the business requirement:
 - Elevated review required for: [security-sensitive files]
 - Regeneration protocol: [will any components be regenerated?]
 
+### How to write acceptance criteria (devaudit#152)
+
+Phrase each AC as a **user-observable journey**, not a technical-layer assertion. Use the Given/When/Then form:
+
+> **Given** [pre-state + which UI surface the user is on], **When** [named user action with a named control], **Then** [observable change in a named UI surface] _(plus any audit / downstream UI changes)_.
+
+HIGH risk especially: every AC must pin to a named UI surface from the implementation plan's surface inventory (Section 2). If you can't phrase an AC in Given/When/Then because no UI surface delivers the change to a user, the scope is incomplete — expand the surface inventory before approving the plan. This is the gap that produced REQ-030 on a consumer project (feature shipped through every gate green, but no order-creation surface let a user select a customisation at order time).
+
+Examples:
+
+- ✅ "Given an admin has linked Poundo to Ogbono in `/dashboard/inventory/links`, When a staff member opens `/dashboard/orders/express/create-order`, picks Ogbono from the Soup group, and marks the order Complete, Then `/dashboard/inventory/{ogbono}` shows stock decreased by 1, a new Sale movement row appears tied to the order ID, and the activity timeline records the link-driven deduction."
+- ❌ "Schema accepts optional `inventoryId` field (persistence round-trip)" — unit-test contract, belongs in `test-plan.md`, not here.
+- ❌ "Resolver maps selected pairs to inventory link" — internal mechanic, not user value.
+
 ## Acceptance Criteria
 
-- [ ] [Criterion 1]
-- [ ] [Criterion 2]
+- [ ] [Criterion 1 — Given/When/Then against a named UI surface]
+- [ ] [Criterion 2 — Given/When/Then against a named UI surface]
 - [ ] All security testing items pass
 - [ ] All validation items confirmed
 - [ ] Independent review completed (if required)

--- a/SDLC/2-implement-and-test.md
+++ b/SDLC/2-implement-and-test.md
@@ -36,6 +36,7 @@ grep 'REQ-XXX' compliance/RTM.md
 **If any file does not exist:** STOP. Run `1-plan-requirement.md` first. Do NOT proceed to implementation without a committed test scope and test plan.
 
 For MEDIUM/HIGH risk, also verify:
+
 ```bash
 # Implementation plan must exist (created during planning stage)
 ls compliance/evidence/REQ-XXX/implementation-plan.md
@@ -57,16 +58,19 @@ If not: `git checkout develop && git pull origin develop`
 Write or update unit tests **before** implementing the code. You know the expected interfaces and behaviour from the implementation plan and test plan.
 
 **2a. Review the test plan:**
+
 ```bash
 cat compliance/evidence/REQ-XXX/test-plan.md
 ```
 
 **2b. Write unit tests** listed in the "Tests to Add" section:
+
 - New business logic → unit tests for services, utilities, validators
 - New API endpoints → auth enforcement tests, response format tests
 - Tests should initially **fail** (the implementation doesn't exist yet)
 
 **2c. Update existing unit tests** listed in the "Tests to Update" section:
+
 - API response shape changed? → Update assertions
 - Business logic changed? → Update unit test expectations
 
@@ -75,6 +79,7 @@ cat compliance/evidence/REQ-XXX/test-plan.md
 ### WAIT CHECKPOINT: Unit Test Coverage
 
 Verify the unit tests cover the test plan:
+
 ```bash
 cat compliance/evidence/REQ-XXX/test-plan.md
 # Check: have all unit test items in "Tests to Add" been implemented?
@@ -114,6 +119,7 @@ Per Test Strategy: regeneration triggers full retest.
 ### WAIT CHECKPOINT: Unit Tests Green
 
 All unit tests must pass before proceeding:
+
 ```bash
 npm test
 ```
@@ -126,19 +132,24 @@ Write or update E2E tests **after** implementation. E2E tests need working UI/AP
 
 > **Skill available:** invoke the **`e2e-test-engineer`** skill for this step (at `.claude/skills/e2e-test-engineer/SKILL.md`). It derives scenarios from the requirement's acceptance criteria, reconciles with the existing test pack (flags obsoletes — but never deletes without confirmation), runs the suite, and files defects for failures or missed ACs. Framework-agnostic (Playwright, Cypress, pytest-playwright, etc.) and tracker-agnostic (GitHub, Linear, Jira, etc.). For projects with no e2e suite yet, the skill also covers bootstrapping one. See [`sdlc/SKILLS.md`](../sdlc/SKILLS.md) for the full list of available skills.
 
-> **Run authenticated flows in CI.** Tests that need a logged-in session (admin forms, role-gated flows) belong in their own Playwright project that depends on `auth-setup`. Register that project name in `sdlc-config.json` `e2e_projects` and set `e2e_seed_command` / `e2e_env` so CI seeds fixtures and runs it as a **report-only** gate (continue-on-error — it surfaces failures as evidence without blocking the merge until proven stable). Prove each AC with an `evidenceShot(page, 'REQ-XXX', 'ACn-…')` so the PNG lands in `compliance/evidence/REQ-XXX/screenshots/`. This is what lets Stage 3 Step 10 reduce manual UAT to a light smoke instead of a full re-click.
+> **Run authenticated flows in CI.** Tests that need a logged-in session (admin forms, role-gated flows) belong in their own Playwright project that depends on `auth-setup`. Register that project name in `sdlc-config.json` `e2e_projects` and set `e2e_seed_command` / `e2e_env` so CI seeds fixtures and runs it as a **report-only** gate (continue-on-error — it surfaces failures as evidence without blocking the merge until proven stable). Prove each UI-driven AC with an `evidenceShot(page, 'REQ-XXX', acN, 'slug')` so the PNG lands in `compliance/evidence/REQ-XXX/screenshots/`. This is what lets Stage 3 Step 10 reduce manual UAT to a light smoke instead of a full re-click.
+
+> **Transport-layer specs have no page** (devaudit#127). Specs that exercise the system at the transport boundary — Node `fetch` against webhooks, `MongoClient` queries, `socket.io-client` assertions — cannot call `evidenceShot`. Their evidence form is the per-spec row in `test-execution-summary.md` describing the asserted behaviour in operator terms. The portal's release-detail "screenshots" panel will show zero entries for purely-transport REQs; that's correct. Reviewers cross-reference `test-execution-summary.md` instead. See `e2e-test-engineer/SKILL.md` § _Specs with no page object_.
 
 **4a. Review the test plan for E2E items:**
+
 ```bash
 cat compliance/evidence/REQ-XXX/test-plan.md
 ```
 
 **4b. Add new E2E tests** listed in the "Tests to Add" section:
+
 - New pages → route protection tests (unauthenticated redirect)
 - New user flows → Playwright tests for critical paths
 - UI components changed? → Update selectors and expected content
 
 **4c. Update existing E2E tests** listed in the "Tests to Update" section:
+
 - New routes added? → Add them to route protection test arrays
 - UI flow changed? → Update selectors and assertions
 
@@ -147,6 +158,7 @@ cat compliance/evidence/REQ-XXX/test-plan.md
 ### WAIT CHECKPOINT: E2E Tests Green
 
 All E2E tests must pass:
+
 ```bash
 npx playwright test
 ```
@@ -185,17 +197,20 @@ Types: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `compliance`, `securi
 ### Step 7: Run All Local Gates (Mandatory)
 
 #### Gate 1: TypeScript
+
 ```bash
 npx tsc --noEmit
 ```
 
 #### Gate 2: Security (SAST + Dependencies)
+
 ```bash
 semgrep scan --config auto [SOURCE_DIR]/ --severity ERROR --severity WARNING
 npm audit --audit-level=high
 ```
 
 If new dependencies added:
+
 ```bash
 git diff origin/main -- package.json package-lock.json | grep '^\+'
 npm audit
@@ -203,23 +218,25 @@ npm audit
 ```
 
 #### Gate 3: E2E Tests
+
 ```bash
 npx playwright test
 ```
 
 #### Exit Criteria
 
-| Gate | Threshold |
-|---|---|
-| TypeScript | 0 errors |
-| SAST (high/critical) | 0 findings |
+| Gate                         | Threshold         |
+| ---------------------------- | ----------------- |
+| TypeScript                   | 0 errors          |
+| SAST (high/critical)         | 0 findings        |
 | Dependencies (high/critical) | 0 vulnerabilities |
-| E2E tests | All pass |
-| Severity-1 defects | 0 open |
+| E2E tests                    | All pass          |
+| Severity-1 defects           | 0 open            |
 
 For Medium/High risk, also verify access control and audit log tests pass (see Test Plan and test-scope.md).
 
 **If SAST finds issues:**
+
 ```bash
 echo "SAST finding: [rule-id] in [file] — [fixed/false-positive: reason]" >> compliance/evidence/REQ-XXX/sast-review.md
 ```
@@ -231,6 +248,7 @@ git push origin develop
 ```
 
 If rejected:
+
 ```bash
 git pull --rebase origin develop
 # Re-run ALL local gates after rebase

--- a/SDLC/3-compile-evidence.md
+++ b/SDLC/3-compile-evidence.md
@@ -136,6 +136,24 @@ cat > compliance/evidence/REQ-XXX/test-execution-summary.md << 'EOF'
 **Git SHA:** [short SHA]
 **CI Run:** [run ID or "local"]
 
+## Test design (devaudit#50)
+
+Records the design-time decisions before listing run results — what was tested, what was deliberately deferred, who/what decided. Auditors (and future maintainers) can see the scope decision was *made*, not implicit.
+
+**Layers planned:** [unit | integration | e2e | visual | manual — pick the ones that apply to this REQ]
+
+**Layers covered:** [same list, marked ✓ for shipped layers / `deferred` for skipped ones]
+
+**Deferrals (if any):**
+
+- [e.g. "e2e N/A — schema-only change, no UI surface reads the new fields yet; deferred to REQ-NNN when the admin form lands"]
+- [e.g. "visual regression N/A — backend service change, no UI affected"]
+- A deferral without a stated rationale is a gap, not a deferral. Either name *why* it was skipped or do the work.
+
+**Skill invocation:** [`e2e-test-engineer` invoked on turn N during Phase 2 — verifiable from the chat transcript] / [`manual scope decision` — operator chose layers directly because <reason>]
+
+**Surface inventory (MEDIUM/HIGH risk REQs):** see `implementation-plan.md` Section 2. Each `In scope` surface here should map to at least one passing test below; each `Already works` surface should map to a regression-pack spec; each `Out of scope (waived)` surface should have a follow-up issue referenced.
+
 ## Gate Results
 
 | Gate | Result | Details |

--- a/SDLC/Implementation_Plan_TEMPLATE.md
+++ b/SDLC/Implementation_Plan_TEMPLATE.md
@@ -35,11 +35,29 @@ Each section below maps to one (or more) of these clauses. Don't delete sections
 > _Closes ISO 29119 §3.4 — test plan_
 
 - **Goal:** REPLACE — one sentence describing what this REQ delivers, no jargon.
+
+### How to write acceptance criteria (devaudit#152)
+
+Phrase each AC as a **user-observable journey**, not a technical-layer assertion. Use the Given/When/Then form:
+
+> **Given** [the relevant pre-state, including which UI surface the user is on],
+> **When** [the user takes a specific, named action with a specific, named control],
+> **Then** [the user can observe a specific, named change in a specific, named UI surface]
+> _(And any additional observable changes — audit rows, downstream UI updates, etc.)_
+
+Concrete examples:
+
+- ✅ "Given Poundo has Ogbono linked, When a staff member opens `/dashboard/orders/express/create-order` and picks Ogbono from the Soup group and marks the order Complete, Then `/dashboard/inventory/{ogbono}` shows stock decreased by 1 and one new Sale movement row tied to the order ID."
+- ❌ "Schema accepts optional `inventoryId` field (persistence round-trip)" — this is a unit-test contract, not a user-observable AC. It belongs in `test-plan.md`, not here.
+- ❌ "Resolver maps selected pairs to inventory link" — same problem. Internal mechanics, not user value.
+
+If you can't phrase an AC in Given/When/Then because no UI surface delivers the change to a user, the scope is incomplete — expand the **Surface inventory** (Section 2) until every AC has a UI surface that delivers it.
+
 - **Acceptance criteria:**
 
 | AC  | Description                                | SRS item it traces to                                                                   |
 | --- | ------------------------------------------ | --------------------------------------------------------------------------------------- |
-| AC1 | REPLACE — one-line behavioural description | REQ-AREA-NNN (existing) / REQ-AREA-NNN (new — propose stub) / `@srs-deferred: <reason>` |
+| AC1 | REPLACE — one-line Given/When/Then journey | REQ-AREA-NNN (existing) / REQ-AREA-NNN (new — propose stub) / `@srs-deferred: <reason>` |
 | AC2 | REPLACE                                    | REPLACE                                                                                 |
 | …   |                                            |                                                                                         |
 
@@ -49,6 +67,24 @@ Each section below maps to one (or more) of these clauses. Don't delete sections
 
 - **In scope:** REPLACE — list every file / module / surface the change touches.
 - **Out of scope:** REPLACE — adjacent areas the change deliberately leaves alone.
+
+### Surface inventory (MEDIUM/HIGH risk — required) (devaudit#152)
+
+List every UI, API, background job, and report **that a real user touches** in the journey this REQ enables. For each surface, mark one of:
+
+- **In scope** — this REQ adds or modifies it
+- **Already works** — existing code already handles it correctly (link the file / route as evidence)
+- **Out of scope (waived)** — explicitly deferred, with one-sentence justification and a follow-up issue link
+
+| Surface                 | URL / file                                           | Status                                                                     |
+| ----------------------- | ---------------------------------------------------- | -------------------------------------------------------------------------- |
+| [e.g. Customer cart]    | `/menu` modal — `components/features/menu/…`         | In scope                                                                   |
+| [e.g. Staff POS]        | `/dashboard/orders/express/…`                        | Out of scope (waived) — front-of-house flow not used yet, follow-up #NN    |
+| [e.g. Admin Edit Order] | `/dashboard/orders/[id]/edit` — `app/admin/orders/…` | Already works — existing customisation picker handles the new fields as-is |
+
+**Rule of thumb:** if the AC list reads _"the schema accepts X"_ or _"the resolver returns Y"_ but never _"the user can do Z in the UI and see the result in the UI"_, the surface inventory is incomplete and the plan is not ready for approval. The matching test-scope ACs in Step 7 must each pin to a surface listed here.
+
+LOW risk REQs may skip the table when the change is genuinely surface-free (refactor, dependency bump, infra-only). State `Surface inventory: N/A — <reason>` instead.
 
 ## 3. Architecture decisions
 

--- a/scripts/update-sdlc-status.sh
+++ b/scripts/update-sdlc-status.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# update-sdlc-status.sh — Post or update the canonical SDLC status
+# sticky comment on a REQ tracking issue (devaudit#131).
+#
+# Purpose: long-running SDLC issues accumulate dozens of comments.
+# The operator scrolling the thread can't find "where are we right
+# now" without re-reading. This helper writes a marker-tagged comment
+# at a predictable shape; subsequent calls find + edit the existing
+# comment instead of stacking new ones, so the latest status always
+# lives in exactly one place on the issue.
+#
+# Idempotent — find-or-create. The marker is HTML-commented so it
+# doesn't show up in the rendered issue UI but is greppable via the
+# API. Subsequent invocations on the same issue replace the body
+# without dropping the marker.
+#
+# Usage:
+#   ./scripts/update-sdlc-status.sh <issue-number> "<last-step>" "<next-step>" [--repo owner/name] [--dry-run]
+#
+# Examples:
+#   ./scripts/update-sdlc-status.sh 322 \
+#     "Phase 2 complete — feat branch landed on develop" \
+#     "Phase 3 — sdlc-implementer auto-continuing"
+#
+#   ./scripts/update-sdlc-status.sh 322 \
+#     "Phase 4 — release PR #455 opened" \
+#     "Operator action — review + merge develop→main when ready" \
+#     --repo metasession-dev/wawagardenbar-app
+#
+# Required:
+#   - `gh` CLI authenticated (uses GITHUB_TOKEN or the current `gh auth` session)
+#   - The issue must exist
+#
+# Optional flags:
+#   --repo owner/name   Override repo (defaults to the cwd's git remote)
+#   --dry-run           Print the body + the gh command that would run,
+#                       without making any API calls. Used by the test
+#                       suite + safe for operator inspection.
+
+set -euo pipefail
+
+if [ "$#" -lt 3 ]; then
+  cat <<'USAGE' >&2
+Usage: update-sdlc-status.sh <issue-number> "<last-step>" "<next-step>" [--repo owner/name] [--dry-run]
+USAGE
+  exit 1
+fi
+
+ISSUE_NUM="$1"
+LAST_STEP="$2"
+NEXT_STEP="$3"
+shift 3
+
+REPO=""
+DRY_RUN=false
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --repo)
+      REPO="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    *)
+      echo "Unknown flag: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Validate issue number is numeric early so we don't make bogus API
+# calls when the caller fat-fingers the arg order.
+if ! [[ "$ISSUE_NUM" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Error: issue number must be a positive integer, got: $ISSUE_NUM" >&2
+  exit 1
+fi
+
+MARKER='<!-- sdlc-implementer:status -->'
+
+# Body shape — keep this compact and load-bearing. The marker MUST be
+# the first line so the find-existing pass can use startswith() in
+# the gh JSON filter without false positives.
+BODY=$(cat <<EOF
+$MARKER
+
+**🟢 LAST STEP** — $LAST_STEP
+
+**🔵 NEXT STEP** — $NEXT_STEP
+
+---
+
+_Updated by \`sdlc-implementer\` on every stage transition. The full SDLC trail lives in the comments below; this comment is the always-current pointer._
+EOF
+)
+
+REPO_FLAG=""
+if [ -n "$REPO" ]; then
+  REPO_FLAG="--repo $REPO"
+fi
+
+if [ "$DRY_RUN" = "true" ]; then
+  echo "[dry-run] would update sticky on issue #$ISSUE_NUM${REPO:+ in $REPO}"
+  echo "----- body -----"
+  echo "$BODY"
+  echo "----- end body -----"
+  exit 0
+fi
+
+# Find an existing status sticky on this issue. We grep through the
+# comments looking for the canonical marker; if found, edit it; if
+# not, create a fresh one.
+#
+# gh's --jq filter handles the lookup server-side so we don't drag
+# every comment back to local. `startswith` is the right matcher
+# because the marker is always the first line.
+EXISTING_ID=""
+# Build the api endpoint. Without --repo, gh resolves from the current
+# git remote — same as `gh issue …` does elsewhere in the framework.
+if [ -n "$REPO" ]; then
+  EXISTING_ID=$(gh api "repos/$REPO/issues/$ISSUE_NUM/comments" --paginate \
+    --jq '.[] | select(.body | startswith("'"$MARKER"'")) | .id' | head -1)
+else
+  EXISTING_ID=$(gh api "repos/{owner}/{repo}/issues/$ISSUE_NUM/comments" --paginate \
+    --jq '.[] | select(.body | startswith("'"$MARKER"'")) | .id' | head -1)
+fi
+
+if [ -n "$EXISTING_ID" ]; then
+  echo "Updating existing SDLC status sticky (comment id: $EXISTING_ID)"
+  if [ -n "$REPO" ]; then
+    gh api "repos/$REPO/issues/comments/$EXISTING_ID" -X PATCH \
+      --field "body=$BODY" >/dev/null
+  else
+    gh api "repos/{owner}/{repo}/issues/comments/$EXISTING_ID" -X PATCH \
+      --field "body=$BODY" >/dev/null
+  fi
+else
+  echo "Posting new SDLC status sticky on issue #$ISSUE_NUM"
+  # shellcheck disable=SC2086  # REPO_FLAG must split on space
+  gh issue comment "$ISSUE_NUM" $REPO_FLAG --body "$BODY" >/dev/null
+fi
+
+echo "SDLC status updated."

--- a/scripts/upload-evidence.sh
+++ b/scripts/upload-evidence.sh
@@ -184,13 +184,33 @@ fi
 # Issue: devaudit#263.
 SUCCEEDED=0
 FAILED=0
+# devaudit#133 — central stub guard. Any file still carrying the
+# DevAudit starter banner ("STARTER TEMPLATE — REPLACE BEFORE
+# COMMITTING" / "...BEFORE GOING TO PRODUCTION" — both phrasings)
+# is skipped before the upload attempt so unedited placeholders
+# can't flip a clause to COVERED off a stub. The check is binary-
+# safe (-a) so it doesn't choke on PNGs or other non-text files.
+SKIPPED=0
 TOTAL_SIZE=0
 UPLOAD_URL="${DEVAUDIT_BASE_URL}/api/evidence/upload"
 MAX_ATTEMPTS=${UPLOAD_MAX_ATTEMPTS:-5}
 INITIAL_BACKOFF_SECONDS=${UPLOAD_INITIAL_BACKOFF_SECONDS:-1}
 
+is_unedited_starter_stub() {
+  # Match BOTH banner phrasings the SDLC has shipped (v0.1.36 changed
+  # the wording from "...GOING TO PRODUCTION" to "...COMMITTING").
+  # -a forces binary→text so we don't error on PNGs/PDFs; the regex
+  # won't match either of those formats by accident.
+  grep -aqE 'STARTER TEMPLATE.+REPLACE BEFORE' "$1"
+}
+
 for FILE in "${FILES[@]}"; do
   FILENAME=$(basename "$FILE")
+  if is_unedited_starter_stub "$FILE"; then
+    echo "SKIPPED ${FILENAME} — unedited starter stub (replace the STARTER TEMPLATE banner to upload)"
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
   FILE_SIZE=$(stat -c%s "$FILE" 2>/dev/null || stat -f%z "$FILE")
   echo -n "Uploading ${FILENAME}... "
   CURL_ARGS=(
@@ -267,8 +287,10 @@ done
 # --- Summary ---
 echo ""
 echo "=== Upload Summary ==="
-echo "Files: ${SUCCEEDED} succeeded, ${FAILED} failed (${#FILES[@]} total)"
+echo "Files: ${SUCCEEDED} succeeded, ${FAILED} failed, ${SKIPPED} skipped (${#FILES[@]} total)"
 echo "Total size: $((TOTAL_SIZE / 1024)) KB"
+# Skipped stubs are intentional (devaudit#133) — they don't fail the
+# run. Only true upload failures bump the exit code.
 if [ "$FAILED" -gt 0 ]; then
   exit 1
 fi


### PR DESCRIPTION
Picks up six framework hardening fixes shipped on DevAudit-Installer. Ships alongside the REQ-076 release (#336) so they reach `main` in the same release wave.

## Bundle B (v0.1.47 + v0.1.49)

- **DevAudit-Installer#133** — `scripts/upload-evidence.sh` skips files still carrying the STARTER TEMPLATE banner; `compliance-evidence.yml` globs `incident-report*.md` so real per-incident reports written by `incident-export.yml` upload as evidence
- **DevAudit-Installer#132** — `sdlc-implementer` Phase 2 gains structural gates for the e2e-test-engineer delegation contract: literal pre-test-work declaration before any `*.spec.ts` edit, plus a self-audit before Phase 3
- **DevAudit-Installer#131** — new `scripts/update-sdlc-status.sh` + LAST/NEXT sticky-comment convention; `sdlc-implementer` updates the sticky at every phase transition + operator-action handoff

## Bundle C (v0.1.52)

- **devaudit#152** — `SDLC/Implementation_Plan_TEMPLATE.md` Section 1 gains Given/When/Then AC writing guide; Section 2 gains a **Surface inventory** sub-section (every UI/API/job/report a real user touches, marked `In scope` / `Already works` / `Out of scope (waived)`). `SDLC/1-plan-requirement.md` Step 6 WAIT CHECKPOINT gains surface-inventory completeness + AC form bullets; Step 7 test-scope heredocs (LOW/MEDIUM/HIGH) carry tier-appropriate AC-writing guidance. Catches the REQ-030 failure mode (green gates ship a feature with no UI surface the user can reach).
- **DevAudit-Installer#127** — `e2e-test-engineer` skill scope clarified: transport-layer specs (Node `fetch` against webhooks, MongoClient queries, socket.io-client assertions) are IN scope; their evidence form is the per-spec entry in `test-execution-summary.md`, not `evidenceShot`
- **DevAudit-Installer#50** — `SDLC/3-compile-evidence.md` `test-execution-summary.md` heredoc gains a top-of-file **Test design** section (layers planned vs covered, deferral rationale, skill-invocation attribution) so the SDLC has a recorded trace that scope was *decided*, not implicit

## What's NOT changed

- No application code (`app/`, `components/`, `lib/`) touched
- No `package.json` runtime dependency changes
- No schema / Prisma migration changes
- Compliance evidence already in `compliance/evidence/REQ-*/` untouched

## Test plan

- [x] Local pre-push \`tsc\` passed
- [ ] CI green on this PR
- [ ] Verify-via-dispatch of `compliance-evidence.yml` against this branch (because that workflow file changed in this diff)
- [ ] Merge to develop → automatically lands in release PR #336 → reaches main when #336 merges