### PR TITLE
chore: migrate DevAudit portal base URL to devaudit.ai

### DIFF
--- a/sdlc-config.json
+++ b/sdlc-config.json
@@ -47,9 +47,7 @@
   "uat": {
     "enabled": true,
     "url": "https://wawagardenbar-app-uat.up.railway.app/",
-    "required_risk_classes": [
-      "*"
-    ]
+    "required_risk_classes": ["*"]
   },
   "approval": {
     "mode": "dual_actor",
@@ -67,7 +65,7 @@
   "working_directory": ".",
   "source_dirs": "app/ lib/",
   "devaudit": {
-    "base_url": "https://devaudit.metasession.co",
+    "base_url": "https://devaudit.ai",
     "project_slug": "wgb",
     "api_key_secret": "DEVAUDIT_API_KEY"
   },


### PR DESCRIPTION
## Summary

The DevAudit portal migrated hosts: \`devaudit.metasession.co\` now returns HTTP 301 → \`devaudit.ai\`. The upload script doesn't follow 301 redirects, so evidence uploads have been broken since the migration completed.

Verification of when it broke:

| Time | Push | Compliance Evidence Upload |
|---|---|---|
| 15:58Z | #358 close-out REQ-076 | ✅ success (3m32s) |
| 17:33Z | #355 housekeeping | ✅ success (1m15s) |
| 18:19Z | **#361 3-tier adoption** | ❌ **failure: HTTP 301 on \`gate-outcomes.json\` upload** |

The migration happened between 17:33Z and 18:19Z.

New host verified responding:

\`\`\`
curl -sI https://devaudit.ai/api/ci/projects/wgb
  → HTTP/2 401 (expected — needs API key; endpoint exists; cloudflare-served)
\`\`\`

Same endpoint paths; just the host changed.

## What changed

| File | Change |
|---|---|
| \`sdlc-config.json\` | \`devaudit.base_url\` → \`https://devaudit.ai\` |

The shell script comment + error-message references to the old URL (\`scripts/submit-for-uat-review.sh\`) are cosmetic — the script reads \`DEVAUDIT_BASE_URL\` from env, so this PR doesn't bother updating those.

## Operator action recommended after merge

Check **Settings → Variables → Actions** for a \`DEVAUDIT_BASE_URL\` **repo variable**. The compliance workflows resolve it via \`\${{ vars.DEVAUDIT_BASE_URL }}\` first and only fall back to \`sdlc-config.json\` if the var is absent.

- If absent: this PR alone fixes it.
- If present: update the var to \`https://devaudit.ai\` too.

## Test plan

- [x] Curl-verified new host responds (401 = correct — needs auth)
- [ ] After merge to develop, next CI Pipeline run's "Upload Evidence" step succeeds
- [ ] After merge, next \`Compliance Evidence Upload\` workflow on develop runs cleanly

## Why this is unrelated to #361

#361's CI Pipeline failure was a coincidence — the host migration happened in the same window. #361's Quality Gates + Register Release both passed; only the upload-to-portal step failed because the portal moved hosts. The 3-tier adoption code itself is fine on develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)