### PR TITLE
test: pin admin-login session-permission-copy contract [REQ-076]

### DIFF
--- a/__tests__/lib/admin-login-helpers.test.ts
+++ b/__tests__/lib/admin-login-helpers.test.ts
@@ -1,0 +1,197 @@
+/**
+ * @requirement REQ-076 — Per-main-category report + per-user access control
+ * @requirement REQ-066 AC10 — incidentsAccess default
+ *
+ * Pins `buildSessionPermissions` — the session-side copy contract
+ * that admin-login.ts uses to copy `admin.permissions` from the DB
+ * record onto the iron-session cookie.
+ *
+ * Source of the REQ-076 production defect this test prevents from
+ * recurring: the original action whitelisted boolean fields onto the
+ * session but silently dropped `mainCategoryReportAccess` (a string
+ * array). Restricted admins logged in with `session.permissions`
+ * shaped as if they had no restriction — the downstream
+ * `getAllowedMainCategoriesForReports` then routed them to the
+ * back-compat see-all-mains branch, silently breaking the RBAC gate.
+ *
+ * The 9 `getAllowedMainCategoriesForReports` unit tests
+ * (`__tests__/lib/permissions.main-category-access.test.ts`) cover the
+ * resolution table given a correctly-shaped session. THIS test covers
+ * the wire between the DB and the helper — making sure every valid
+ * permission field round-trips, defaults are correct, and the field
+ * shape preserves the helper's three-state contract
+ * (undefined → see all, [] → deny all, [slug] → restricted subset).
+ */
+import { describe, it, expect } from 'vitest';
+import { buildSessionPermissions } from '@/lib/admin-login-helpers';
+import type { IAdminPermissions } from '@/interfaces/admin-permissions.interface';
+
+describe('REQ-076 — buildSessionPermissions', () => {
+  describe('null / undefined input', () => {
+    it('returns undefined for null', () => {
+      expect(buildSessionPermissions(null)).toBeUndefined();
+    });
+
+    it('returns undefined for undefined', () => {
+      expect(buildSessionPermissions(undefined)).toBeUndefined();
+    });
+  });
+
+  describe('boolean permission fields', () => {
+    it('copies all 8 standard booleans verbatim when true', () => {
+      const raw: Partial<IAdminPermissions> = {
+        orderManagement: true,
+        menuManagement: true,
+        inventoryManagement: true,
+        rewardsAndLoyalty: true,
+        reportsAndAnalytics: true,
+        expensesManagement: true,
+        settingsAndConfiguration: true,
+        kitchenManagement: true,
+        incidentsAccess: true,
+      };
+      const out = buildSessionPermissions(raw);
+      expect(out).toMatchObject({
+        orderManagement: true,
+        menuManagement: true,
+        inventoryManagement: true,
+        rewardsAndLoyalty: true,
+        reportsAndAnalytics: true,
+        expensesManagement: true,
+        settingsAndConfiguration: true,
+        kitchenManagement: true,
+        incidentsAccess: true,
+      });
+    });
+
+    it('coerces missing booleans to false via !!', () => {
+      // Legacy admin doc missing several keys
+      const out = buildSessionPermissions({});
+      expect(out?.orderManagement).toBe(false);
+      expect(out?.menuManagement).toBe(false);
+      expect(out?.inventoryManagement).toBe(false);
+      expect(out?.rewardsAndLoyalty).toBe(false);
+      expect(out?.reportsAndAnalytics).toBe(false);
+      expect(out?.expensesManagement).toBe(false);
+      expect(out?.settingsAndConfiguration).toBe(false);
+      expect(out?.kitchenManagement).toBe(false);
+    });
+
+    it('coerces explicit false to false (no accidental true)', () => {
+      const out = buildSessionPermissions({
+        orderManagement: false,
+        menuManagement: false,
+      });
+      expect(out?.orderManagement).toBe(false);
+      expect(out?.menuManagement).toBe(false);
+    });
+  });
+
+  describe('incidentsAccess (REQ-066 AC10 default-to-true)', () => {
+    it('defaults to true when field is missing (pre-AC10 admin)', () => {
+      const out = buildSessionPermissions({});
+      expect(out?.incidentsAccess).toBe(true);
+    });
+
+    it('defaults to true when field is undefined explicitly', () => {
+      const out = buildSessionPermissions({ incidentsAccess: undefined });
+      expect(out?.incidentsAccess).toBe(true);
+    });
+
+    it('respects explicit false', () => {
+      const out = buildSessionPermissions({ incidentsAccess: false });
+      expect(out?.incidentsAccess).toBe(false);
+    });
+
+    it('respects explicit true', () => {
+      const out = buildSessionPermissions({ incidentsAccess: true });
+      expect(out?.incidentsAccess).toBe(true);
+    });
+  });
+
+  describe('mainCategoryReportAccess (REQ-076 — load-bearing pass-through)', () => {
+    it('omits the field when raw is undefined (back-compat — see all mains)', () => {
+      const out = buildSessionPermissions({});
+      expect('mainCategoryReportAccess' in (out ?? {})).toBe(false);
+    });
+
+    it('omits the field when raw is explicitly undefined', () => {
+      const out = buildSessionPermissions({
+        mainCategoryReportAccess: undefined,
+      });
+      expect('mainCategoryReportAccess' in (out ?? {})).toBe(false);
+    });
+
+    it('omits the field when raw is null (same as undefined — back-compat)', () => {
+      const out = buildSessionPermissions({
+        mainCategoryReportAccess:
+          null as unknown as IAdminPermissions['mainCategoryReportAccess'],
+      });
+      expect('mainCategoryReportAccess' in (out ?? {})).toBe(false);
+    });
+
+    it('preserves an explicit empty array (deny all)', () => {
+      const out = buildSessionPermissions({
+        mainCategoryReportAccess: [],
+      });
+      expect(out?.mainCategoryReportAccess).toEqual([]);
+      // Explicitly distinguish [] from undefined — the helper's three-
+      // state contract depends on this.
+      expect(out?.mainCategoryReportAccess).not.toBeUndefined();
+    });
+
+    it('preserves a restricted subset verbatim', () => {
+      const out = buildSessionPermissions({
+        mainCategoryReportAccess: ['food', 'drinks'],
+      });
+      expect(out?.mainCategoryReportAccess).toEqual(['food', 'drinks']);
+    });
+
+    it('omits a malformed non-array value (defensive — back-compat)', () => {
+      // Legacy data shape or hand-edited DB row with the wrong type
+      const out = buildSessionPermissions({
+        mainCategoryReportAccess:
+          'food' as unknown as IAdminPermissions['mainCategoryReportAccess'],
+      });
+      expect('mainCategoryReportAccess' in (out ?? {})).toBe(false);
+    });
+  });
+
+  describe('integration — the full permission shape', () => {
+    it('round-trips a restricted admin (RBAC regression pin)', () => {
+      // The shape of the admin document that produced the REQ-076 prod
+      // defect: reportsAndAnalytics enabled + restricted to drinks
+      const raw: Partial<IAdminPermissions> = {
+        orderManagement: true,
+        reportsAndAnalytics: true,
+        mainCategoryReportAccess: ['drinks'],
+      };
+      const out = buildSessionPermissions(raw);
+      // Both the gate field AND the restriction MUST land on the
+      // session for the downstream helper to enforce restriction.
+      expect(out?.reportsAndAnalytics).toBe(true);
+      expect(out?.mainCategoryReportAccess).toEqual(['drinks']);
+    });
+
+    it('round-trips a back-compat admin (no field present)', () => {
+      const raw: Partial<IAdminPermissions> = {
+        orderManagement: true,
+        reportsAndAnalytics: true,
+        // mainCategoryReportAccess intentionally absent
+      };
+      const out = buildSessionPermissions(raw);
+      expect(out?.reportsAndAnalytics).toBe(true);
+      expect('mainCategoryReportAccess' in (out ?? {})).toBe(false);
+    });
+
+    it('round-trips a deny-all admin (explicit empty)', () => {
+      const raw: Partial<IAdminPermissions> = {
+        orderManagement: true,
+        reportsAndAnalytics: true,
+        mainCategoryReportAccess: [],
+      };
+      const out = buildSessionPermissions(raw);
+      expect(out?.mainCategoryReportAccess).toEqual([]);
+    });
+  });
+});

