### PR TITLE
fix: deep-triage all #330 regression-pack failures + customer-auth fixture [REQ-076][#330]

### DIFF
--- a/__tests__/services/admin-service.update-permissions.test.ts
+++ b/__tests__/services/admin-service.update-permissions.test.ts
@@ -1,0 +1,278 @@
+/**
+ * @requirement REQ-076 — Per-main-category report + per-user access control
+ * @requirement SRS REQ-MENUMGT-006
+ *
+ * Pins the Mongoose-Mixed save contract for `AdminService.updateAdminPermissions`.
+ *
+ * The `permissions` field on the user model uses `Schema.Types.Mixed`, which
+ * Mongoose cannot auto-detect changes on — even when the whole value is
+ * reassigned. Without `markModified('permissions')` before `save()`, any new
+ * sub-key the schema doesn't know about (e.g. REQ-076's
+ * `mainCategoryReportAccess: string[]`) gets silently dropped, and the
+ * persisted document continues to look identical to the prior shape.
+ *
+ * This silent-drop was the production defect surfaced by
+ * `e2e/admin/main-category-report-permissions-ui.spec.ts` AC6: untick
+ * Unrestricted + select Food + Drinks → save → DB read shows the field is
+ * still undefined. Restricted admins would have logged in with the full
+ * see-all-mains permission set the schema-known boolean fields imply.
+ *
+ * What this spec pins:
+ *   ✓ `admin.permissions = data.permissions` runs (overwrite reference)
+ *   ✓ `admin.markModified('permissions')` is called BEFORE save
+ *   ✓ The full `IAdminPermissions` shape — including
+ *     `mainCategoryReportAccess` — is what got assigned
+ *   ✓ Order: assign → markModified → save (markModified before save)
+ *   ✓ AuditLogService still receives oldPermissions + newPermissions
+ *   ✓ Throws on missing admin / non-admin role / super-admin target
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/mongodb', () => ({
+  connectDB: vi.fn(),
+}));
+
+// First findById call is the admin lookup (awaited directly).
+// Second findById call is inside getUserForAudit and chains .select(...).
+// Track both via separate spies and route by call order.
+const mockAdminFind = vi.fn();
+const mockAuditUserFind = vi.fn();
+const mockFindOne = vi.fn();
+let findByIdCallCount = 0;
+vi.mock('@/models/user-model', () => ({
+  default: {
+    findById: (id: string) => {
+      findByIdCallCount += 1;
+      if (findByIdCallCount === 1) {
+        // First call — awaited directly by updateAdminPermissions
+        return mockAdminFind(id);
+      }
+      // Subsequent — .select(...) chain in getUserForAudit
+      return {
+        select: (_fields: string) => mockAuditUserFind(id),
+      };
+    },
+    findOne: (...args: unknown[]) => mockFindOne(...args),
+  },
+}));
+
+const mockCreateLog = vi.fn();
+vi.mock('@/services/audit-log-service', () => ({
+  AuditLogService: {
+    createLog: (...args: unknown[]) => mockCreateLog(...args),
+  },
+}));
+
+import { AdminService } from '@/services/admin-service';
+import type { IAdminPermissions } from '@/interfaces/admin-permissions.interface';
+
+function makeAdminDoc(
+  overrides: Partial<{
+    isAdmin: boolean;
+    role: string;
+    username: string;
+    email: string;
+    permissions: Partial<IAdminPermissions>;
+  }> = {}
+) {
+  const markModified = vi.fn();
+  const save = vi.fn().mockResolvedValue(undefined);
+  return {
+    _id: 'admin123',
+    isAdmin: overrides.isAdmin ?? true,
+    role: overrides.role ?? 'admin',
+    username: overrides.username ?? 'admin-user',
+    email: overrides.email ?? 'admin@example.com',
+    permissions: overrides.permissions ?? {
+      orderManagement: true,
+      menuManagement: false,
+      inventoryManagement: false,
+      rewardsAndLoyalty: false,
+      reportsAndAnalytics: true,
+      expensesManagement: false,
+      settingsAndConfiguration: false,
+      kitchenManagement: false,
+      incidentsAccess: true,
+    },
+    markModified,
+    save,
+  };
+}
+
+function makeUpdater(updatedBy: string = 'super-admin-id') {
+  // `getUserForAudit` (private to AdminService) does a second
+  // `UserModel.findById(id).select('email role')` to resolve the
+  // updater's email + role for the audit log. Routed via
+  // `mockAuditUserFind` because the second findById has a `.select(...)`
+  // chain that the module mock distinguishes by call count.
+  mockAuditUserFind.mockResolvedValue({
+    _id: updatedBy,
+    email: 'super@example.com',
+    role: 'super-admin',
+  });
+  return updatedBy;
+}
+
+const BASE_PERMISSIONS: IAdminPermissions = {
+  orderManagement: true,
+  menuManagement: false,
+  inventoryManagement: false,
+  rewardsAndLoyalty: false,
+  reportsAndAnalytics: true,
+  expensesManagement: false,
+  settingsAndConfiguration: false,
+  kitchenManagement: false,
+  incidentsAccess: true,
+};
+
+describe('AdminService.updateAdminPermissions', () => {
+  beforeEach(() => {
+    mockAdminFind.mockReset();
+    mockAuditUserFind.mockReset();
+    findByIdCallCount = 0;
+    mockFindOne.mockReset();
+    mockCreateLog.mockReset();
+  });
+
+  it('persists mainCategoryReportAccess array via markModified', async () => {
+    const doc = makeAdminDoc();
+    mockAdminFind.mockResolvedValue(doc);
+    makeUpdater();
+
+    const newPermissions: IAdminPermissions = {
+      ...BASE_PERMISSIONS,
+      mainCategoryReportAccess: ['food', 'drinks'],
+    };
+
+    await AdminService.updateAdminPermissions({
+      adminId: 'admin123',
+      permissions: newPermissions,
+      updatedBy: 'super-admin-id',
+    });
+
+    // The assigned value carries the array
+    expect(doc.permissions).toEqual(newPermissions);
+    expect(doc.permissions.mainCategoryReportAccess).toEqual([
+      'food',
+      'drinks',
+    ]);
+
+    // markModified('permissions') is the load-bearing call. Without it,
+    // Mongoose silently drops sub-keys it doesn't know about.
+    expect(doc.markModified).toHaveBeenCalledWith('permissions');
+
+    // Order: markModified must precede save (mongoose checks dirty state
+    // when save is invoked).
+    const markOrder = doc.markModified.mock.invocationCallOrder[0];
+    const saveOrder = doc.save.mock.invocationCallOrder[0];
+    expect(markOrder).toBeLessThan(saveOrder);
+
+    // save was called once
+    expect(doc.save).toHaveBeenCalledTimes(1);
+  });
+
+  it('persists empty mainCategoryReportAccess (no-access state)', async () => {
+    const doc = makeAdminDoc({
+      permissions: {
+        ...BASE_PERMISSIONS,
+        mainCategoryReportAccess: ['food'],
+      },
+    });
+    mockAdminFind.mockResolvedValue(doc);
+    makeUpdater();
+
+    await AdminService.updateAdminPermissions({
+      adminId: 'admin123',
+      permissions: { ...BASE_PERMISSIONS, mainCategoryReportAccess: [] },
+      updatedBy: 'super-admin-id',
+    });
+
+    expect(doc.permissions.mainCategoryReportAccess).toEqual([]);
+    expect(doc.markModified).toHaveBeenCalledWith('permissions');
+  });
+
+  it('persists undefined mainCategoryReportAccess (unrestricted)', async () => {
+    const doc = makeAdminDoc({
+      permissions: {
+        ...BASE_PERMISSIONS,
+        mainCategoryReportAccess: ['food', 'drinks'],
+      },
+    });
+    mockAdminFind.mockResolvedValue(doc);
+    makeUpdater();
+
+    await AdminService.updateAdminPermissions({
+      adminId: 'admin123',
+      permissions: BASE_PERMISSIONS, // no mainCategoryReportAccess key
+      updatedBy: 'super-admin-id',
+    });
+
+    expect(doc.permissions.mainCategoryReportAccess).toBeUndefined();
+    expect(doc.markModified).toHaveBeenCalledWith('permissions');
+  });
+
+  it('writes oldPermissions + newPermissions to audit log', async () => {
+    const oldPerm: IAdminPermissions = { ...BASE_PERMISSIONS };
+    const doc = makeAdminDoc({ permissions: oldPerm });
+    mockAdminFind.mockResolvedValue(doc);
+    makeUpdater();
+
+    const newPermissions: IAdminPermissions = {
+      ...BASE_PERMISSIONS,
+      mainCategoryReportAccess: ['drinks'],
+    };
+
+    await AdminService.updateAdminPermissions({
+      adminId: 'admin123',
+      permissions: newPermissions,
+      updatedBy: 'super-admin-id',
+    });
+
+    expect(mockCreateLog).toHaveBeenCalledTimes(1);
+    const auditPayload = mockCreateLog.mock.calls[0][0];
+    expect(auditPayload.action).toBe('admin.permissions-updated');
+    expect(auditPayload.resourceId).toBe('admin123');
+    expect(auditPayload.details.newPermissions).toEqual(newPermissions);
+    expect(
+      auditPayload.details.newPermissions.mainCategoryReportAccess
+    ).toEqual(['drinks']);
+  });
+
+  it('throws when admin not found', async () => {
+    mockAdminFind.mockResolvedValue(null);
+
+    await expect(
+      AdminService.updateAdminPermissions({
+        adminId: 'missing',
+        permissions: BASE_PERMISSIONS,
+        updatedBy: 'super-admin-id',
+      })
+    ).rejects.toThrow('Admin not found');
+  });
+
+  it('throws when user is not an admin', async () => {
+    const doc = makeAdminDoc({ isAdmin: false });
+    mockAdminFind.mockResolvedValue(doc);
+
+    await expect(
+      AdminService.updateAdminPermissions({
+        adminId: 'admin123',
+        permissions: BASE_PERMISSIONS,
+        updatedBy: 'super-admin-id',
+      })
+    ).rejects.toThrow('User is not an admin');
+  });
+
+  it('throws when target is super-admin (cannot modify)', async () => {
+    const doc = makeAdminDoc({ role: 'super-admin' });
+    mockAdminFind.mockResolvedValue(doc);
+
+    await expect(
+      AdminService.updateAdminPermissions({
+        adminId: 'super-admin-id',
+        permissions: BASE_PERMISSIONS,
+        updatedBy: 'super-admin-id',
+      })
+    ).rejects.toThrow('Cannot modify super-admin permissions');
+  });
+});

--- a/e2e/daily-report-payments.spec.ts
+++ b/e2e/daily-report-payments.spec.ts
@@ -7,6 +7,7 @@
  */
 import { test as base, expect, Page } from '@playwright/test';
 import path from 'path';
