### PR TITLE
test: tips-breakdown parser walks ancestors instead of class selectors [#346]

### DIFF
--- a/e2e/orders/close-tab-tip-capture.spec.ts
+++ b/e2e/orders/close-tab-tip-capture.spec.ts
@@ -39,30 +39,72 @@ async function readTipsBreakdown(page: Page): Promise<{
 }> {
   return page.evaluate(() => {
     const result = { total: 0, cash: 0, card: 0, transfer: 0 };
+
+    const parseNGN = (s: string): number | null => {
+      const m = s.match(/(?:₦|NGN)\s*([\d,]+(?:\.\d+)?)/);
+      return m ? parseFloat(m[1].replace(/,/g, '')) : null;
+    };
+
+    // Find the Tips Received section heading + extract `... total`
+    // from the heading's text.
     const sectionHeading = Array.from(document.querySelectorAll('h3')).find(
       (h) => /Tips Received/i.test(h.textContent ?? '')
     );
     if (!sectionHeading) return result;
+    const totalAmount = parseNGN(sectionHeading.textContent ?? '');
+    if (totalAmount != null) result.total = totalAmount;
 
-    const totalMatch = (sectionHeading.textContent ?? '').match(
-      /(?:₦|NGN)\s*([\d,]+(?:\.\d+)?)\s*total/i
-    );
-    if (totalMatch) result.total = parseFloat(totalMatch[1].replace(/,/g, ''));
-
+    // Find the grid sibling. The tip-cards section lives directly
+    // under the heading in `tips-section.tsx`.
     const grid = sectionHeading.nextElementSibling;
     if (!grid) return result;
-    const cards = grid.querySelectorAll('[class*="rounded"]');
-    for (const card of cards) {
-      const titleText =
-        card.querySelector('[class*="font-medium"]')?.textContent?.trim() ?? '';
-      const amountText =
-        card.querySelector('[class*="text-2xl"]')?.textContent?.trim() ?? '';
-      const m = amountText.match(/(?:₦|NGN)\s*([\d,]+(?:\.\d+)?)/);
-      if (!m) continue;
-      const amount = parseFloat(m[1].replace(/,/g, ''));
-      if (titleText === 'Cash tips') result.cash = amount;
-      else if (titleText === 'POS / Card tips') result.card = amount;
-      else if (titleText === 'Transfer tips') result.transfer = amount;
+
+    // Walk every descendant element under the grid. For each one whose
+    // textContent starts with a known title ("Cash tips" / "POS / Card
+    // tips" / etc.) treat that element as the Card and look for ₦N
+    // anywhere inside it. More forgiving than relying on specific
+    // sub-class selectors (`[class*="text-2xl"]`) that quietly drift
+    // when CardContent / CardHeader markup changes.
+    const labels: Array<{ label: string; key: 'cash' | 'card' | 'transfer' }> =
+      [
+        { label: 'Cash tips', key: 'cash' },
+        { label: 'POS / Card tips', key: 'card' },
+        { label: 'Transfer tips', key: 'transfer' },
+      ];
+
+    const all = Array.from(grid.querySelectorAll('*')) as HTMLElement[];
+    for (const { label, key } of labels) {
+      // Locate the element whose own textContent (excluding children
+      // we'd over-greedily inherit from parents) STARTS with the label.
+      const titleEl = all.find((el) => {
+        const txt = (el.textContent ?? '').trim();
+        return txt === label || txt.startsWith(label + '\n');
+      });
+      if (!titleEl) continue;
+      // The amount lives in a sibling element of the title's CardHeader,
+      // i.e. inside the parent Card. Walk up until we find an ancestor
+      // containing a ₦ amount text.
+      let node: HTMLElement | null = titleEl.parentElement;
+      while (node && node !== grid) {
+        const amount = parseNGN(node.textContent ?? '');
+        // Reject the section-wide total ("₦300 total") — that text
+        // includes the word "total" or "tip"; the per-card amount does
+        // NOT include "total".
+        if (
+          amount != null &&
+          !/total/i.test(node.textContent ?? '') &&
+          // Don't match an ancestor that contains MULTIPLE labels
+          // (i.e. wrapped grid containing all cards).
+          !labels.some(
+            (l) =>
+              l.label !== label && (node?.textContent ?? '').includes(l.label)
+          )
+        ) {
+          result[key] = amount;
+          break;
+        }
+        node = node.parentElement;
+      }
     }
     return result;
   });

--- a/e2e/orders/express-tip-capture.spec.ts
+++ b/e2e/orders/express-tip-capture.spec.ts
@@ -42,30 +42,56 @@ async function readTipsBreakdown(page: Page): Promise<{
 }> {
   return page.evaluate(() => {
     const result = { total: 0, cash: 0, card: 0, transfer: 0 };
+
+    const parseNGN = (s: string): number | null => {
+      const m = s.match(/(?:₦|NGN)\s*([\d,]+(?:\.\d+)?)/);
+      return m ? parseFloat(m[1].replace(/,/g, '')) : null;
+    };
+
     const sectionHeading = Array.from(document.querySelectorAll('h3')).find(
       (h) => /Tips Received/i.test(h.textContent ?? '')
     );
     if (!sectionHeading) return result;
-
-    const totalMatch = (sectionHeading.textContent ?? '').match(
-      /(?:₦|NGN)\s*([\d,]+(?:\.\d+)?)\s*total/i
-    );
-    if (totalMatch) result.total = parseFloat(totalMatch[1].replace(/,/g, ''));
+    const totalAmount = parseNGN(sectionHeading.textContent ?? '');
+    if (totalAmount != null) result.total = totalAmount;
 
     const grid = sectionHeading.nextElementSibling;
     if (!grid) return result;
-    const cards = grid.querySelectorAll('[class*="rounded"]');
-    for (const card of cards) {
-      const titleText =
-        card.querySelector('[class*="font-medium"]')?.textContent?.trim() ?? '';
-      const amountText =
-        card.querySelector('[class*="text-2xl"]')?.textContent?.trim() ?? '';
-      const m = amountText.match(/(?:₦|NGN)\s*([\d,]+(?:\.\d+)?)/);
-      if (!m) continue;
-      const amount = parseFloat(m[1].replace(/,/g, ''));
-      if (titleText === 'Cash tips') result.cash = amount;
-      else if (titleText === 'POS / Card tips') result.card = amount;
-      else if (titleText === 'Transfer tips') result.transfer = amount;
+
+    // Same robust strategy as the close-tab-tip-capture sibling spec:
+    // find the title element by its known text + walk up its ancestor
+    // chain to the nearest container with a ₦amount that doesn't also
+    // mention "total" (the section-wide total).
+    const labels: Array<{ label: string; key: 'cash' | 'card' | 'transfer' }> =
+      [
+        { label: 'Cash tips', key: 'cash' },
+        { label: 'POS / Card tips', key: 'card' },
+        { label: 'Transfer tips', key: 'transfer' },
+      ];
+
+    const all = Array.from(grid.querySelectorAll('*')) as HTMLElement[];
+    for (const { label, key } of labels) {
+      const titleEl = all.find((el) => {
+        const txt = (el.textContent ?? '').trim();
+        return txt === label || txt.startsWith(label + '\n');
+      });
+      if (!titleEl) continue;
+      let node: HTMLElement | null = titleEl.parentElement;
+      while (node && node !== grid) {
+        const amount = parseNGN(node.textContent ?? '');
+        if (
+          amount != null &&
+          !/total/i.test(node.textContent ?? '') &&
+          !labels.some(
+            (l) =>
+              l.label !== label && (node?.textContent ?? '').includes(l.label)
+          )
+        ) {
+          result[key] = amount;
+          break;
+        }
+        node = node.parentElement;
+      }
     }
     return result;
   });


### PR DESCRIPTION
Closes Bucket 3 of [#330](https://github.com/metasession-dev/wawagardenbar-app/issues/330). Investigation tracked in [#346](https://github.com/metasession-dev/wawagardenbar-app/issues/346).

## Investigation outcome

**Not a regression. Not a customer-facing tip aggregation defect.** Verified by analysing the CI run [27189865796](https://github.com/metasession-dev/wawagardenbar-app/actions/runs/27189865796):

- Page snapshot at AC7's failure clearly shows "Tips Received ₦300.00 total" with "Cash tips ₦300.00 / 100.0% of total tips" rendered on screen.
- Product code (`services/financial-report-service.ts:aggregatePartialPayments` + `components/features/reports/tips-section.tsx`) is correctly computing and rendering the tip. Zero changes since REQ-035 release.
- The TEST parses the page DOM and silently returns `cash: 0`. That's the only bug.

Daily-report-payments spec was also in this bucket — confirmed it's the cookie-banner intercept fixed by [#343](https://github.com/metasession-dev/wawagardenbar-app/pull/343) (already merged). No additional change needed.

## What's fixed

`readTipsBreakdown` (duplicated in both `close-tab-tip-capture.spec.ts` and `express-tip-capture.spec.ts`) used class-based selectors:

```ts
grid.querySelectorAll('[class*="rounded"]')     // expect Card divs
card.querySelector('[class*="font-medium"]')    // expect CardTitle text
card.querySelector('[class*="text-2xl"]')       // expect amount text
```

That works while shadcn Card / CardHeader / CardContent emit those exact classes. When the selectors don't match (Tailwind responsive variants, shadcn upgrades, marker class drift), the parser **silently returns 0** — the test then asserts `cash - baselineCash = 0 - 0 = 0 < TIP` and fails with no diagnostic.

### New strategy

Locate the title element by its **known text** ("Cash tips" / "POS / Card tips" / "Transfer tips"), then walk the ancestor chain upward looking for the nearest container with a ₦-formatted amount that:

- Doesn't also contain "total" (rejects the section-wide heading)
- Doesn't also contain another label (rejects the wrapping grid)

Resilient to CardHeader / CardContent / Card class churn, Tailwind responsive variants, and future shadcn upgrades.

Same fix applied to both spec files — parser is duplicated in both. Extracting to a shared `e2e/helpers/` module would be cleaner but is left to a follow-up since the parser hasn't been needed elsewhere.

## Test plan

- [x] `npx tsc --noEmit` → exit 0
- [ ] Once merged: e2e-regression's next run shows AC7 specs green; baseline + after-close reads return real values, delta ≥ TIP

## Risk

**LOW**. Test-only change. Product code untouched. Parser is more permissive but still anchored on the known label text.

Ref: REQ-035, #330, #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)