### PR TITLE
test: add costPerUnit to trackByLocation inventory fixture [#330]

### DIFF
--- a/scripts/seed-e2e-fixtures.ts
+++ b/scripts/seed-e2e-fixtures.ts
@@ -155,6 +155,7 @@ async function seedE2eFixtures() {
       minimumStock: 1,
       maximumStock: 50,
       unit: 'unit',
+      costPerUnit: 400, // schema-required (matches trackedMenuItem.costPerUnit)
       supplier: 'E2E Fixture Supplier',
       trackByLocation: true,
       locations: [


### PR DESCRIPTION
## Summary

Fixes the E2E Regression CI failure on develop tip (run [27203573022](https://github.com/metasession-dev/wawagardenbar-app/actions/runs/27203573022)) that's currently blocking release PR #336.

**Root cause:** the trackByLocation Inventory fixture I added in #344 (REQ-066 AC8/AC9 specs) omitted the schema-required \`costPerUnit\` field. \`InventoryModel.create()\` threw a Mongoose validation error during \`seed-e2e-fixtures.ts\`, the seed step exited 1, and **zero specs ran on every regression CI invocation since #344 merged**.

\`\`\`
Seed failed: Error: Inventory validation failed: costPerUnit: Path \`costPerUnit\` is required.
\`\`\`

**Fix:** add \`costPerUnit: 400\` matching the dedicated MenuItem already declared in the same seed block (the menu item I created in #344 has \`costPerUnit: 400\`).

## Why it didn't fail before merging #344

The fixture seed is gated by \`seed-e2e-fixtures.ts\` running locally — and on the #344 PR's own E2E run, the seed step would have failed identically. The #344 PR's CI was green because the workflow change in #344 fixed the env-var plumbing; the seed-fixture addition was in the same PR and silently broke this step. The signal was buried under "E2E Regression Suite passed" because that PR's regression run was actually red on this same seed-step failure but I misread it as the older failure pattern. Documented honestly here.

## Test plan

- [x] tsc clean
- [ ] CI: E2E Regression Suite green (seed step completes, all specs run)
- [ ] After merge: trigger E2E Regression on #336 → expected 0 unexpected failures

## Closes

Part of #330 (regression-pack health) — last residual breakage after #343/#344/#348/#349.

🤖 Generated with [Claude Code](https://claude.com/claude-code)