+import { waitForAuthLoaded } from './helpers/customer-auth';
 
 const ADMIN_FILE = path.join(__dirname, '../.auth/admin.json');
 
@@ -123,6 +124,13 @@ test.describe
     // ── Navigate to menu ──────────────────────────────────────
     await page.goto(`/menu?tableNumber=${TEST_TABLE}`);
     await page.waitForLoadState('networkidle');
+    // REQ-064 hardened the customer flow: `MenuItemDetailModal`'s
+    // Add-to-Cart handler reads `useAuth().session?.isLoggedIn` and
+    // redirects to `/login?redirect=/menu` when the session is still
+    // `undefined`. With admin storage state the iron-session IS
+    // logged-in once `/api/auth/session` resolves, but the click can
+    // beat the fetch. Wait for that response before adding to cart.
+    await waitForAuthLoaded(page);
 
     // ── Add first in-stock menu item to cart ───────────────────
     const menuItem = page
@@ -327,6 +335,10 @@ test.describe
     // ── Add order via menu ────────────────────────────────────
     await page.goto(`/menu?tableNumber=${TEST_TABLE_OPEN}`);
     await page.waitForLoadState('networkidle');
+    // Same race fix as the first test — wait for `/api/auth/session`
+    // before the `MenuItemDetailModal` Add-to-Cart click so the modal
+    // doesn't redirect to /login under REQ-064's auth gate.
+    await waitForAuthLoaded(page);
 
     const menuItem = page
       .locator('[data-testid^="menu-item-"]')

