### PR TITLE
chore: devaudit update to v0.1.53 (E2E 3-tier gating model)

### DIFF
--- a/.claude/skills/e2e-test-engineer/SKILL.md
+++ b/.claude/skills/e2e-test-engineer/SKILL.md
@@ -133,6 +133,26 @@ Resist padding. A new endpoint doesn't need a test that re-verifies login if log
 
 For each scenario, write a one-line description. Present the full grouped list to the user before writing any code: _"Here's the coverage I'd propose — anything to add or drop?"_
 
+#### Classify each spec into a tier (devaudit#152 follow-up, v0.1.53)
+
+When designing each scenario, also pick the tier it'll live in. Three tiers map to MoSCoW priority + gating point (see `Test_Strategy.md` § _E2E gating model_):
+
+| Tier           | File location            | Picks this when…                                                                                                                                                                                                                                                                     |
+| -------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **smoke**      | `e2e/smoke/*.spec.ts`    | Cross-cutting sanity that proves the app is up: login, basic nav, one canonical CRUD per main domain. Runs on every push to the integration branch. Keep small — total smoke wall-clock target is ~3–5 min.                                                                          |
+| **critical**   | `e2e/critical/*.spec.ts` | Must-priority SRS item that breaks a headline flow if it regresses. Examples: payment authorisation, order completion, admin permission editing, RBAC enforcement on financial surfaces. Runs on PR-to-release-branch. Total critical wall-clock target ~10–15 min (includes smoke). |
+| **regression** | `e2e/<area>/*.spec.ts`   | Should/Could-priority SRS item, edge cases, less-load-bearing flows. Runs nightly + post-merge + dispatch. Total full pack can be 30+ min; that's the point of the tier.                                                                                                             |
+
+Decision tree, applied per scenario:
+
+1. **Does the spec prove a Must-priority SRS AC (or a baseline "app is up" sanity check)?** → smoke or critical.
+2. **Within Must: would a regression here break a headline business flow visible to a paying customer or stop a release from shipping?** → critical. Otherwise → smoke.
+3. **Should/Could priority, edge case, advanced flow?** → regression (file under `e2e/<area>/`, not under `e2e/smoke/` or `e2e/critical/`).
+
+When you can't decide between critical and regression, default to **regression** — promoting a spec from regression → critical later is cheap (move the file); demoting in the other direction is rarely needed but equally cheap. The cost of putting a Should spec in critical is everyone waiting longer on every PR-to-main for a low-value signal.
+
+Record the tier choice in the eventual `test-execution-summary.md` § _Test design_ (devaudit#50) — Layers covered should name which tier each new spec landed in. Reviewers verify the tier choice is defensible during the WAIT CHECKPOINT.
+
 ### Phase 4 — Reconcile with existing tests
 
 For the area touched by the change, look at what's already there.

--- a/.claude/skills/e2e-test-engineer/references/e2e-regression-3-tier.yml
+++ b/.claude/skills/e2e-test-engineer/references/e2e-regression-3-tier.yml
@@ -1,0 +1,178 @@
+# Reference: three-tier E2E gating workflow (devaudit#152 follow-up, v0.1.53)
+#
+# Copy this into your consumer-owned .github/workflows/e2e-regression.yml
+# to adopt the 3-tier model: smoke (every develop push, fast) / critical
+# (PR-to-main, ~10-15 min target) / regression (nightly + push-to-main +
+# dispatch, full audit trail with auto-issue on failure).
+#
+# The framework does NOT sync this file automatically — your consumer
+# owns its e2e-regression.yml. Apply the patterns below to your own
+# file; keep any consumer-specific env / matrix / runner customisations.
+#
+# Tier definitions:
+#   - smoke   — runs on develop push via ci.yml (no change here)
+#   - critical — Playwright project that selects e2e/smoke/ + e2e/critical/
+#   - regression — Playwright project that selects all e2e/**/*.spec.ts
+#
+# playwright.config.ts must define the `critical` project for this to
+# fire; if it doesn't, the gate falls back to the existing `smoke`
+# project so PR-to-main stays green during migration.
+
+name: E2E Regression
+
+on:
+  pull_request:
+    branches: [main] # critical-tier gate before merge
+  push:
+    branches: [main] # full regression after merge; auto-issues on failure
+  schedule:
+    - cron: '0 2 * * *' # nightly full regression
+  workflow_dispatch:
+    inputs:
+      specs:
+        description: 'Optional: space-separated spec paths or --grep pattern for a scoped run. Empty = full regression.'
+        required: false
+
+permissions:
+  contents: read
+  issues: write # post-merge auto-issue on regression failure
+
+concurrency:
+  group: e2e-regression-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  e2e:
+    name: E2E Regression Tests
+    runs-on: ubuntu-latest # adapt to your runner; e.g. self-hosted, ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # for E2E_NEW_SPECS computation
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22' # match your project
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      # Decide which Playwright project to run based on the trigger.
+      # PR-to-main uses critical with smoke fall-back; push-to-main and
+      # schedule run the full regression project; workflow_dispatch
+      # accepts an optional spec filter.
+      - name: Determine E2E project + spec selector
+        id: select
+        run: |
+          set -euo pipefail
+          EVENT="${{ github.event_name }}"
+          case "$EVENT" in
+            pull_request)
+              if grep -qE "name:\s*['\"]critical['\"]" playwright.config.ts 2>/dev/null; then
+                echo "project=critical" >> "$GITHUB_OUTPUT"
+                echo "Using critical-tier project (smoke + e2e/critical/)"
+              else
+                echo "project=smoke" >> "$GITHUB_OUTPUT"
+                echo "::warning::No 'critical' Playwright project defined; falling back to smoke. See e2e-test-engineer/references/e2e-regression-3-tier.yml + the Phase 3 tier-classification guide."
+              fi
+              echo "specs=" >> "$GITHUB_OUTPUT"
+              ;;
+            push|schedule)
+              echo "project=regression" >> "$GITHUB_OUTPUT"
+              echo "specs=" >> "$GITHUB_OUTPUT"
+              echo "Running full regression project"
+              ;;
+            workflow_dispatch)
+              echo "project=regression" >> "$GITHUB_OUTPUT"
+              echo "specs=${{ github.event.inputs.specs }}" >> "$GITHUB_OUTPUT"
+              if [ -n "${{ github.event.inputs.specs }}" ]; then
+                echo "Scoped dispatch: ${{ github.event.inputs.specs }}"
+              fi
+              ;;
+          esac
+
+      - name: Run E2E suite
+        id: run
+        env:
+          PLAYWRIGHT_HTML_REPORTER_OPEN: never
+          PLAYWRIGHT_JSON_OUTPUT_NAME: e2e-regression-results.json
+          # Add your e2e_env values here as needed (DEVAUDIT_BASE_URL etc.)
+        run: |
+          set -euo pipefail
+          PROJECT="${{ steps.select.outputs.project }}"
+          SPECS="${{ steps.select.outputs.specs }}"
+          if [ -n "$SPECS" ]; then
+            npx playwright test --project="$PROJECT" --reporter=json,html $SPECS
+          else
+            npx playwright test --project="$PROJECT" --reporter=json,html
+          fi
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: e2e-regression-report
+          path: |
+            e2e-regression-results.json
+            playwright-report/
+            test-results/
+
+      # ─────────────────────────────────────────────────────────────
+      # Post-merge auto-issue on regression failure (push:branches:[main])
+      #
+      # Catches regressions that slipped past the critical-tier PR gate.
+      # Opens a high-priority issue tagging the merge commit + the
+      # failing specs so the operator can triage within working hours.
+      # No auto-revert — that's intentionally an operator decision.
+      # ─────────────────────────────────────────────────────────────
+      - name: Open hotfix issue on post-merge regression
+        if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          MERGE_SHA="${{ github.sha }}"
+          MERGE_SHA_SHORT=$(echo "$MERGE_SHA" | cut -c1-7)
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          # Extract failing spec names from the JSON reporter output if available.
+          FAILING=""
+          if [ -f e2e-regression-results.json ]; then
+            FAILING=$(jq -r '
+              [.. | objects | select(.status == "failed" or .status == "timedOut") | .title // empty]
+              | unique | .[]
+            ' e2e-regression-results.json 2>/dev/null | head -20 || true)
+          fi
+          if [ -z "$FAILING" ]; then
+            FAILING="(see the failing run logs — could not parse spec titles from reporter output)"
+          fi
+
+          BODY=$(cat <<EOF
+          ## Post-merge regression caught on \`main\`
+
+          The full regression suite failed on the post-merge run for commit \`${MERGE_SHA_SHORT}\`. The critical-tier PR gate let this slip through.
+
+          **Failing specs (best-effort extracted from the JSON reporter):**
+
+          \`\`\`
+          ${FAILING}
+          \`\`\`
+
+          **Triage actions:**
+
+          - [ ] Read the run log: ${RUN_URL}
+          - [ ] Pull \`e2e-regression-report\` artifact from the run; inspect \`test-results/<spec>/error-context.md\` for page state at failure
+          - [ ] Decide: hotfix on \`main\`, revert \`${MERGE_SHA_SHORT}\`, or accept-with-rationale if the failure is environmental
+          - [ ] If the failing spec is a Must-tier candidate that should have caught this pre-merge, move it from \`e2e/\` to \`e2e/critical/\` so the next PR-to-main runs it
+
+          **Auto-filed by:** \`e2e-regression.yml\` (devaudit#152 3-tier gating, v0.1.53+)
+          EOF
+          )
+
+          gh issue create \
+            --title "[hotfix] Post-merge regression on \`${MERGE_SHA_SHORT}\` — full E2E failed" \
+            --body "$BODY" \
+            --label "bug,priority:high"

--- a/SDLC/Test_Architecture.md
+++ b/SDLC/Test_Architecture.md
@@ -25,24 +25,28 @@ These standards apply to all Metasession products, client engagements, and inter
 ## 1. Architectural Principles
 
 ### DRY (Don't Repeat Yourself)
+
 - Reusable test utilities and helper functions across suites
 - Shared fixtures and base classes
 - Centralized configuration management
 - Common assertion libraries and custom matchers
 
 ### Isolation
+
 - Each test runs independently without side effects
 - Database state reset between test runs
 - External dependencies mocked to prevent flakiness
 - Parallel execution enabled without interference
 
 ### Speed over Exhaustiveness
+
 - Fast feedback prioritized (unit tests < 30 seconds)
 - Parallelization and sharding for E2E suites
-- Strategic test selection based on code changes
+- Strategic test selection based on code changes — first concrete implementation is the three-tier E2E gating model (smoke / critical / regression), see Test_Strategy.md § _E2E gating model_ (v0.1.53+)
 - Regression suites optimized for execution time
 
 ### Traceability
+
 - Tests linked to requirements via ticket IDs
 - BDD feature files tagged with requirement references
 - Automated requirement-test-result mapping
@@ -53,38 +57,38 @@ These standards apply to all Metasession products, client engagements, and inter
 
 ### Unit Layer (Foundation)
 
-| Attribute | Standard |
-|---|---|
-| Coverage | Minimum 70% for critical modules |
-| Speed | Suite completes in < 30 seconds |
-| Scope | Individual functions, methods, components in isolation |
-| Mocking | External dependencies must be mocked |
+| Attribute | Standard                                               |
+| --------- | ------------------------------------------------------ |
+| Coverage  | Minimum 70% for critical modules                       |
+| Speed     | Suite completes in < 30 seconds                        |
+| Scope     | Individual functions, methods, components in isolation |
+| Mocking   | External dependencies must be mocked                   |
 
 ### Integration Layer (Middle)
 
-| Attribute | Standard |
-|---|---|
-| Coverage | Minimum 80% of integration points |
-| Scope | Component interactions, service integrations, API contracts |
-| Data | In-memory databases or MSW for API mocking |
+| Attribute | Standard                                                    |
+| --------- | ----------------------------------------------------------- |
+| Coverage  | Minimum 80% of integration points                           |
+| Scope     | Component interactions, service integrations, API contracts |
+| Data      | In-memory databases or MSW for API mocking                  |
 
 ### E2E Layer (Top)
 
-| Attribute | Standard |
-|---|---|
-| Coverage | 100% of critical user paths |
-| Scope | Complete user journeys from UI to database |
-| Browser support | Chromium, Firefox, WebKit |
-| BDD | playwright-bdd for acceptance criteria |
+| Attribute       | Standard                                   |
+| --------------- | ------------------------------------------ |
+| Coverage        | 100% of critical user paths                |
+| Scope           | Complete user journeys from UI to database |
+| Browser support | Chromium, Firefox, WebKit                  |
+| BDD             | playwright-bdd for acceptance criteria     |
 
 ### Additional Layers
 
-| Layer | Standard |
-|---|---|
-| Security | SAST, SCA, DAST (see Section 3) |
-| Performance | Load and stress testing before major releases |
-| Accessibility | WCAG 2.1 AA for public-facing features |
-| Visual regression | Optional, recommended for UI-heavy products |
+| Layer             | Standard                                      |
+| ----------------- | --------------------------------------------- |
+| Security          | SAST, SCA, DAST (see Section 3)               |
+| Performance       | Load and stress testing before major releases |
+| Accessibility     | WCAG 2.1 AA for public-facing features        |
+| Visual regression | Optional, recommended for UI-heavy products   |
 
 ---
 
@@ -92,50 +96,50 @@ These standards apply to all Metasession products, client engagements, and inter
 
 ### Test Frameworks
 
-| Purpose | Tool | Notes |
-|---|---|---|
-| Unit testing (TS/JS) | Jest or Vitest | Project chooses one |
-| Unit testing (Python) | pytest | |
-| Component testing | React Testing Library | |
-| E2E testing | Playwright | Organizational standard |
-| BDD integration | playwright-bdd | |
-| API mocking | MSW (Mock Service Worker) | |
-| HTTP mocking | Nock | Node.js environments |
+| Purpose               | Tool                      | Notes                   |
+| --------------------- | ------------------------- | ----------------------- |
+| Unit testing (TS/JS)  | Jest or Vitest            | Project chooses one     |
+| Unit testing (Python) | pytest                    |                         |
+| Component testing     | React Testing Library     |                         |
+| E2E testing           | Playwright                | Organizational standard |
+| BDD integration       | playwright-bdd            |                         |
+| API mocking           | MSW (Mock Service Worker) |                         |
+| HTTP mocking          | Nock                      | Node.js environments    |
 
 ### Test Management
 
-| Purpose | Tool |
-|---|---|
-| Test case management | Qase |
-| CI/CD | GitHub Actions |
-| Reporting | Playwright HTML Reporter, JUnit XML |
+| Purpose              | Tool                                |
+| -------------------- | ----------------------------------- |
+| Test case management | Qase                                |
+| CI/CD                | GitHub Actions                      |
+| Reporting            | Playwright HTML Reporter, JUnit XML |
 
 ### Security Testing
 
-| Purpose | Tool | When |
-|---|---|---|
-| SAST (static analysis) | Semgrep and/or SonarQube | Every commit |
-| SCA (dependency scanning) | Snyk | Every commit |
-| Dependency updates | Dependabot | Continuous |
-| DAST (dynamic testing) | OWASP ZAP | Periodic / pre-release |
-| Supply chain analysis | Socket.dev | Optional, for enhanced analysis |
+| Purpose                   | Tool                     | When                            |
+| ------------------------- | ------------------------ | ------------------------------- |
+| SAST (static analysis)    | Semgrep and/or SonarQube | Every commit                    |
+| SCA (dependency scanning) | Snyk                     | Every commit                    |
+| Dependency updates        | Dependabot               | Continuous                      |
+| DAST (dynamic testing)    | OWASP ZAP                | Periodic / pre-release          |
+| Supply chain analysis     | Socket.dev               | Optional, for enhanced analysis |
 
 ### Performance Testing
 
-| Purpose | Tool |
-|---|---|
-| Load testing | Artillery |
+| Purpose         | Tool       |
+| --------------- | ---------- |
+| Load testing    | Artillery  |
 | Web performance | Lighthouse |
 
 ### Development Tooling
 
-| Purpose | Tool |
-|---|---|
-| Git hooks | Husky |
-| Commit linting | commitlint (Conventional Commits) |
-| Code linting | ESLint |
-| Code formatting | Prettier |
-| Containerization | Docker |
+| Purpose          | Tool                              |
+| ---------------- | --------------------------------- |
+| Git hooks        | Husky                             |
+| Commit linting   | commitlint (Conventional Commits) |
+| Code linting     | ESLint                            |
+| Code formatting  | Prettier                          |
+| Containerization | Docker                            |
 
 ---
 
@@ -199,13 +203,13 @@ Products must implement:
 
 ### Strategy by Test Level
 
-| Test Level | Data Strategy | Rationale |
-|---|---|---|
-| Unit | Mocked data | Fast, predictable |
-| Integration | In-memory DB or MSW | Isolated, controlled |
-| E2E (local) | Test database (Docker) | Real behavior, containerized |
-| E2E (CI) | Ephemeral database | Production-like, auto-provisioned |
-| Staging | Dedicated staging DB | Production-equivalent, anonymized |
+| Test Level  | Data Strategy          | Rationale                         |
+| ----------- | ---------------------- | --------------------------------- |
+| Unit        | Mocked data            | Fast, predictable                 |
+| Integration | In-memory DB or MSW    | Isolated, controlled              |
+| E2E (local) | Test database (Docker) | Real behavior, containerized      |
+| E2E (CI)    | Ephemeral database     | Production-like, auto-provisioned |
+| Staging     | Dedicated staging DB   | Production-equivalent, anonymized |
 
 ### Data Factories (Required)
 
@@ -229,16 +233,16 @@ Products must implement:
 
 All products implement these stages in order:
 
-| Stage | Purpose | Exit Criteria |
-|---|---|---|
-| 1. Lint | ESLint + Prettier validation | 0 errors |
-| 2. Type Check | Strict compilation | 0 errors |
-| 3. Unit Tests | Component-level testing with coverage | Meets coverage target |
-| 4. Security Scans | SAST + SCA | 0 high/critical findings |
-| 5. Integration Tests | API and service validation | All pass |
-| 6. E2E Tests | Full Playwright suite with parallelization | All critical paths pass |
-| 7. Build | Production build verification | Succeeds |
-| 8. Report | Artifact upload and status reporting | Artifacts stored |
+| Stage                | Purpose                                    | Exit Criteria            |
+| -------------------- | ------------------------------------------ | ------------------------ |
+| 1. Lint              | ESLint + Prettier validation               | 0 errors                 |
+| 2. Type Check        | Strict compilation                         | 0 errors                 |
+| 3. Unit Tests        | Component-level testing with coverage      | Meets coverage target    |
+| 4. Security Scans    | SAST + SCA                                 | 0 high/critical findings |
+| 5. Integration Tests | API and service validation                 | All pass                 |
+| 6. E2E Tests         | Full Playwright suite with parallelization | All critical paths pass  |
+| 7. Build             | Production build verification              | Succeeds                 |
+| 8. Report            | Artifact upload and status reporting       | Artifacts stored         |
 
 PR cannot merge unless all stages pass.
 
@@ -259,21 +263,25 @@ PR cannot merge unless all stages pass.
 Hook templates are provided in `sdlc/files/hooks/` in the DevAudit repository. Copy them into your project during setup (see `0-project-setup.md` Step 5c).
 
 **Pre-commit** (`.husky/pre-commit` — template: `hooks/pre-commit`):
+
 - Runs lint-staged on staged files (ESLint + Prettier)
 - Blocks commit on failure
 
 **Commit-msg** (`.husky/commit-msg` — template: `hooks/commit-msg`):
+
 - Runs commitlint to validate Conventional Commits format
 - Required format: `type(scope): description`
 - Warns on missing `Ref: REQ-XXX` and `Co-Authored-By` trailers
 - Configuration: `commitlint.config.mjs` (template: `hooks/commitlint.config.mjs`)
 
 **Pre-push** (`.husky/pre-push` — template: `hooks/pre-push`):
+
 - TypeScript compilation check (`tsc --noEmit`) as a fast gate
 - Full test suite, SAST, and dependency audit run in CI — not in the pre-push hook (too slow for a local gate)
 - Blocks push on TypeScript errors
 
 **Setup:**
+
 ```bash
 npm install --save-dev husky @commitlint/cli @commitlint/config-conventional lint-staged
 npx husky init
@@ -289,17 +297,17 @@ npm pkg set scripts.prepare="husky"
 
 ## 8. Artifact Storage
 
-| Artifact | Storage | Retention |
-|---|---|---|
-| Test results (HTML) | GitHub Actions artifacts | 90 days |
-| Screenshots | GitHub Actions artifacts | 90 days |
-| Videos | GitHub Actions artifacts | 90 days |
-| Coverage reports | Codecov | Indefinite |
-| JUnit XML | GitHub Actions + Qase | 90 days + Indefinite |
-| Release artifacts | AWS S3 / Azure Blob | 3-7 years (compliance) |
-| Security scans | Snyk + SonarQube dashboards | Indefinite |
-| SAST evidence (JSON) | Project compliance directory | 3 years minimum |
-| Dependency audits | Project compliance directory | 3 years minimum |
+| Artifact             | Storage                      | Retention              |
+| -------------------- | ---------------------------- | ---------------------- |
+| Test results (HTML)  | GitHub Actions artifacts     | 90 days                |
+| Screenshots          | GitHub Actions artifacts     | 90 days                |
+| Videos               | GitHub Actions artifacts     | 90 days                |
+| Coverage reports     | Codecov                      | Indefinite             |
+| JUnit XML            | GitHub Actions + Qase        | 90 days + Indefinite   |
+| Release artifacts    | AWS S3 / Azure Blob          | 3-7 years (compliance) |
+| Security scans       | Snyk + SonarQube dashboards  | Indefinite             |
+| SAST evidence (JSON) | Project compliance directory | 3 years minimum        |
+| Dependency audits    | Project compliance directory | 3 years minimum        |
 
 ### Flakiness Handling (Required)
 
@@ -314,14 +322,14 @@ npm pkg set scripts.prepare="husky"
 
 ### Naming Conventions
 
-| File Type | Pattern | Example |
-|---|---|---|
-| Unit tests | `*.test.ts`, `*.test.tsx` | `auth.test.ts` |
-| Integration tests | `*.integration.test.ts` | `api.integration.test.ts` |
-| E2E tests | `*.spec.ts` | `login.spec.ts` |
-| BDD features | `*.feature` | `authentication.feature` |
-| Page objects | `*Page.ts` (PascalCase) | `LoginPage.ts` |
-| Accessibility | `*.a11y.test.ts` | `navigation.a11y.test.ts` |
+| File Type         | Pattern                   | Example                   |
+| ----------------- | ------------------------- | ------------------------- |
+| Unit tests        | `*.test.ts`, `*.test.tsx` | `auth.test.ts`            |
+| Integration tests | `*.integration.test.ts`   | `api.integration.test.ts` |
+| E2E tests         | `*.spec.ts`               | `login.spec.ts`           |
+| BDD features      | `*.feature`               | `authentication.feature`  |
+| Page objects      | `*Page.ts` (PascalCase)   | `LoginPage.ts`            |
+| Accessibility     | `*.a11y.test.ts`          | `navigation.a11y.test.ts` |
 
 ### ESLint Configuration
 
@@ -409,13 +417,13 @@ module.exports = {
 
 ## 11. Coverage & Quality Thresholds
 
-| Metric | Target |
-|---|---|
+| Metric                                | Target      |
+| ------------------------------------- | ----------- |
 | Unit test coverage (critical modules) | 70% minimum |
-| Integration point coverage | 80% minimum |
-| Critical user path E2E coverage | 100% |
-| Security scan (high/critical) | 0 findings |
-| Accessibility (public-facing) | WCAG 2.1 AA |
+| Integration point coverage            | 80% minimum |
+| Critical user path E2E coverage       | 100%        |
+| Security scan (high/critical)         | 0 findings  |
+| Accessibility (public-facing)         | WCAG 2.1 AA |
 
 ### Quality Metrics (Required Tracking)
 
@@ -447,10 +455,10 @@ Each product creates a product-specific Test Plan that:
 
 ## Document Control
 
-| Version | Date | Author | Changes |
-|---|---|---|---|
-| 1.0 | January 2026 | QA Team | Initial creation |
-| 2.0 | March 2026 | QA Team | Clean boundary split — removed compliance/governance content (now in Policy), removed methodology content (now in Strategy). Architecture now owns tools, patterns, code standards, CI config only. Added security tooling table. |
+| Version | Date         | Author  | Changes                                                                                                                                                                                                                           |
+| ------- | ------------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1.0     | January 2026 | QA Team | Initial creation                                                                                                                                                                                                                  |
+| 2.0     | March 2026   | QA Team | Clean boundary split — removed compliance/governance content (now in Policy), removed methodology content (now in Strategy). Architecture now owns tools, patterns, code standards, CI config only. Added security tooling table. |
 
 **Next Review Date:** March 2027
 

--- a/SDLC/Test_Policy.md
+++ b/SDLC/Test_Policy.md
@@ -113,10 +113,10 @@ AI-generated code presents risks distinct from human-authored code:
 
 ### Permitted AI Tools
 
-| Tool | Permitted Use | Restrictions |
-|---|---|---|
-| Claude (Anthropic) | Code generation, test generation, documentation, review assistance | No deployment without human review |
-| GitHub Copilot | Inline code suggestions | Same review requirements as any AI-generated code |
+| Tool               | Permitted Use                                                      | Restrictions                                      |
+| ------------------ | ------------------------------------------------------------------ | ------------------------------------------------- |
+| Claude (Anthropic) | Code generation, test generation, documentation, review assistance | No deployment without human review                |
+| GitHub Copilot     | Inline code suggestions                                            | Same review requirements as any AI-generated code |
 
 Adding a new tool requires Engineering Leadership approval and updates to this policy, the Test Strategy, and relevant project Test Plans.
 
@@ -150,17 +150,31 @@ Testing effort is prioritized by risk level, determined at planning time:
 
 AI involvement in Medium or High categories raises risk by one level. The Test Strategy defines specific testing depth requirements per level.
 
+### E2E gate enforcement (v0.1.53+)
+
+The MoSCoW prioritisation of acceptance criteria maps onto three E2E gates, each enforced at a different point in the workflow:
+
+- **Must-tier ACs in the smoke subset** must pass on every push to the integration branch. Blocking — a red smoke gate stops the integration hop.
+- **Must-tier ACs in the critical subset** must pass on every PR to the release branch. Blocking — a red critical gate stops the release.
+- **Should/Could-tier ACs (full regression)** must pass on the next post-merge run to the release branch OR a hotfix issue is auto-filed. Not pre-merge blocking — the safety net is post-hoc triage by the operator within working hours.
+
+Operator override on a hotfix issue (accept-with-rationale) is logged on the issue itself + carried in the next release's `test-execution-summary.md` design record (devaudit#50). The framework does not permit silently shipping a failing test — every red regression spec ends as either fixed, reverted, or accepted-with-recorded-rationale.
+
+See Test_Strategy.md § _System Testing (E2E)_ — _E2E gating model_ for the tier definitions + cost philosophy.
+
 ---
 
 ## Roles & Responsibilities
 
 ### Engineering Leadership
+
 - Approve and maintain this policy
 - Allocate testing resources
 - Review metrics and drive improvement
 - Approve AI tool additions
 
 ### QA Team / Test Engineers
+
 - Design and execute strategies and plans
 - Develop and maintain automated suites
 - Report defects and verify fixes
@@ -168,6 +182,7 @@ AI involvement in Medium or High categories raises risk by one level. The Test S
 - Verify security scan results
 
 ### Developers
+
 - Write unit tests for all changes
 - Execute local testing before committing (including security scans)
 - Fix identified defects
@@ -175,6 +190,7 @@ AI involvement in Medium or High categories raises risk by one level. The Test S
 - Document AI use per project requirements
 
 ### Product Managers / Business Analysts
+
 - Define clear acceptance criteria
 - Participate in test planning and risk assessment
 - Review and approve completion reports
@@ -244,16 +260,16 @@ Training completion is tracked as ISO 27001 evidence.
 ```
 Test Policy (this document)
   → WHY we test, WHAT we commit to, WHO is responsible
-  
+
 Test Strategy
   → HOW we approach testing methodically
-  
+
 Test Architecture
   → WHAT we build tests with, HOW we structure the code
-  
+
 Periodic Security Review Schedule
   → WHEN periodic security activities happen
-  
+
 Project Test Plans (per product)
   → WHERE and WHEN for specific products
 ```
@@ -262,11 +278,11 @@ Project Test Plans (per product)
 
 ## Document Control
 
-| Version | Date | Author | Changes |
-|---|---|---|---|
-| 1.0 | January 2026 | Engineering Leadership | Initial creation |
-| 2.0 | March 2026 | Engineering Leadership | Added AI governance, security commitments |
-| 3.0 | March 2026 | Engineering Leadership | Clean boundary split — removed content now owned by Test Strategy (methodology) and Test Architecture (tooling) |
+| Version | Date         | Author                 | Changes                                                                                                         |
+| ------- | ------------ | ---------------------- | --------------------------------------------------------------------------------------------------------------- |
+| 1.0     | January 2026 | Engineering Leadership | Initial creation                                                                                                |
+| 2.0     | March 2026   | Engineering Leadership | Added AI governance, security commitments                                                                       |
+| 3.0     | March 2026   | Engineering Leadership | Clean boundary split — removed content now owned by Test Strategy (methodology) and Test Architecture (tooling) |
 
 **Next Review Date:** March 2027
 

--- a/SDLC/Test_Strategy.md
+++ b/SDLC/Test_Strategy.md
@@ -38,6 +38,24 @@ Validates interactions between system components — API contracts, service inte
 
 End-to-end validation of complete user workflows from UI to database. Primary responsibility of the QA team. Automated using BDD frameworks that map acceptance criteria to executable specifications. Covers 100% of critical user paths.
 
+#### E2E gating model — three tiers (devaudit#152 follow-up, v0.1.53)
+
+Full E2E regression on every PR is expensive — a 30+ minute wait per release-PR blocks velocity for diminishing marginal safety once smoke covers the headline flows. The framework's gating model maps the existing MoSCoW prioritisation onto three tiers, each gated at a different point in the workflow:
+
+| Tier           | Location                                | When it runs                                              | Wall-clock target                     | Audit role                     |
+| -------------- | --------------------------------------- | --------------------------------------------------------- | ------------------------------------- | ------------------------------ |
+| **smoke**      | `e2e/smoke/*.spec.ts`                   | every push to `$INTEGRATION_BRANCH` (via `ci.yml`)        | ~3–5 min                              | fast feedback on every change  |
+| **critical**   | `e2e/smoke/` + `e2e/critical/*.spec.ts` | PR-to-`$RELEASE_BRANCH` (via `e2e-regression.yml`)        | ~10–15 min                            | release-readiness Must gate    |
+| **regression** | all `e2e/**/*.spec.ts`                  | nightly + push-to-`$RELEASE_BRANCH` + `workflow_dispatch` | ~35 min (or your project's full pack) | full audit trail + drift catch |
+
+The mapping to MoSCoW: **Must-priority SRS items live in `e2e/smoke/` (fast feedback) and `e2e/critical/` (release gate); Should/Could items live in `e2e/` and are covered by the regression tier.** The classifier is the developer authoring the spec — see `skills/e2e-test-engineer/SKILL.md` Phase 3 for the decision tree.
+
+**Cost philosophy.** Smoke protects every push from breaking the headline flow. Critical protects every release from a Must-tier regression. Full regression protects the audit trail + catches drift overnight. We accept that a Should/Could-tier regression _can_ slip past the PR gate; we catch it on the next post-merge run + auto-file a hotfix issue. The framework prefers this over a 35-min wait on every release because operator velocity matters and the safety net stays intact.
+
+**Post-merge safety net.** Every push to `$RELEASE_BRANCH` re-runs the full regression. On failure, `e2e-regression.yml` auto-files a `bug, priority:high` issue tagging the merge commit + the failing specs. The operator triages within working hours — hotfix forward, revert the commit, or accept-with-rationale if the failure is environmental. No automated revert (false positives + flakes + UAT-data drift are real classes; an operator triages each individually).
+
+**Reference workflow.** A copy-pasteable `e2e-regression.yml` shape lives at `skills/e2e-test-engineer/references/e2e-regression-3-tier.yml`. Adoption is opt-in per consumer (the framework doesn't currently sync this workflow; consumers own their own `e2e-regression.yml`).
+
 ### Acceptance Testing
 
 Validates that requirements and acceptance criteria are met from a business perspective. Conducted in staging environments mirroring production. Requires sign-off from Product Managers. May include formal UAT with stakeholders for regulated features.
@@ -86,24 +104,24 @@ Specific tools implementing these gates are defined in the Test Architecture.
 
 Defined in the Periodic Security Review Schedule:
 
-| Activity | Frequency |
-|---|---|
-| Full codebase SAST review | Quarterly |
-| Dependency deep audit | Quarterly |
-| Access control review | Quarterly |
-| Audit log integrity review | Quarterly |
-| Penetration testing (third party) | Annually |
-| Disaster recovery test | Annually |
-| Third-party security assessment | Annually |
+| Activity                          | Frequency |
+| --------------------------------- | --------- |
+| Full codebase SAST review         | Quarterly |
+| Dependency deep audit             | Quarterly |
+| Access control review             | Quarterly |
+| Audit log integrity review        | Quarterly |
+| Penetration testing (third party) | Annually  |
+| Disaster recovery test            | Annually  |
+| Third-party security assessment   | Annually  |
 
 ### Remediation SLAs
 
-| Severity | Per-Commit Gate | Periodic Finding |
-|---|---|---|
-| Critical | Block merge, fix immediately | 7 days |
-| High | Block merge, fix immediately | 30 days |
-| Medium | Document and plan remediation | 90 days |
-| Low | Track for next review | Next quarterly review |
+| Severity | Per-Commit Gate               | Periodic Finding      |
+| -------- | ----------------------------- | --------------------- |
+| Critical | Block merge, fix immediately  | 7 days                |
+| High     | Block merge, fix immediately  | 30 days               |
+| Medium   | Document and plan remediation | 90 days               |
+| Low      | Track for next review         | Next quarterly review |
 
 ---
 
@@ -115,22 +133,22 @@ This section implements the AI governance commitments from the Test Policy with 
 
 AI involvement is a factor in risk classification:
 
-| Code Category | Base Risk | AI Adjustment |
-|---|---|---|
-| Internal tools, no regulated data | Low | Remains Low |
-| User-facing features, API changes, PII handling | Medium | Remains Medium |
-| Auth, payments, RBAC, crypto, data validation | High | Remains High |
-| Any of the above with AI regeneration | Any | Raise by one level |
+| Code Category                                   | Base Risk | AI Adjustment      |
+| ----------------------------------------------- | --------- | ------------------ |
+| Internal tools, no regulated data               | Low       | Remains Low        |
+| User-facing features, API changes, PII handling | Medium    | Remains Medium     |
+| Auth, payments, RBAC, crypto, data validation   | High      | Remains High       |
+| Any of the above with AI regeneration           | Any       | Raise by one level |
 
 ### Mandatory Human Review Process
 
 **Review scope by risk level:**
 
-| Risk Level | Reviewer | Focus |
-|---|---|---|
-| Low | Any team member with domain knowledge | Functional correctness, obvious security issues |
-| Medium | Developer experienced in affected area | Above + security implications, dependency validation |
-| High | Senior developer + security-aware review | Above + independent verification, threat modeling |
+| Risk Level | Reviewer                                 | Focus                                                |
+| ---------- | ---------------------------------------- | ---------------------------------------------------- |
+| Low        | Any team member with domain knowledge    | Functional correctness, obvious security issues      |
+| Medium     | Developer experienced in affected area   | Above + security implications, dependency validation |
+| High       | Senior developer + security-aware review | Above + independent verification, threat modeling    |
 
 **Every reviewer checks AI-generated code for:**
 
@@ -155,11 +173,11 @@ Incremental AI-assisted edits follow standard testing gates.
 
 ### AI Documentation Requirements
 
-| Risk Level | Commit Tag | Evidence | Prompts |
-|---|---|---|---|
-| Low | `Co-Authored-By` tag | Not required | Not required |
-| Medium | `Co-Authored-By` tag | Summary of generation | Summary of prompts |
-| High | `Co-Authored-By` tag | Detailed AI record | Detailed prompts and outputs |
+| Risk Level | Commit Tag           | Evidence              | Prompts                      |
+| ---------- | -------------------- | --------------------- | ---------------------------- |
+| Low        | `Co-Authored-By` tag | Not required          | Not required                 |
+| Medium     | `Co-Authored-By` tag | Summary of generation | Summary of prompts           |
+| High       | `Co-Authored-By` tag | Detailed AI record    | Detailed prompts and outputs |
 
 ---
 
@@ -177,18 +195,18 @@ Risk level is determined at planning time for each requirement:
 
 ### Testing Depth by Risk Level
 
-| Activity | Low | Medium | High |
-|---|---|---|---|
-| Unit tests | Required | Required | Required |
-| Integration tests | As applicable | Required | Required |
-| E2E tests | Critical paths | Full coverage | Full coverage |
-| SAST scan | Required | Required | Required |
-| Dependency audit | Required | Required | Required |
-| Access control testing | If applicable | Required | Required |
-| Audit log testing | If applicable | Required | Required |
-| Performance testing | Not required | If applicable | Required |
-| Penetration testing | Not required | Not required | Consider |
-| Independent review | Not required | Not required | Required |
+| Activity               | Low            | Medium        | High          |
+| ---------------------- | -------------- | ------------- | ------------- |
+| Unit tests             | Required       | Required      | Required      |
+| Integration tests      | As applicable  | Required      | Required      |
+| E2E tests              | Critical paths | Full coverage | Full coverage |
+| SAST scan              | Required       | Required      | Required      |
+| Dependency audit       | Required       | Required      | Required      |
+| Access control testing | If applicable  | Required      | Required      |
+| Audit log testing      | If applicable  | Required      | Required      |
+| Performance testing    | Not required   | If applicable | Required      |
+| Penetration testing    | Not required   | Not required  | Consider      |
+| Independent review     | Not required   | Not required  | Required      |
 
 ---
 
@@ -293,28 +311,28 @@ Tracked requirements include: `Ref: REQ-XXX`
 
 ### Required Artifact Types
 
-| Category | Artifacts |
-|---|---|
-| Planning | Test Policy, Test Strategy, Project Test Plans |
-| Specification | BDD feature files, test case specifications, security scenarios |
-| Execution | Test logs, CI/CD logs, SAST/SCA reports, AI use records, defect reports |
-| Reporting | Status reports, completion reports, security summaries |
+| Category      | Artifacts                                                               |
+| ------------- | ----------------------------------------------------------------------- |
+| Planning      | Test Policy, Test Strategy, Project Test Plans                          |
+| Specification | BDD feature files, test case specifications, security scenarios         |
+| Execution     | Test logs, CI/CD logs, SAST/SCA reports, AI use records, defect reports |
+| Reporting     | Status reports, completion reports, security summaries                  |
 
 ---
 
 ## Agile Artifact Mapping
 
-| ISO Artifact | Metasession Implementation |
-|---|---|
-| Test Policy | This document hierarchy (Policy + Strategy + Architecture) |
-| Requirements Specification | Product backlog with acceptance criteria |
-| Test Plan | Project-specific Test Plan + sprint planning |
-| Test Case Specification | BDD feature files (Gherkin Given/When/Then) |
-| Test Execution Log | CI/CD pipeline logs, test management tool records |
-| Defect Reports | Issue tracker with severity labels and workflows |
-| Traceability Matrix | Requirement-test-defect linkage (RTM or tool-based) |
-| Security Evidence | SAST/SCA results, dependency audits, security summaries |
-| AI Audit Trail | Co-Authored-By tags, evidence directory records, PR history |
+| ISO Artifact               | Metasession Implementation                                  |
+| -------------------------- | ----------------------------------------------------------- |
+| Test Policy                | This document hierarchy (Policy + Strategy + Architecture)  |
+| Requirements Specification | Product backlog with acceptance criteria                    |
+| Test Plan                  | Project-specific Test Plan + sprint planning                |
+| Test Case Specification    | BDD feature files (Gherkin Given/When/Then)                 |
+| Test Execution Log         | CI/CD pipeline logs, test management tool records           |
+| Defect Reports             | Issue tracker with severity labels and workflows            |
+| Traceability Matrix        | Requirement-test-defect linkage (RTM or tool-based)         |
+| Security Evidence          | SAST/SCA results, dependency audits, security summaries     |
+| AI Audit Trail             | Co-Authored-By tags, evidence directory records, PR history |
 
 ---
 
@@ -344,11 +362,11 @@ Sprint retrospectives, quarterly metric reviews, and incident lessons learned fe
 
 ## Document Control
 
-| Version | Date | Author | Changes |
-|---|---|---|---|
-| 1.0 | January 2026 | QA Team | Initial creation |
-| 2.0 | March 2026 | QA Team | Added AI methodology, security methodology, V&V |
-| 3.0 | March 2026 | QA Team | Clean boundary split — moved specific tools, code patterns, CI config to Test Architecture. Strategy now owns methodology only. |
+| Version | Date         | Author  | Changes                                                                                                                         |
+| ------- | ------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| 1.0     | January 2026 | QA Team | Initial creation                                                                                                                |
+| 2.0     | March 2026   | QA Team | Added AI methodology, security methodology, V&V                                                                                 |
+| 3.0     | March 2026   | QA Team | Clean boundary split — moved specific tools, code patterns, CI config to Test Architecture. Strategy now owns methodology only. |
 
 **Next Review Date:** March 2027
 


### PR DESCRIPTION
## Summary

Sync from `@metasession.co/devaudit-cli` **v0.1.52 → v0.1.53**.

Headline change: **new three-tier E2E gating model** documented in `Test_Strategy.md` and `Test_Policy.md`:

| Tier | Location | When it runs | Wall-clock target | Audit role |
|---|---|---|---|---|
| **smoke** | `e2e/smoke/*.spec.ts` | every push to develop (via `ci.yml`) | ~3–5 min | fast feedback on every change |
| **critical** | `e2e/smoke/` + `e2e/critical/*.spec.ts` | PR-to-main (via `e2e-regression.yml`) | ~10–15 min | release-readiness Must gate |
| **regression** | all `e2e/**/*.spec.ts` | nightly + push-to-main + dispatch | ~35 min | full audit trail + drift catch |

## Why this matters for us

Directly addresses the cost/safety tradeoff that surfaced during the REQ-076 release (PR #336 + #352): full regression on every release PR amplified our chronic UAT shared-state pollution into a recurring release blocker requiring admin-overrides. The 3-tier model gates only Must-tier ACs at PR time and runs full regression post-merge + auto-files a hotfix issue on failure.

## What changed

| File | Lines | Why |
|---|---|---|
| `SDLC/Test_Policy.md` | +42 | New "E2E gate enforcement (v0.1.53+)" section |
| `SDLC/Test_Strategy.md` | +148 | New "E2E gating model — three tiers" subsection (table + cost philosophy + post-merge safety net + reference-workflow pointer) |
| `SDLC/Test_Architecture.md` | +210 | 3-tier model integration |
| `.claude/skills/e2e-test-engineer/SKILL.md` | +20 | Phase 3 tier-classifier guidance |
| `.claude/skills/e2e-test-engineer/references/e2e-regression-3-tier.yml` | new 178 | Reference `e2e-regression.yml` for opt-in adoption |

## What did NOT change (intentional)

- **Our `.github/workflows/e2e-regression.yml` is untouched.** Adoption of the 3-tier model is **opt-in per consumer** — the reference workflow is a template, not an auto-sync target.
- 6 other files (`compliance-evidence.yml` whitespace alignment, `2-implement-and-test.md`, `3-compile-evidence.md`, `Implementation_Plan_TEMPLATE.md`, `adr-author` + `requirements-aligner` + `sdlc-implementer` skills) had purely cosmetic diffs already prettier-normalized to develop's state — no substantive content lost.

## Test plan

- [x] tsc clean (markdown + skill docs, no code)
- [ ] CI Quality Gates pass
- [ ] After merge, develop tip carries the 3-tier model docs

## Follow-up (separate cycle)

The reference workflow at `.claude/skills/e2e-test-engineer/references/e2e-regression-3-tier.yml` is a template for our future `e2e-regression.yml` redesign. Worth opening an issue to adopt it once #352 (UAT pollution backlog) is being scoped.

## Refs

- `@metasession.co/devaudit-cli` v0.1.53 (npm)
- Prior sync PR: #340 (`chore: devaudit update to v0.1.52`)
- Issue #352 — UAT pollution; the new 3-tier model is the framework-side answer to this pattern
- PR #336 — REQ-076 release that motivated the 3-tier work upstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)