### PR TITLE
compliance: re-anchor release version to REQ-076 for #336 evidence consolidation [REQ-076]

### DIFF
--- a/compliance/pending-releases/RELEASE-TICKET-REQ-076.md
+++ b/compliance/pending-releases/RELEASE-TICKET-REQ-076.md
@@ -1,13 +1,19 @@
 # Release Ticket: REQ-076 — Per-main-category reports + per-user access control
 
 **Status:** DRAFT
-**Date:** 2026-06-08
+**Date:** 2026-06-08 (release-anchor refreshed 2026-06-10)
 **Requirement ID:** REQ-076
 **Risk Level:** MEDIUM
 **GitHub Issue:** [#332](https://github.com/metasession-dev/wawagardenbar-app/issues/332)
-**Integration PR:** (this PR — to be opened against develop)
-**Release PR:** (single-REQ release path, `[REQ-076]` brackets in PR title for derive-release-version attribution)
+**Integration PR:** [#336 (develop → main)](https://github.com/metasession-dev/wawagardenbar-app/pull/336)
+**Release PR:** [#336 (develop → main)](https://github.com/metasession-dev/wawagardenbar-app/pull/336) — single-REQ release path, `[REQ-076]` brackets in PR title for derive-release-version attribution
 **Sign-off (dual-actor):** Pending portal UAT + Production approval.
+
+## Release-anchor note (2026-06-10)
+
+Today's intermediate merges (#353 `[REQ-013]`, #354 / #356 docs-only) drifted the `derive-release-version.sh` output away from `REQ-076` — #353's CI Pipeline ran with `[REQ-013]` in the latest commit subject and uploaded SAST + dependency-audit + test_report evidence to the `REQ-013` release entry on the portal instead of `REQ-076`. The release-PR #336's check-release-approval gate consequently queried `v2026.06.10` (the bare-date fallback) and saw no compliance-gate evidence on that entry.
+
+This commit re-anchors the release version: the bracketed `[REQ-076]` subject restores derive-release-version's output to `REQ-076`, the next CI Pipeline run on develop re-uploads SAST + dependency-audit + test_report to the `REQ-076` release entry, and the check-release-approval gate on #336 picks up the consolidated evidence. No code change — release infrastructure only.
 
 ---
 


### PR DESCRIPTION
## Summary

Re-anchors `derive-release-version.sh`'s output to **REQ-076** so #336's CI Pipeline uploads SAST + dependency-audit + test_report evidence to the correct release entry on the portal.

## Why this is needed

Today's intermediate merges fragmented the release evidence across three portal entries:

| Release entry on portal | Evidence types currently there |
|---|---|
| **REQ-076** | Original dev evidence: security-summary, plans, screenshots, REQ-076 test_report (uploaded during the REQ-076 feature PRs earlier this week) |
| **REQ-013** | **🔴 SAST + dependency_audit + test_report (uploaded by #353's CI Pipeline at 09:36Z)** — orphaned by accident |
| **v2026.06.10** | Compliance docs, RTM, audit log, release-ticket markdowns (uploaded by today's compliance-evidence runs) |

Cause: `derive-release-version.sh` picks a version from the **latest commit subject** brackets. After #353 merged (subject `test: pin daily-report no-double-count contract [REQ-013][#352]`), the version derived to `REQ-013`, sending #353's SAST + dep-audit uploads to the wrong release entry. Subsequent docs-only merges (#354 / #356) had no brackets at all → bare-date `v2026.06.10`.

When the operator UAT-approved on the portal, the approval form rejected with:

```
Missing compliance gates: SAST Scan, Dependency Audit, E2E Tests, Test Reports.
No evidence uploaded. Evidence must be present before approval.
```

…because none of those gate-evidence types live on the `v2026.06.10` release entry the gate is checking.

## The fix

This PR's commit subject `compliance: re-anchor release version to REQ-076 ... [REQ-076]` carries the `[REQ-076]` brackets `derive-release-version.sh` needs.

On merge to develop:

1. Next CI Pipeline run on develop derives `REQ-076` (matching brackets in subject).
2. SAST + dependency-audit + test_report uploads land on the `REQ-076` release entry, consolidating with the existing REQ-076 evidence.
3. The check-release-approval gate on #336 also derives `REQ-076` and finds the full evidence set.
4. The operator UAT-approves the **`REQ-076`** entry on the portal (not `v2026.06.10`).
5. Gate flips green, #336 unblocks.

## What changed in code

Markdown-only update to `compliance/pending-releases/RELEASE-TICKET-REQ-076.md`:
- Fills in the Integration PR / Release PR fields (both #336)
- Adds a "Release-anchor note (2026-06-10)" section documenting the fragmentation + the corrective action

No application code changes.

## Test plan

- [x] tsc clean (markdown only)
- [ ] CI Quality Gates pass
- [ ] After merge to develop, the next CI Pipeline run shows `Release version: REQ-076` in its log
- [ ] After CI Pipeline finishes, portal `REQ-076` release entry shows SAST + dependency-audit + test_report present
- [ ] Operator UAT-approves the REQ-076 entry; #336's Release Approval Gate re-fires green

## Refs

- PR #336 — the release PR this unblocks
- PR #353 — the commit whose `[REQ-013]` subject caused the drift
- PR #354 / #356 — docs-only merges that further drifted to bare-date

🤖 Generated with [Claude Code](https://claude.com/claude-code)