--- a/app/actions/auth/admin-login.ts
+++ b/app/actions/auth/admin-login.ts
@@ -5,6 +5,7 @@ import { getIronSession } from 'iron-session';
 import { connectDB } from '@/lib/mongodb';
 import { AdminService } from '@/services/admin-service';
 import { sessionOptions, SessionData } from '@/lib/session';
+import { buildSessionPermissions } from '@/lib/admin-login-helpers';
 
 interface AdminLoginResult {
   success: boolean;
@@ -43,47 +44,19 @@ export async function adminLoginAction(
     session.name = admin.name || admin.username;
     session.role = admin.role;
 
-    // Sanitize permissions - only store the boolean flags we need
-    // This handles potential legacy data and keeps cookie size small
-    if (admin.permissions) {
-      console.log(
-        '[Login] Raw permissions from DB:',
-        JSON.stringify(admin.permissions)
-      );
-      session.permissions = {
-        orderManagement: !!admin.permissions.orderManagement,
-        menuManagement: !!admin.permissions.menuManagement,
-        inventoryManagement: !!admin.permissions.inventoryManagement,
-        rewardsAndLoyalty: !!admin.permissions.rewardsAndLoyalty,
-        reportsAndAnalytics: !!admin.permissions.reportsAndAnalytics,
-        expensesManagement: !!admin.permissions.expensesManagement,
-        settingsAndConfiguration: !!admin.permissions.settingsAndConfiguration,
-        kitchenManagement: !!admin.permissions.kitchenManagement,
-        // REQ-066 AC10 — new permission key. Default to true so existing
-        // users (whose DB record predates AC10) keep access on first
-        // login without needing a data backfill; only an explicit
-        // toggle-off in the permissions editor sets this to false.
-        incidentsAccess: admin.permissions.incidentsAccess !== false,
-        // REQ-076 — per-user main-category report access. Three valid
-        // shapes: undefined / null (back-compat, see all mains), [] (no
-        // access), or a slug array (restricted subset). Preserve the
-        // exact shape from the DB so the helper's resolution table
-        // distinguishes between "unrestricted" and "explicit deny-all".
-        ...(Array.isArray(admin.permissions.mainCategoryReportAccess)
-          ? {
-              mainCategoryReportAccess:
-                admin.permissions.mainCategoryReportAccess,
-            }
-          : {}),
-      };
-      console.log(
-        '[Login] Saving permissions to session:',
-        JSON.stringify(session.permissions)
-      );
-    } else {
-      console.log('[Login] No permissions found for admin');
-      session.permissions = undefined;
-    }
+    // Sanitize permissions — extracted to `lib/admin-login-helpers.ts`
+    // so the field-by-field copy contract is unit-tested in isolation
+    // (pinning the REQ-066 + REQ-076 default + pass-through rules
+    // without standing up iron-session + Mongo + bcrypt).
+    console.log(
+      '[Login] Raw permissions from DB:',
+      JSON.stringify(admin.permissions)
+    );
+    session.permissions = buildSessionPermissions(admin.permissions);
+    console.log(
+      '[Login] Saving permissions to session:',
+      JSON.stringify(session.permissions)
+    );
 
     session.isGuest = false;
     session.isLoggedIn = true;

--- a/lib/admin-login-helpers.ts
+++ b/lib/admin-login-helpers.ts
@@ -1,0 +1,59 @@
+/**
+ * Helpers for `app/actions/auth/admin-login.ts`.
+ *
+ * Extracted so the session-permission-copy contract is unit-testable
+ * without standing up iron-session, Mongo, and bcrypt for every check.
+ *
+ * The contract was the source of a REQ-076 production defect: the
+ * action whitelisted boolean permissions onto the session cookie but
+ * silently dropped `mainCategoryReportAccess` (a string array), so
+ * restricted admins logged in with `session.permissions` shaped as if
+ * they had no restriction — `getAllowedMainCategoriesForReports`
+ * routed them to the back-compat see-all-mains branch. This helper
+ * pins the field-by-field copy so any new permission added in a
+ * future REQ has a single forced-update site + a single test surface.
+ */
+import type { IAdminPermissions } from '@/interfaces/admin-permissions.interface';
+
+/**
+ * Build the session-side `permissions` object from a raw admin
+ * permissions record (from the DB).
+ *
+ * - `null` / `undefined` raw → `undefined` (the action stores nothing
+ *   on the session; downstream helpers default appropriately).
+ * - Otherwise: every boolean field is normalised via `!!` so legacy
+ *   `undefined` resolves to `false`.
+ * - `incidentsAccess` defaults to `true` (REQ-066 AC10 — pre-AC10
+ *   admins should keep access on first login without a backfill).
+ * - `mainCategoryReportAccess` (REQ-076) is included **only** when the
+ *   raw value is an array. `undefined` / `null` / wrong-type values
+ *   are omitted, which the downstream
+ *   `getAllowedMainCategoriesForReports` treats as "back-compat: see
+ *   all mains".
+ *
+ * Keeping the cookie payload minimal: when there's no array, the
+ * field is omitted entirely rather than persisted as `undefined`.
+ *
+ * @requirement REQ-066 AC10 — incidentsAccess default
+ * @requirement REQ-076 — mainCategoryReportAccess pass-through
+ */
+export function buildSessionPermissions(
+  raw: Partial<IAdminPermissions> | null | undefined
+): IAdminPermissions | undefined {
+  if (!raw) return undefined;
+
+  return {
+    orderManagement: !!raw.orderManagement,
+    menuManagement: !!raw.menuManagement,
+    inventoryManagement: !!raw.inventoryManagement,
+    rewardsAndLoyalty: !!raw.rewardsAndLoyalty,
+    reportsAndAnalytics: !!raw.reportsAndAnalytics,
+    expensesManagement: !!raw.expensesManagement,
+    settingsAndConfiguration: !!raw.settingsAndConfiguration,
+    kitchenManagement: !!raw.kitchenManagement,
+    incidentsAccess: raw.incidentsAccess !== false,
+    ...(Array.isArray(raw.mainCategoryReportAccess)
+      ? { mainCategoryReportAccess: raw.mainCategoryReportAccess }
+      : {}),
+  };
+}


### PR DESCRIPTION
Follow-up to [#339](https://github.com/metasession-dev/wawagardenbar-app/pull/339) (REQ-076 RBAC production fix). Adds the regression-pinning test the operator asked for after the fix landed.

## Context

PR #339 fixed a REQ-076 production defect: `admin-login.ts` was whitelisting permission fields onto the session cookie but silently dropping the new `mainCategoryReportAccess` field. Restricted admins effectively had unrestricted access. The 9 unit tests in `__tests__/lib/permissions.main-category-access.test.ts` correctly pinned the resolution table given a well-shaped session — the gap was at the **wire between the DB and the helper**, which those tests don't cover.

This PR closes that gap.

## Refactor

Extract the field-by-field session-copy logic from `admin-login.ts` into `lib/admin-login-helpers.ts:buildSessionPermissions(raw)`. Pure function — no Mongo, no iron-session, no bcrypt. The action calls it; tests target it directly.

`admin-login.ts` becomes a one-liner:

```ts
session.permissions = buildSessionPermissions(admin.permissions);
```

## Unit test — 18 cases

Pins every row of the session-copy contract:

- `null` / `undefined` input → `undefined`
- 8 standard booleans: copy verbatim when true, `!!` coerce when missing or undefined, respect explicit `false`
- `incidentsAccess` (REQ-066 AC10): default to `true` when missing (pre-AC10 back-compat); respect explicit `false`
- `mainCategoryReportAccess` (REQ-076, load-bearing):
  - `undefined` → field omitted (back-compat see-all)
  - `null` → field omitted (treated same as undefined)
  - `[]` → field preserved as `[]` (deny-all — distinct from undefined)
  - `['food']` → preserved verbatim (restricted)
  - non-array value → defensively omitted
- Integration: round-trip a restricted admin with both gate fields, proving the production-defect class can't recur silently

## Why this prevents the regression

Any future REQ that adds a new permission field hits a single forced-update site in `buildSessionPermissions` and a single test surface. The test asserts:

- The presence-or-absence of `mainCategoryReportAccess` distinguishes back-compat from deny-all (the three-state contract the downstream helper depends on).
- A restricted admin's gate field AND restriction field both arrive on the session intact.

If a future PR drops a field, the boolean-section tests fail. If a future PR mishandles array vs undefined, the integration round-trip tests fail.

## Test plan

- [x] `npx tsc --noEmit` → exit 0
- [x] `npx vitest run __tests__/lib/admin-login-helpers.test.ts` → 18/18 pass

Ref: REQ-076

🤖 Generated with [Claude Code](https://claude.com/claude-code)