### PR TITLE
ci: plumb webhook secrets + seed trackByLocation inventory [#330]

### DIFF
--- a/.github/workflows/e2e-regression.yml
+++ b/.github/workflows/e2e-regression.yml
@@ -60,6 +60,14 @@ jobs:
       E2E_SUPER_ADMIN_PASSWORD: E2eTest@2026!
       E2E_CSR_USERNAME: e2e-csr
       E2E_CSR_PASSWORD: E2eTest@2026!
+      # REQ-069 webhook specs sign synthetic payloads against these
+      # secrets; without them the signature comparison crashes
+      # server-side and the spec sees 500 instead of 401. Repo secrets
+      # set by operator (Settings → Secrets → Actions); must match the
+      # UAT server's values to keep parity.
+      MONNIFY_SECRET_KEY: ${{ secrets.MONNIFY_SECRET_KEY }}
+      PAYSTACK_SECRET_KEY: ${{ secrets.PAYSTACK_SECRET_KEY }}
+      INTERNAL_API_SECRET: ${{ secrets.INTERNAL_API_SECRET }}
 
     steps:
       - uses: actions/checkout@v4

--- a/scripts/seed-e2e-fixtures.ts
+++ b/scripts/seed-e2e-fixtures.ts
@@ -116,6 +116,68 @@ async function seedE2eFixtures() {
     });
     console.log('✓ Seeded 1 expense (operating / Utilities / ₦1,000)');
 
+    // ── trackByLocation inventory ──────────────────────────────────────────
+    // REQ-066 AC8 + AC9 specs (sale-point + over-sell) look up an
+    // Inventory document with: trackByLocation true + ≥2 locations +
+    // total stock ≥ 2. Specs MUTATE the document during their run
+    // (force one location empty, set defaultSalesLocation, etc.) — CI
+    // runs against a fresh Mongo each time so mutation persistence
+    // doesn't matter; the seed only needs to exist on first run.
+    //
+    // Idempotent via deletion by menuItemId before re-create.
+    const E2E_TBL_NAME_HINT = 'E2E-FIXTURE Track-By-Location';
+
+    // Pick (or create) a dedicated menu item so the seeded inventory
+    // doesn't conflict with the existing menu's stock-tracked items.
+    let trackedMenuItem = await MenuItemModel.findOne({
+      name: E2E_TBL_NAME_HINT,
+    });
+    if (!trackedMenuItem) {
+      trackedMenuItem = await MenuItemModel.create({
+        kind: 'menu-item',
+        name: E2E_TBL_NAME_HINT,
+        description: 'E2E fixture menu item for REQ-066 AC8/AC9 specs',
+        mainCategory: 'food',
+        category: foodMenuItem.category || 'food',
+        price: 1000,
+        costPerUnit: 400,
+        preparationTime: 1,
+        isAvailable: false, // hidden from customer menu
+        trackInventory: true,
+      });
+    }
+
+    await InventoryModel.deleteMany({ menuItemId: trackedMenuItem._id });
+
+    await InventoryModel.create({
+      menuItemId: trackedMenuItem._id,
+      currentStock: 10, // overwritten by pre-save hook from locations sum
+      minimumStock: 1,
+      maximumStock: 50,
+      unit: 'unit',
+      supplier: 'E2E Fixture Supplier',
+      trackByLocation: true,
+      locations: [
+        {
+          location: 'main-bar',
+          locationName: 'Main Bar',
+          currentStock: 5,
+          minimumStock: 1,
+        },
+        {
+          location: 'kitchen',
+          locationName: 'Kitchen',
+          currentStock: 5,
+          minimumStock: 1,
+        },
+      ],
+      defaultSalesLocation: 'main-bar',
+      preventOrdersWhenOutOfStock: false,
+    });
+    console.log(
+      '✓ Seeded 1 trackByLocation inventory (2 locations × 5 stock = 10 total) for REQ-066 AC8/AC9 specs'
+    );
+
     console.log('\n✅ E2E fixtures seeded.');
   } finally {
     await mongoose.connection.close();


### PR DESCRIPTION
Bucket 1 of the regression-pack health work tracked in [#330](https://github.com/metasession-dev/wawagardenbar-app/issues/330). Closes **4 of the 12** pre-existing failures the nightly cron flagged.

## What's in

### 1. Webhook signature secrets (2 specs fixed)

Adds `MONNIFY_SECRET_KEY`, `PAYSTACK_SECRET_KEY`, and `INTERNAL_API_SECRET` to `.github/workflows/e2e-regression.yml`'s env block. Without them:
- `payments/webhook-signature-rejection` — server returns 500 instead of 401 because the signature comparison crashes server-side
- `payments/webhook-idempotency-replay` — spec throws `'MONNIFY_SECRET_KEY not set'` before sending the synthetic webhook

### 2. REQ-066 AC8/AC9 inventory seed (2 specs fixed)

`scripts/seed-e2e-fixtures.ts` now creates a dedicated `E2E-FIXTURE Track-By-Location` MenuItem + an Inventory document with:
- `trackByLocation: true`
- 2 locations (`main-bar` + `kitchen`) × 5 stock each = 10 total
- `defaultSalesLocation: 'main-bar'`

Idempotent: deletes existing by `menuItemId` before re-create. Specs that find this document then mutate it (force one location empty, etc.) — CI's fresh-Mongo-per-run makes mutation persistence a non-issue.

This unblocks:
- `admin-order-inventory-delta.sale-point` — seed predicate `"no trackByLocation inventory with 2+ locations + 2+ total stock found on UAT"` now satisfied
- `admin-order-inventory-delta.over-sell` — same

## 🔑 Operator action required before this can land green

Set the three secrets in **repo Settings → Secrets and variables → Actions**:

| Secret | Value source |
|---|---|
| `MONNIFY_SECRET_KEY` | Match UAT's value (probably already in `.env.local`) |
| `PAYSTACK_SECRET_KEY` | Same — match UAT |
| `INTERNAL_API_SECRET` | Same — match UAT |

Without these set on the repo, the workflow's `${{ secrets.* }}` expressions resolve to empty strings — the env vars get set but to no value, leaving the original failure shape unchanged. The fix is correct; it just needs the secrets to land.

## What remains in #330 after this lands

| Bucket | Specs remaining | Tracking |
|---|---|---|
| Bucket 2 — Express-order timeouts | 4 | Separate tracking issue + investigation cycle |
| Bucket 3 — Daily Report tips | 2 | Separate tracking issue + investigation cycle |
| Bucket 4 — REQ-064 support tickets | 2 | Separate tracking issue + investigation cycle |

I'll file the 3 tracking issues in parallel — each becomes a discrete fix cycle.

## Test plan

- [x] `npx tsc --noEmit` → exit 0
- [ ] **Operator**: confirm the 3 secrets are set on the repo
- [ ] Once merged + secrets set: e2e-regression's next run shows the 4 Bucket-1 specs green
- [ ] No regression on currently-green specs

## Risk

**LOW**:
- Workflow change is additive (3 new env vars)
- Seed change is additive (new MenuItem + Inventory, idempotent)
- No production code paths touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)