### PR TITLE
test: align REQ-064 specs with documented routing matrix [#347]

### DIFF
--- a/e2e/support-ticket-staff-flow.spec.ts
+++ b/e2e/support-ticket-staff-flow.spec.ts
@@ -171,6 +171,13 @@ csrTest.describe('REQ-064 staff flow — queue → detail → reply → status',
       // The action revalidates the route; verify the new state on the page.
       await expect(statusSelect).toContainText(/resolved/i, { timeout: 5000 });
 
+      // `updateSupportStatusAction` fires inside startTransition (React 18+)
+      // → setStatus updates the trigger synchronously, but the server
+      // roundtrip + revalidatePath complete async. Wait for network to
+      // settle so the DB query below sees the persisted state, not the
+      // mid-flight optimistic state.
+      await page.waitForLoadState('networkidle');
+
       // DB-side verification: reply persisted + status flipped.
       const persisted = await readTicket(seeded.ticketId);
       expect(persisted?.status).toBe('resolved');

--- a/e2e/support-ticket-whatsapp-inbound.spec.ts
+++ b/e2e/support-ticket-whatsapp-inbound.spec.ts
@@ -102,6 +102,48 @@ async function deleteTicketsByPhone(phone: string) {
   }
 }
 
+/**
+ * REQ-064 routing matrix: `support_text` from a NEW customer takes the
+ * welcome-template branch, NOT the ticket-create branch (intentional —
+ * new customers get a "here's how to reach us" template first; only
+ * already-engaged customers create tickets via the inbound bridge).
+ *
+ * To test the ticket-create branch we must seed the customer as
+ * `active`: phoneVerified + lastLoginAt within 30 days. Spec-local seed
+ * is cleaner than depending on UAT's drifting user data and matches
+ * the storage pattern used by REQ-073 / REQ-075 specs.
+ */
+async function seedActiveCustomer(phone: string): Promise<string> {
+  const { uri, dbName } = mongoConn();
+  const client = new MongoClient(uri);
+  try {
+    await client.connect();
+    const result = await client.db(dbName).collection('users').insertOne({
+      phone,
+      phoneVerified: true,
+      lastLoginAt: new Date(),
+      isGuest: false,
+      accountStatus: 'active',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    return String(result.insertedId);
+  } finally {
+    await client.close();
+  }
+}
+
+async function deleteUserByPhone(phone: string) {
+  const { uri, dbName } = mongoConn();
+  const client = new MongoClient(uri);
+  try {
+    await client.connect();
+    await client.db(dbName).collection('users').deleteMany({ phone });
+  } finally {
+    await client.close();
+  }
+}
+
 async function postInbound(
   request: APIRequestContext,
   payload: unknown
@@ -132,6 +174,7 @@ csrTest.describe('REQ-064 WhatsApp inbound → support ticket bridge', () => {
   csrTest.afterEach(async () => {
     if (phone) {
       await deleteTicketsByPhone(phone);
+      await deleteUserByPhone(phone);
       phone = null;
     }
   });
@@ -154,6 +197,13 @@ csrTest.describe('REQ-064 WhatsApp inbound → support ticket bridge', () => {
       guard(csrTest.skip, await isAuthenticated(page));
 
       phone = uniqueDigits();
+      // REQ-064 routing: `support_text` from a NEW customer takes the
+      // welcome-template branch (intentional — new customers get a
+      // "here's how to reach us" message first). Only `active`
+      // customers (phoneVerified + recent lastLoginAt) reach the
+      // ticket-create branch. Seed the customer in that state.
+      await seedActiveCustomer(phone);
+
       const body =
         'Hi, I think the delivery I got an hour ago was missing the sides, can someone check please?';
       const messageId = `wamid.E2E-${Date.now()}`;


### PR DESCRIPTION
Closes Bucket 4 of [#330](https://github.com/metasession-dev/wawagardenbar-app/issues/330). Bug investigation tracked in [#347](https://github.com/metasession-dev/wawagardenbar-app/issues/347).

## Investigation outcome

**Not a regression. Not a downstream-REQ break.** Verified:

- Zero commits on `lib/whatsapp.ts`, `services/whatsapp-inbound-service.ts`, `services/support-ticket-service.ts` since REQ-064 RELEASED 2026-06-03.
- `__tests__/services/whatsapp-inbound.support-ticket.test.ts` passes 2/2.
- Operator confirmed Interpretation A: new customers get welcome-template first; only `active` customers reach the ticket-create branch via the inbound bridge. This is REQ-064's intentional routing matrix (documented in `services/whatsapp-inbound-service.ts:21-28`).

The 2 failing specs disagreed with that intent. Both are **test-bugs only**, no production code touched.

## What's fixed

### 1. `support-ticket-whatsapp-inbound.spec.ts` — wrong customer state

The spec seeded a brand-new phone number → state `new` → routing went to welcome-template branch → no ticket → spec asserted ticket exists → `null` → fail.

Fix: seed the customer as `active` (phoneVerified + recent lastLoginAt) via direct Mongo insert before posting the inbound webhook. `afterEach` cleans both the user and any created tickets. Same storage-helper pattern as REQ-073/075 specs.

### 2. `support-ticket-staff-flow.spec.ts` AC5 — race condition

`updateSupportStatusAction` fires inside React 18 `startTransition`. `setStatus` updates the Radix Select trigger synchronously, but the server roundtrip + `revalidatePath` complete async. The old spec asserted the trigger text contained `resolved` (passes immediately from local state) then read the DB — the DB read raced ahead of the server action's persistence, observed `status: 'open'`.

Fix: `page.waitForLoadState('networkidle')` between the visible-text assertion and the DB query. Waits until the RSC payload has been received + applied. Deterministic + minimal-cost.

## Production behaviour verified intentional

For the record: a real customer who messages WhatsApp for the first time saying *"my delivery was missing the sides"* will get a welcome template back, not a staff-queued ticket. This is by design per REQ-064. If the operator ever wants to change that (e.g. first-touch support escalation), it'd be a fresh REQ — out of scope for this PR.

## Test plan

- [x] `npx tsc --noEmit` → exit 0
- [ ] Once merged: e2e-regression's next run shows both REQ-064 specs green

## Risk

**LOW**. Test-only changes. Production code untouched.

Ref: REQ-064, #330, #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)