--- a/e2e/helpers/customer-auth.ts
+++ b/e2e/helpers/customer-auth.ts
@@ -1,4 +1,6 @@
 import { MongoClient, ObjectId } from 'mongodb';
+import { sealData } from 'iron-session';
+import type { BrowserContext, Page } from '@playwright/test';
 
 /**
  * REQ-074 — Customer journey E2E coverage (sub-issue #292).
@@ -140,6 +142,205 @@ export async function cleanupUserById(
     await client.connect();
     const db = client.db(conn.dbName);
     await db.collection('users').deleteOne({ _id: new ObjectId(userId) });
+  } finally {
+    await client.close();
+  }
+}
+
+// ─── Session-bake helpers (REQ-013 customer-flow specs) ────────────────────
+//
+// REQ-064 hardened the customer-flow surfaces (`/menu`, `/checkout`,
+// `MenuItemDetailModal.handleAddToCart`) so the client-side `useAuth()`
+// hook gates them: when `/api/auth/session` resolves without
+// `isLoggedIn`, the modal redirects to `/login?redirect=/menu`. Admin
+// storage state still produces a logged-in session for admin users
+// (admin/super-admin/csr ARE users), but there's a small race:
+// `useAuth()` fetches `/api/auth/session` on mount; if the user clicks
+// `Add to Cart` before the fetch resolves, `session` is `undefined`
+// and the gate redirects. The helpers below let a spec either:
+//
+//   (a) Spawn a separate browser context with a pre-baked CUSTOMER
+//       iron-session cookie (real customer role, not an admin acting
+//       as a customer), bypassing the PIN flow that's infeasible in CI
+//       without a stub SMS / WhatsApp backend.
+//
+//   (b) Stay on the existing admin storage state but wait for
+//       `/api/auth/session` to resolve before any auth-gated click,
+//       closing the race window.
+//
+// Both paths produce a cryptographically-valid `iron-session` cookie
+// that the Next.js process accepts identically to one minted by a
+// real PIN-verify flow.
+
+export interface SeededCustomerForSession {
+  _id: string;
+  phone: string;
+  email: string;
+  name: string;
+}
+
+/**
+ * Seed a verified-customer user document directly into Mongo. Skips
+ * Mongoose (and therefore Mongoose validation), matching the seed
+ * pattern in `e2e/helpers/main-category-report-seed.ts`. Defaults
+ * produce a unique phone + email + name per call.
+ *
+ * Unlike `waitForPin` + the verify-pin flow above, this seed assumes
+ * the spec wants a FULLY VERIFIED customer ready to consume in
+ * `bakeCustomerSessionCookie` — no PIN intercept required.
+ */
+export async function seedVerifiedCustomer(opts?: {
+  phone?: string;
+  email?: string;
+  name?: string;
+}): Promise<SeededCustomerForSession> {
+  const stamp = Date.now().toString(36).slice(-8);
+  const phone =
+    opts?.phone ||
+    `+234${Date.now().toString().slice(-9)}${Math.floor(Math.random() * 10)}`;
+  const email = opts?.email || `e2e-customer-${stamp}@e2e.local`;
+  const name = opts?.name || `E2E Customer ${stamp}`;
+
+  const conn = mongoConn();
+  const client = new MongoClient(conn.uri);
+  try {
+    await client.connect();
+    const result = await client.db(conn.dbName).collection('users').insertOne({
+      phone,
+      email,
+      name,
+      firstName: 'E2E',
+      lastName: 'Customer',
+      role: 'customer',
+      isAdmin: false,
+      isGuest: false,
+      phoneVerified: true,
+      emailVerified: true,
+      isVerified: true,
+      accountStatus: 'active',
+      lastLoginAt: new Date(),
+      totalSpent: 0,
+      totalOrders: 0,
+      rewardsEarned: 0,
+      loyaltyPoints: 0,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    return { _id: String(result.insertedId), phone, email, name };
+  } finally {
+    await client.close();
+  }
+}
+
+/**
+ * Produce an `iron-session`-sealed cookie value for a seeded
+ * customer. Same password as the running app (`SESSION_PASSWORD`),
+ * same TTL as `lib/session.ts` (7 days), same shape as a real
+ * PIN-verify-action mint. The returned string is ready for
+ * `context.addCookies(...)`.
+ */
+export async function bakeCustomerSessionCookie(
+  customer: SeededCustomerForSession
+): Promise<string> {
+  const password = process.env.SESSION_PASSWORD;
+  if (!password) {
+    throw new Error(
+      'SESSION_PASSWORD env var is required to bake a customer session cookie. Set it before invoking the customer-auth setup or per-spec helper.'
+    );
+  }
+  return sealData(
+    {
+      userId: customer._id,
+      email: customer.email,
+      phone: customer.phone,
+      name: customer.name,
+      role: 'customer' as const,
+      isGuest: false,
+      isLoggedIn: true,
+      createdAt: Date.now(),
+    },
+    {
+      password,
+      ttl: 60 * 60 * 24 * 7, // matches lib/session.ts cookieOptions.maxAge
+    }
+  );
+}
+
+/**
+ * Attach a baked customer session cookie to a Playwright browser
+ * context. Use this when a spec needs a separate authenticated
+ * customer alongside the existing admin storage state (e.g.
+ * REQ-013's daily-report-payments where the admin creates the tab
+ * but the customer adds the order).
+ *
+ * @param baseUrl the running app's URL — Playwright derives the
+ *                cookie domain from it. Pass `process.env.BASE_URL ||
+ *                'http://localhost:3000'` in most specs.
+ */
+export async function attachCustomerSessionToContext(
+  context: BrowserContext,
+  customer: SeededCustomerForSession,
+  baseUrl: string
+): Promise<void> {
+  const cookieValue = await bakeCustomerSessionCookie(customer);
+  const cookieName = process.env.SESSION_COOKIE_NAME || 'wawa_session';
+  await context.addCookies([
+    {
+      name: cookieName,
+      value: cookieValue,
+      url: baseUrl,
+      httpOnly: true,
+      sameSite: 'Lax',
+      expires: Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 7,
+    },
+  ]);
+}
+
+/**
+ * Wait until `/api/auth/session` resolves on the current page. Used
+ * by specs that hit customer-facing routes with admin storage state
+ * — the race between the client-side `useAuth()` fetch and a user
+ * click on `Add to Cart` causes the modal to read `session ===
+ * undefined`, trip its logged-out branch, and redirect to /login.
+ *
+ * Non-throwing: if the session response was already cached or never
+ * fires (e.g. a SSR-hydrated page), the timeout fallback simply
+ * proceeds rather than failing the spec.
+ */
+export async function waitForAuthLoaded(
+  page: Page,
+  options?: { timeoutMs?: number }
+): Promise<void> {
+  const timeout = options?.timeoutMs ?? 10_000;
+  await page
+    .waitForResponse(
+      (resp) =>
+        resp.url().includes('/api/auth/session') &&
+        (resp.status() === 200 || resp.status() === 304),
+      { timeout }
+    )
+    .catch(() => {
+      /* hydrated from cache or already settled — proceed */
+    });
+}
+
+/**
+ * Cleanup the seeded customer + any orders or tabs created under
+ * their userId. Call from `afterAll` to keep UAT free of leaked
+ * fixtures.
+ */
+export async function cleanupSeededCustomer(
+  customer: SeededCustomerForSession
+): Promise<void> {
+  const conn = mongoConn();
+  const client = new MongoClient(conn.uri);
+  try {
+    await client.connect();
+    const db = client.db(conn.dbName);
+    const userId = new ObjectId(customer._id);
+    await db.collection('users').deleteOne({ _id: userId });
+    await db.collection('orders').deleteMany({ userId });
+    await db.collection('tabs').deleteMany({ userId });
   } finally {
     await client.close();
   }

--- a/e2e/helpers/main-category-report-seed.ts
+++ b/e2e/helpers/main-category-report-seed.ts
@@ -306,7 +306,23 @@ export async function seedAdminWithReportAccess(
     permissions.mainCategoryReportAccess = access;
   }
 
-  const username = `${prefix}-${Date.now().toString(36)}`;
+  // User-model enforces `username` maxlength: 30. The raw insertOne below
+  // bypasses Mongoose validation on INSERT, but the production paths the
+  // spec exercises (`authenticate()` → `admin.save()` to update
+  // lastLoginAt, `updateAdminPermissions()` → `admin.save()`) run full
+  // validation and reject a too-long username with
+  // `User validation failed: username (length 39) > 30`.
+  //
+  // The literal-prefix pattern (e.g. `e2e-req076-perms-XXXXXX-edit-YYYYYY`)
+  // produced 35-49 char usernames that silently violated this on every
+  // E2E run. Compress into a fixed-budget form: short stable prefix +
+  // run-local short id, total ≤ 30.
+  const shortId = Date.now().toString(36).slice(-6);
+  const shortPrefixHash = prefix
+    .replace(/[^a-z0-9]/g, '')
+    .slice(0, 18) // leave room for "-" + 6 char shortId + "-" + "e2e" tag
+    .toLowerCase();
+  const username = `e2e-${shortPrefixHash}-${shortId}`.slice(0, 30);
 
   return withDb(async (db) => {
     // `phone` has a unique index on UAT (users.phone_1). Multiple

--- a/e2e/orders/close-tab-tip-capture.spec.ts
+++ b/e2e/orders/close-tab-tip-capture.spec.ts
@@ -90,9 +90,15 @@ async function readTipsBreakdown(page: Page): Promise<{
         // Reject the section-wide total ("₦300 total") — that text
         // includes the word "total" or "tip"; the per-card amount does
         // NOT include "total".
+        // The section heading h3 reads "Tips Received \n ₦300.00 total"
+        // — only digits/commas/dots/whitespace between ₦ and "total". A
+        // per-card subtitle reads "100.0% of total tips" — non-digit
+        // chars between ₦ and "total". Discriminate by requiring the
+        // section-total shape so per-card subtitle text doesn't falsely
+        // reject the card's own amount.
         if (
           amount != null &&
-          !/total/i.test(node.textContent ?? '') &&
+          !/₦[\d,.\s]+\s*total/i.test(node.textContent ?? '') &&
           // Don't match an ancestor that contains MULTIPLE labels
           // (i.e. wrapped grid containing all cards).
           !labels.some(

--- a/e2e/orders/express-tip-capture.spec.ts
+++ b/e2e/orders/express-tip-capture.spec.ts
@@ -79,9 +79,13 @@ async function readTipsBreakdown(page: Page): Promise<{
       let node: HTMLElement | null = titleEl.parentElement;
       while (node && node !== grid) {
         const amount = parseNGN(node.textContent ?? '');
+        // Discriminate the section-wide total (h3 reads "Tips Received
+        // ₦300.00 total") from the per-card amount whose subtitle reads
+        // "100.0% of total tips" by requiring the section-total shape
+        // (only digits/commas/dots/whitespace between ₦ and "total").
         if (
           amount != null &&
-          !/total/i.test(node.textContent ?? '') &&
+          !/₦[\d,.\s]+\s*total/i.test(node.textContent ?? '') &&
           !labels.some(
             (l) =>
               l.label !== label && (node?.textContent ?? '').includes(l.label)

--- a/e2e/support-ticket-staff-flow.spec.ts
+++ b/e2e/support-ticket-staff-flow.spec.ts
@@ -171,12 +171,15 @@ csrTest.describe('REQ-064 staff flow — queue → detail → reply → status',
       // The action revalidates the route; verify the new state on the page.
       await expect(statusSelect).toContainText(/resolved/i, { timeout: 5000 });
 
-      // `updateSupportStatusAction` fires inside startTransition (React 18+)
-      // → setStatus updates the trigger synchronously, but the server
-      // roundtrip + revalidatePath complete async. Wait for network to
-      // settle so the DB query below sees the persisted state, not the
-      // mid-flight optimistic state.
-      await page.waitForLoadState('networkidle');
+      // `updateSupportStatusAction` fires inside startTransition (React 18+).
+      // The trigger updates synchronously; the server roundtrip is async
+      // and disables the combobox while in flight (`disabled={isPending}`
+      // in the Select wrapper). `networkidle` is too coarse — it can
+      // settle before the action's POST starts, so the DB read below
+      // raced ahead and saw 'open'. Waiting for the combobox to become
+      // re-enabled is the deterministic signal that the action's full
+      // server roundtrip (including DB write + revalidatePath) is done.
+      await expect(statusSelect).not.toBeDisabled({ timeout: 10000 });
 
       // DB-side verification: reply persisted + status flipped.
       const persisted = await readTicket(seeded.ticketId);

--- a/scripts/seed-e2e-fixtures.ts
+++ b/scripts/seed-e2e-fixtures.ts
@@ -5,6 +5,7 @@ import MenuItemModel from '@/models/menu-item-model';
 import InventoryModel from '@/models/inventory-model';
 import { ExpenseModel } from '@/models/expense-model';
 import { InventorySnapshotModel } from '@/models/inventory-snapshot-model';
+import SystemSettingsModel from '@/models/system-settings-model';
 
 dotenv.config({ path: '.env.local' });
 
@@ -178,6 +179,47 @@ async function seedE2eFixtures() {
     console.log(
       '✓ Seeded 1 trackByLocation inventory (2 locations × 5 stock = 10 total) for REQ-066 AC8/AC9 specs'
     );
+
+    // ── Payment gateway settings (REQ-069 signature-verification specs) ───
+    // `PaystackService.getConfig` + `MonnifyService.getConfig` read secrets
+    // from the `payment-gateway-config` SystemSettings document, NOT env
+    // vars directly. The webhook signature-rejection specs (REQ-069 /
+    // SRS REQ-PAY-002) hit `/api/webhooks/{paystack,monnify}` with bad
+    // signatures and expect a 401. Without configured secrets, the route
+    // handlers throw "Paystack/Monnify secret key is not configured" and
+    // surface as 500. Seed from CI env vars so the validation path
+    // actually runs.
+    const paystackSecret = process.env.PAYSTACK_SECRET_KEY || '';
+    const paystackPublic = process.env.PAYSTACK_PUBLIC_KEY || 'pk_test_e2e';
+    if (paystackSecret) {
+      await SystemSettingsModel.findOneAndUpdate(
+        { key: 'payment-gateway-config' },
+        {
+          $set: {
+            value: {
+              activeProvider: 'monnify',
+              paystack: {
+                enabled: true,
+                mode: 'test',
+                publicKey: paystackPublic,
+                secretKey: paystackSecret,
+              },
+              monnify: { enabled: true },
+            },
+            updatedBy: superAdmin._id,
+            updatedAt: new Date(),
+          },
+        },
+        { upsert: true, new: true }
+      );
+      console.log(
+        '✓ Seeded payment-gateway-config (paystack secret from env) for REQ-069 signature specs'
+      );
+    } else {
+      console.log(
+        '⚠️  PAYSTACK_SECRET_KEY env var missing — REQ-069 paystack specs will fail with 500 not 401'
+      );
+    }
 
     console.log('\n✅ E2E fixtures seeded.');
   } finally {

--- a/services/admin-service.ts
+++ b/services/admin-service.ts
@@ -452,6 +452,12 @@ export class AdminService {
 
     const oldPermissions = admin.permissions;
     admin.permissions = data.permissions;
+    // `permissions` is Schema.Types.Mixed; Mongoose can't auto-detect
+    // changes to a Mixed path even when the whole value is reassigned.
+    // markModified is the documented pattern. Without it, REQ-076's
+    // `mainCategoryReportAccess` (a new sub-key the schema doesn't
+    // know about) gets silently dropped on save.
+    admin.markModified('permissions');
     await admin.save();
 
     const auditUser = await this.getUserForAudit(data.updatedBy);


### PR DESCRIPTION
## Summary

Closes the last 9 outstanding E2E failures on the develop tip — including 2 brand-new regressions in REQ-076 specs surfaced by the first successful seed-step CI run on develop tip (after #350).

**All 9 root causes were derived from CI error-context.md page snapshots** — not guesses. Highlights:

- **REQ-076 production bug**: `AdminService.updateAdminPermissions` was silently dropping `mainCategoryReportAccess` because `permissions` is a `Schema.Types.Mixed` field that needs `markModified('permissions')` before save. The codebase has no other markModified calls — this was a latent footgun the new REQ-076 sub-key exposed.
- **REQ-076 seed bug**: seed usernames were 35–49 chars (e.g. `e2e-req076-perms-mq6nqqjj-edit-XXXXXX`) violating user-model `maxlength: 30`. Every `admin.save()` in `authenticate` + `updateAdminPermissions` threw silently.
- **REQ-035 tip parser**: my #349 fix used `/total/i` which also matched the "% of total tips" subtitle inside each card → rejected the per-card amount.
- **REQ-069 paystack 500**: env var `PAYSTACK_SECRET_KEY` (set in #344) never reached the DB-backed `payment-gateway-config` SystemSettings doc → `getConfig` threw before signature check could run.
- **REQ-064 staff-flow race**: `networkidle` settled before the `startTransition` POST started → DB read raced ahead.
- **REQ-013 daily-report-payments**: REQ-064 hardened `MenuItemDetailModal.handleAddToCart` — admin storage state IS valid but `useAuth()` had a race window where session was still `undefined` → modal redirected to `/login`.

## Files changed

| File | What |
|---|---|
| **`services/admin-service.ts`** | Add `markModified('permissions')` before save (Mongoose Mixed contract) |
| **`__tests__/services/admin-service.update-permissions.test.ts`** | 7 unit cases pinning the markModified contract |
| `e2e/helpers/main-category-report-seed.ts` | Compress seed username to ≤30 chars |
| `e2e/orders/close-tab-tip-capture.spec.ts` | Tip parser regex: `/₦[\d,.\s]+\s*total/i` |
| `e2e/orders/express-tip-capture.spec.ts` | Same fix |
| `e2e/support-ticket-staff-flow.spec.ts` | Wait for combobox non-disabled instead of networkidle |
| `scripts/seed-e2e-fixtures.ts` | Seed `payment-gateway-config` from env vars |
| **`e2e/helpers/customer-auth.ts`** | Customer-auth fixture: `seedVerifiedCustomer`, `bakeCustomerSessionCookie` (iron-session sealData), `attachCustomerSessionToContext`, `waitForAuthLoaded` |
| `e2e/daily-report-payments.spec.ts` | Invoke `waitForAuthLoaded` after `/menu` navigation |

## Customer-auth fixture (per operator request)

A reusable fixture for any future spec hitting REQ-064's customer-auth-gated surfaces without standing up a PIN-flow stub in CI:

- `seedVerifiedCustomer({phone?, email?, name?})` — direct-Mongo verified customer (skips PIN gates)
- `bakeCustomerSessionCookie(customer)` — iron-session sealData mint with same `SESSION_PASSWORD` + 7d TTL as production cookieOptions
- `attachCustomerSessionToContext(context, customer, baseUrl)` — Playwright cookie injection for hybrid admin+customer specs
- `waitForAuthLoaded(page)` — race-close helper

The daily-report-payments immediate fix uses `waitForAuthLoaded` (still on admin storage state — admin IS a logged-in user). The full fixture is in place for future REQ-013 / REQ-064 customer-flow specs that genuinely need a customer-role session.

## Verification

- ✅ tsc clean
- ✅ 1206 unit tests passing (7 new for `updateAdminPermissions`)
- ⏳ E2E regression on develop after merge: expected 0 unexpected failures

## Closes (after CI confirms)

- Part of #330 (regression-pack health) — all 4 buckets now addressed
- Unblocks release PR #336 (REQ-076)

🤖 Generated with [Claude Code](https://claude.com/claude-code)