### PR TITLE
fix: suppress cookie consent banner for authenticated staff [REQ-065]

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,10 @@
 import type { Metadata } from 'next';
+import { cookies } from 'next/headers';
+import { getIronSession } from 'iron-session';
 import './globals.css';
 import { Providers } from '@/components/shared/providers';
 import { CookieConsentBanner } from '@/components/shared/cookie-consent-banner';
+import { sessionOptions, SessionData } from '@/lib/session';
 
 export const metadata: Metadata = {
   title: 'Wawa Garden Bar - Order Food & Drinks',
@@ -10,17 +13,51 @@ export const metadata: Metadata = {
   keywords: ['restaurant', 'food delivery', 'wawa cafe', 'garden bar'],
 };
 
-export default function RootLayout({
+/**
+ * Whether the current request is from a logged-in staff member
+ * (csr / admin / super-admin). Staff don't need the customer-facing
+ * cookie consent banner — their employment relationship is the
+ * consent, and the banner overlays admin dashboard surfaces (e.g. the
+ * permissions form's Save Changes button at the bottom of the page).
+ *
+ * Returns false on any error (missing cookie, malformed session,
+ * iron-session crypto failure) — keeps the failure mode privacy-safe:
+ * unknown auth state → show the banner.
+ *
+ * @requirement REQ-065 — cookie consent banner scope clarified.
+ *   Banner continues to render for anonymous customers + logged-in
+ *   customers (`role: 'customer'`); only staff get the suppression.
+ */
+async function isAuthenticatedStaff(): Promise<boolean> {
+  try {
+    const session = await getIronSession<SessionData>(
+      await cookies(),
+      sessionOptions
+    );
+    return (
+      session.isLoggedIn === true &&
+      (session.role === 'csr' ||
+        session.role === 'admin' ||
+        session.role === 'super-admin')
+    );
+  } catch {
+    return false;
+  }
+}
+
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const isStaff = await isAuthenticatedStaff();
+
   return (
     <html lang="en">
       <body className="font-sans antialiased">
         <Providers>
           {children}
-          <CookieConsentBanner />
+          {!isStaff && <CookieConsentBanner />}
         </Providers>
       </body>
     </html>


### PR DESCRIPTION
Follow-up to [REQ-065](https://github.com/metasession-dev/wawagardenbar-app/issues?q=REQ-065) (cookie consent banner). Tightens the banner's scope: customer-facing only, suppressed for authenticated staff.

## Symptom (observed in CI)

The REQ-076 release PR [#336](https://github.com/metasession-dev/wawagardenbar-app/pull/336) E2E run on `2026-06-09T07:09:09Z` showed `main-category-report-permissions-ui.spec.ts` AC6 timing out at 30s. Page snapshot at failure:

```yaml
# ...admin permissions form fully rendered, all toggles in place...
- generic [ref=e307]:
  - paragraph [ref=e308]: We use cookies for authentication and your cart. By continuing
                          to use the site you accept this.
  - button "Got it" [ref=e309] [cursor=pointer]
```

The cookie banner overlays the form's `Save Changes` button. Playwright finds the button geometrically, fires the click — `document.elementFromPoint(...)` resolves to the banner's `Got it` button instead. Click never reaches Save Changes. Timeout.

## Why this is a product bug, not just a test bug

`CookieConsentBanner` is mounted at the root layout (`app/layout.tsx:23`). It renders on **every** route — customer pages, admin dashboard, login pages, everything. The banner is positioned `fixed bottom-0 left-0 right-0 z-50` — exactly the bottom strip where admin save buttons live.

Staff don't need to consent to authentication cookies. Their employment relationship is the consent. The banner is a customer-facing element leaking into admin surfaces — a UX bug that happens to also block CI tests.

## Fix

Server-side session check in `app/layout.tsx`. Render the banner only when the request is NOT from authenticated staff.

```tsx
const isStaff = await isAuthenticatedStaff();
// ...
{!isStaff && <CookieConsentBanner />}
```

Behaviour matrix:

| User state | Banner visible? |
|---|---|
| Anonymous on `/menu`, `/cart`, etc. | ✅ Yes — REQ-065 unchanged for customers |
| Logged-in customer (`role: 'customer'`) | ✅ Yes — customer consent semantics preserved |
| Logged-in CSR / admin / super-admin | ❌ No — employment relationship is the consent |
| Anonymous on `/admin/login` | ✅ Yes (anonymous → no session) — minor; banner brief during login |

Failure mode: any error reading the session (missing cookie, malformed, iron-session crypto failure) returns `false` → banner shows. Privacy-safe default.

## Cost

One HMAC verify of the iron-session cookie per layout render. Same crypto path every server action + dashboard page already runs. ~µs.

## Side-benefit

The REQ-076 Spec 5 timeout disappears without a test change. The defensive cookie-banner dismissal I added to the REQ-076 access-control spec's `loginAs` (in [#339](https://github.com/metasession-dev/wawagardenbar-app/pull/339)) becomes redundant for any spec that runs after authentication — can be cleaned up in a follow-up if desired, or left as defensive code.

## Test plan

- [x] `npx tsc --noEmit` → exit 0
- [ ] Once merged: release PR #336 picks up the new develop tip → e2e-regression re-runs → expect Spec 5 to pass without timing out

## Risk

**LOW**. Server-side session check + JSX conditional render. The check has been used in every server action since iron-session was introduced. Reverting is a 6-line rollback.

Ref: REQ-065

🤖 Generated with [Claude Code](https://claude.com/claude-code)