### PR TITLE
chore: retry-safe critical-tier E2E assertions + cleanup contract [#352]

### DIFF
--- a/SDLC/test-isolation.md
+++ b/SDLC/test-isolation.md
@@ -1,0 +1,185 @@
+# Test isolation contract — E2E retry-safe assertions
+
+**Origin:** issue [#352](https://github.com/metasession-dev/wawagardenbar-app/issues/352) — UAT shared-state pollution amplified by Playwright `serial`-describe retries.
+
+The load-bearing release-blocker for REQ-076 (PR [#336](https://github.com/metasession-dev/wawagardenbar-app/pull/336)) was a Playwright retry chain that re-created DB state inside `describe.serial` blocks. The retry doubled the contribution to aggregate assertions: `cashDelta=1224, expected=612` — exactly 2× — on `daily-report-payments.spec.ts:279`. This document captures the contract critical-tier E2E specs follow to be deterministic under retry, against shared CI Mongo state, and across same-day concurrent runs.
+
+The defenses are layered. **Use the cheapest one that's sufficient for your spec.**
+
+---
+
+## Layer 1 — `retries: 0` on the critical project (foundation)
+
+`playwright.config.ts`:
+
+```ts
+{
+  name: 'critical',
+  retries: 0,        // ← load-bearing per #352
+  testMatch: [/e2e\/smoke\/.*\.spec\.ts$/, /e2e\/critical\/.*\.spec\.ts$/, ...],
+  dependencies: ['auth-setup'],
+}
+```
+
+This eliminates the **within-run retry-doubling** class. A `describe.serial` block that fails partway no longer re-creates its DB state. Transient flakes surface as a single PR-gate failure that the operator manually reruns — accepted trade for eliminating the spurious-doubling case entirely.
+
+Regression tier keeps the top-level `retries: 2` because its post-merge auto-issue safety net (per the 3-tier model, see [`Test_Strategy.md`](Test_Strategy.md) § _E2E gating model_) handles its noise differently.
+
+---
+
+## Layer 2 — Entity-specific assertions (preferred for tip + payment write-path proofs)
+
+When a spec proves "the UI flow wrote field X with value V", the **strongest** assertion is to query Mongo for the specific entity that field belongs to — not to verify a downstream aggregate.
+
+### Pattern
+
+```ts
+import {
+  findRecentOrderWithTip,
+  deleteOrderById,
+} from '../helpers/db-assertions';
+
+test.describe('REQ-XXX: ...', () => {
+  let createdOrderId: string | null = null;
+
+  test.afterEach(async () => {
+    if (createdOrderId) {
+      await deleteOrderById(createdOrderId).catch(() => {});
+      createdOrderId = null;
+    }
+  });
+
+  test('order persists tip with expected method', async ({ page }) => {
+    const since = new Date(); // ← scope the DB query to "this test"
+
+    // ... UI flow ...
+
+    const order = await findRecentOrderWithTip({
+      since,
+      tipAmount: 500,
+      tipPaymentMethod: 'cash',
+      paymentMethod: 'card',
+    });
+    expect(order).toBeTruthy();
+    expect(order.tipAmount).toBe(500);
+    expect(order.tipPaymentMethod).toBe('cash');
+    expect(order.paymentMethod).toBe('card');
+
+    createdOrderId = String(order._id);
+  });
+});
+```
+
+### Why this is strongest
+
+- **Retry-safe** — the query scopes to `paidAt: { $gte: since }` so it can't pick up a previous attempt's record. With `retries: 0` at the project level, retries can't even happen, but the timestamp scope is belt-and-braces against same-day concurrent runs.
+- **Concurrency-safe** — even if a cron run + a PR run + a manual dispatch all fire on the same calendar day, each captures its own `since` and finds only its own record.
+- **Stronger semantically** — asserts the actual field that REQ-035 specifies (`tipPaymentMethod`), not a derived aggregate. A regression in the WRITE path is caught directly; the aggregation correctness is already unit-tested at `__tests__/services/financial-report-service.tip.test.ts` etc.
+- **Cleanup is trivial** — `deleteOrderById(createdOrderId)` in `afterEach`.
+
+### Where to use it
+
+Specs that prove "this UI flow caused this DB write" — `express-tip-capture.spec.ts`, `close-tab-tip-capture.spec.ts`. Any spec whose AC is "field X persists with value V after action Y" should use this pattern.
+
+### Helpers
+
+See [`e2e/helpers/db-assertions.ts`](../e2e/helpers/db-assertions.ts):
+
+| Helper                                                                        | When to use                        |
+| ----------------------------------------------------------------------------- | ---------------------------------- |
+| `findRecentOrderWithTip({since, tipAmount, tipPaymentMethod, paymentMethod})` | Tip-recording E2Es                 |
+| `findRecentTabWithTip({since, tipAmount, paymentType})`                       | Close-tab tip E2Es                 |
+| `findRecentPaidOrder({since, total, paymentMethod})`                          | Revenue-tracking E2Es              |
+| `deleteOrderById(id)` / `deleteTabById(id)`                                   | Cleanup in afterEach / afterAll    |
+| `deleteOrdersByReferencePrefix(prefix)`                                       | Bulk cleanup by `paymentReference` |
+| `pollForDoc(collection, filter, opts)`                                        | Generic — for new entity types     |
+
+---
+
+## Layer 3 — Relaxed `>=` assertions (acceptable for revenue-reporting E2Es)
+
+When a spec proves "the daily report INCLUDES my payment", strict equality (`expect(delta).toBe(amount)`) is the wrong contract. It claims "no other writes on this day" — which is true on an isolated dev box but **false on shared CI Mongo with concurrent runs and yesterday's residue**.
+
+Use `>=` instead:
+
+```ts
+const delta = updated.cash - baseline.cash;
+// Correct: "the daily report INCLUDES my payment". May also include
+// other contributions (concurrent runs / prior fixtures) — that's not
+// a failure of MY test.
+expect(delta).toBeGreaterThanOrEqual(myPaymentAmount);
+```
+
+**The strict no-double-counting check moves to the unit-test layer** — see `__tests__/services/financial-report-service.partial-payment-no-double-count.test.ts`, which proves `paymentBreakdown.total === expected` deterministically with mocked Mongo. The E2E asserts the integration shape (UI flow → DB write → daily report includes), not the math.
+
+### Where to use it
+
+Specs where dropping the aggregate assertion would lose meaningful integration coverage but the strict math is already unit-tested. Examples: `daily-report-payments.spec.ts`, `dashboard-revenue.spec.ts`, `express-order-report.spec.ts`.
+
+---
+
+## Layer 4 — Cleanup of created entities (hygiene)
+
+Critical-tier specs that create tabs / orders / inventory entries SHOULD clean up after themselves. Not strictly required for correctness (Layers 1-3 cover that), but it bounds the residue load on shared CI Mongo and keeps later runs' baselines clean.
+
+```ts
+test.afterAll(async () => {
+  if (createdTabId) {
+    const { deleteTabById } = await import('../helpers/db-assertions');
+    await deleteTabById(createdTabId);
+  }
+});
+```
+
+Use `afterAll` rather than `afterEach` for serial-describe blocks where the tab persists across tests in the same block. Always wrap in try/catch (or `.catch(() => {})`) — cleanup failure should never fail the spec.
+
+### What if the failing test skips cleanup?
+
+It usually does. `afterEach` / `afterAll` run on success and on `test.skip()`, but **NOT** on uncaught test failure when the test itself throws. The defenses in Layers 1-3 are what makes the suite robust against this — cleanup is a hygiene optimisation, not the safety net.
+
+### Where to use it
+
+Any spec that creates DB entities. Even revenue-reporting specs that survive on `>=` benefit from cleanup so daily-aggregate baselines stay small.
+
+---
+
+## Anti-patterns
+
+| ❌ Don't                                                    | ✅ Do                                                                                                          |
+| ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `expect(report.cash - baseline.cash).toBe(amount)`          | `expect(report.cash - baseline.cash).toBeGreaterThanOrEqual(amount)` OR direct DB query for the specific order |
+| Rely on `afterEach` cleanup to keep state clean             | Use timestamp-scoped queries that don't depend on a clean baseline                                             |
+| Create unbounded test data and never clean up               | At minimum, use a distinctive `paymentReference` prefix (`E2E-XYZ-${Date.now()}`) so cleanup is possible later |
+| Use `describe.serial` when tests don't depend on each other | Use independent tests where possible; `describe.serial` couples failure modes                                  |
+| Set `retries > 0` on critical tier                          | Keep `retries: 0` on critical — surface flakes don't amplify into doubling                                     |
+
+---
+
+## The 3-tier model — where this contract applies
+
+| Tier           | Retry policy              | Isolation expectation                                                                                                                                                            |
+| -------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **smoke**      | inherits `retries: 2`     | Smoke specs should be fast + side-effect-free — Layer 1 should be enough for most.                                                                                               |
+| **critical**   | `retries: 0` (foundation) | All four layers in play. Specs use Layer 2 or 3 + Layer 4 cleanup. **This contract is mandatory for critical-tier specs.**                                                       |
+| **regression** | inherits `retries: 2`     | Best-effort. Post-merge auto-issue mechanism (see `e2e-regression.yml` + `Test_Strategy.md`) catches anything that slips through. This contract is recommended but not enforced. |
+
+---
+
+## Worked examples
+
+- `e2e/critical/express-tip-capture.spec.ts` — Layer 2 (entity-specific DB query)
+- `e2e/critical/close-tab-tip-capture.spec.ts` — Layer 2 + Layer 4 (cleanup by RESTORING the open-tab fixture, not deleting it)
+- `e2e/critical/daily-report-payments.spec.ts` — Layer 3 (`>=`) + Layer 4 (delete the test-created tab)
+- `e2e/critical/dashboard-revenue.spec.ts` — Layer 3 (already uses `>=`; no changes needed for retry-safety)
+- `e2e/critical/express-order-report.spec.ts` — Layer 3 (already uses `>=`; no changes needed)
+
+---
+
+## Refs
+
+- [`Test_Strategy.md`](Test_Strategy.md) § _E2E gating model — three tiers_
+- [`Test_Policy.md`](Test_Policy.md) § _E2E gate enforcement (v0.1.53+)_
+- Issue [#352](https://github.com/metasession-dev/wawagardenbar-app/issues/352) — the motivating bug
+- Issue [#360](https://github.com/metasession-dev/wawagardenbar-app/issues/360) / PR [#361](https://github.com/metasession-dev/wawagardenbar-app/pull/361) — 3-tier adoption
+- PR [#353](https://github.com/metasession-dev/wawagardenbar-app/pull/353) — the unit-test pin that lets the E2E drop the strict no-double-counting check
+- [`e2e/helpers/db-assertions.ts`](../e2e/helpers/db-assertions.ts) — the helper library

--- a/e2e/critical/close-tab-tip-capture.spec.ts
+++ b/e2e/critical/close-tab-tip-capture.spec.ts
@@ -5,21 +5,31 @@
  * closing partial-payment row, and that the resulting Tab persists the
  * tip on the row (with the row's paymentType serving as the tip method).
  *
- * The Daily Financial Report's Tips Received section should show the
- * tip under the bucket matching the closing payment's method.
- *
  * Skips if no open tabs exist on the test environment.
+ *
+ * Retry-safe assertion model (#352): instead of asserting on a daily-
+ * report aggregate delta (which retry-doubles when describe.serial
+ * blocks re-run after a failure), captures a timestamp before the UI
+ * flow and queries Mongo directly for the tab closed after that
+ * timestamp whose partialPayments contain the exact (tipAmount +
+ * paymentType) row. The aggregation correctness is unit-tested at
+ * `__tests__/services/financial-report-service.tip.test.ts`.
+ *
+ * Cleanup: the tab is RESTORED to `open` status (not deleted) so the
+ * subsequent run has the same open tab to exercise. This is the
+ * idempotent equivalent of "leave the test fixture as you found it".
+ *
+ * See SDLC/test-isolation.md for the contract.
  */
 import { test as base, expect, Page } from '@playwright/test';
 import path from 'path';
+import { findRecentTabWithTip, withMongo } from '../helpers/db-assertions';
 
 const ADMIN_FILE = path.join(__dirname, '../../.auth/admin.json');
 
 const test = base.extend({
   storageState: ADMIN_FILE,
 });
-
-test.describe.configure({ mode: 'serial' });
 
 async function isAuthenticated(page: Page): Promise<boolean> {
   try {
@@ -31,113 +41,10 @@ async function isAuthenticated(page: Page): Promise<boolean> {
   }
 }
 
-async function readTipsBreakdown(page: Page): Promise<{
-  total: number;
-  cash: number;
-  card: number;
-  transfer: number;
-}> {
-  return page.evaluate(() => {
-    const result = { total: 0, cash: 0, card: 0, transfer: 0 };
-
-    const parseNGN = (s: string): number | null => {
-      const m = s.match(/(?:₦|NGN)\s*([\d,]+(?:\.\d+)?)/);
-      return m ? parseFloat(m[1].replace(/,/g, '')) : null;
-    };
-
-    // Find the Tips Received section heading + extract `... total`
-    // from the heading's text.
-    const sectionHeading = Array.from(document.querySelectorAll('h3')).find(
-      (h) => /Tips Received/i.test(h.textContent ?? '')
-    );
-    if (!sectionHeading) return result;
-    const totalAmount = parseNGN(sectionHeading.textContent ?? '');
-    if (totalAmount != null) result.total = totalAmount;
-
-    // Find the grid sibling. The tip-cards section lives directly
-    // under the heading in `tips-section.tsx`.
-    const grid = sectionHeading.nextElementSibling;
-    if (!grid) return result;
-
-    // Walk every descendant element under the grid. For each one whose
-    // textContent starts with a known title ("Cash tips" / "POS / Card
-    // tips" / etc.) treat that element as the Card and look for ₦N
-    // anywhere inside it. More forgiving than relying on specific
-    // sub-class selectors (`[class*="text-2xl"]`) that quietly drift
-    // when CardContent / CardHeader markup changes.
-    const labels: Array<{ label: string; key: 'cash' | 'card' | 'transfer' }> =
-      [
-        { label: 'Cash tips', key: 'cash' },
-        { label: 'POS / Card tips', key: 'card' },
-        { label: 'Transfer tips', key: 'transfer' },
-      ];
-
-    const all = Array.from(grid.querySelectorAll('*')) as HTMLElement[];
-    for (const { label, key } of labels) {
-      // Locate the element whose own textContent (excluding children
-      // we'd over-greedily inherit from parents) STARTS with the label.
-      const titleEl = all.find((el) => {
-        const txt = (el.textContent ?? '').trim();
-        return txt === label || txt.startsWith(label + '\n');
-      });
-      if (!titleEl) continue;
-      // The amount lives in a sibling element of the title's CardHeader,
-      // i.e. inside the parent Card. Walk up until we find an ancestor
-      // containing a ₦ amount text.
-      let node: HTMLElement | null = titleEl.parentElement;
-      while (node && node !== grid) {
-        const amount = parseNGN(node.textContent ?? '');
-        // Reject the section-wide total ("₦300 total") — that text
-        // includes the word "total" or "tip"; the per-card amount does
-        // NOT include "total".
-        // The section heading h3 reads "Tips Received \n ₦300.00 total"
-        // — only digits/commas/dots/whitespace between ₦ and "total". A
-        // per-card subtitle reads "100.0% of total tips" — non-digit
-        // chars between ₦ and "total". Discriminate by requiring the
-        // section-total shape so per-card subtitle text doesn't falsely
-        // reject the card's own amount.
-        if (
-          amount != null &&
-          !/₦[\d,.\s]+\s*total/i.test(node.textContent ?? '') &&
-          // Don't match an ancestor that contains MULTIPLE labels
-          // (i.e. wrapped grid containing all cards).
-          !labels.some(
-            (l) =>
-              l.label !== label && (node?.textContent ?? '').includes(l.label)
-          )
-        ) {
-          result[key] = amount;
-          break;
-        }
-        node = node.parentElement;
-      }
-    }
-    return result;
-  });
-}
-
-async function openTodayReport(page: Page) {
-  await page.goto('/dashboard/reports/daily');
-  await page.waitForLoadState('networkidle');
-  await page.getByRole('button', { name: 'Today' }).click();
-  await page.waitForLoadState('networkidle');
-  await page
-    .getByText('Generating report...')
-    .waitFor({ state: 'hidden', timeout: 15000 })
-    .catch(() => {});
-}
-
-test.describe.serial('REQ-035: close-tab tip capture', () => {
-  let baselineCashTips = 0;
-  // Shared flag — AC2 silently `test.skip`s when UAT has no open tab to
-  // close. The Daily Report still renders a "Tips Received" heading
-  // regardless, so AC7's existing heading-based skip fallback can't tell
-  // the difference between "AC2 was skipped" and "AC2 ran but the tip
-  // didn't land". AC7 then assertion-failed with `Received: 0` because
-  // baseline stayed at the AC2-init value. Use a positive flag so AC7
-  // only asserts when AC2 actually closed a tab.
-  let tabClosedInThisRun = false;
+test.describe('REQ-035: close-tab tip capture', () => {
   const TIP = 250;
+  let closedTabId: string | null = null;
+  let closingRowAddedIndex: number | null = null;
 
   test.beforeEach(async ({ page }, testInfo) => {
     if (!(await isAuthenticated(page))) {
@@ -145,9 +52,45 @@ test.describe.serial('REQ-035: close-tab tip capture', () => {
     }
   });
 
-  test('AC2 — close an open tab with a cash tip', async ({ page }) => {
-    await openTodayReport(page);
-    baselineCashTips = (await readTipsBreakdown(page)).cash;
+  test.afterEach(async () => {
+    // Restore the tab to `open` status + remove the closing partial-
+    // payment row this test added. Keeps the seeded open-tab fixture
+    // available for subsequent runs (retry / schedule / dispatch).
+    if (closedTabId && closingRowAddedIndex !== null) {
+      const tabId = closedTabId;
+      const addedIndex = closingRowAddedIndex;
+      await withMongo(async (db) => {
+        const { ObjectId } = await import('mongodb');
+        const tab = await db
+          .collection('tabs')
+          .findOne({ _id: new ObjectId(tabId) });
+        if (!tab) return;
+        const updatedPartials = (tab.partialPayments || []).filter(
+          (_: unknown, i: number) => i !== addedIndex
+        );
+        await db.collection('tabs').updateOne(
+          { _id: new ObjectId(tabId) },
+          {
+            $set: {
+              status: 'open',
+              paymentStatus: 'unpaid',
+              partialPayments: updatedPartials,
+            },
+            $unset: { paidAt: '', closedAt: '', paymentReference: '' },
+          }
+        );
+      }).catch(() => {
+        /* idempotent — best-effort */
+      });
+      closedTabId = null;
+      closingRowAddedIndex = null;
+    }
+  });
+
+  test('AC2 — close an open tab with a ₦250 cash tip; partialPayments row persists with paymentType:cash + tipAmount:250', async ({
+    page,
+  }) => {
+    const since = new Date();
 
     await page.goto('/dashboard/orders/tabs');
     await page.waitForLoadState('networkidle');
@@ -181,28 +124,30 @@ test.describe.serial('REQ-035: close-tab tip capture', () => {
     // Submit close-tab.
     const submit = page.getByRole('button', { name: /Pay ₦.*Close Tab/i });
     await submit.click();
-
-    // Toast / refresh.
     await page.waitForLoadState('networkidle');
-    // Mark the tab as actually closed only after the submit completes;
-    // AC7 reads this to decide whether to assert or skip.
-    tabClosedInThisRun = true;
-  });
 
-  test('AC7 — Daily Report Tips Received cash card increased', async ({
-    page,
-  }) => {
-    // If AC2 silent-skipped (no open tab on UAT), there's no tip to
-    // verify — skip rather than fail with `Received: 0`.
-    test.skip(
-      !tabClosedInThisRun,
-      'AC2 was skipped (no open tab to close) — nothing to assert in AC7'
+    // Direct DB assertion — find the tab that was closed after `since`
+    // whose partialPayments include a row with our tip + paymentType.
+    const tab = await findRecentTabWithTip({
+      since,
+      tipAmount: TIP,
+      paymentType: 'cash',
+    });
+    expect(tab).toBeTruthy();
+    expect(tab.status).toBe('closed');
+    expect(tab.paymentStatus).toBe('paid');
+
+    // Record the closing-row index for afterEach cleanup. The closing
+    // row was the LAST partialPayment added.
+    const partials = tab.partialPayments as Array<{
+      tipAmount?: number;
+      paymentType: string;
+    }>;
+    const closingRowIndex = partials.findIndex(
+      (p) => p.tipAmount === TIP && p.paymentType === 'cash'
     );
-
-    await openTodayReport(page);
-    const heading = page.locator('h3').filter({ hasText: /Tips Received/i });
-    await expect(heading).toBeVisible({ timeout: 15000 });
-    const { cash } = await readTipsBreakdown(page);
-    expect(cash - baselineCashTips).toBeGreaterThanOrEqual(TIP);
+    expect(closingRowIndex).toBeGreaterThanOrEqual(0);
+    closedTabId = String(tab._id);
+    closingRowAddedIndex = closingRowIndex;
   });
 });

--- a/e2e/critical/daily-report-payments.spec.ts
+++ b/e2e/critical/daily-report-payments.spec.ts
@@ -275,17 +275,37 @@ test.describe
     const cardDelta = updated.card - baseline.card;
     const totalDelta = updated.totalRevenue - baseline.totalRevenue;
 
-    // Partial payment (cash) must appear in Cash column
-    expect(cashDelta).toBe(partialAmount);
+    // Relaxed to `>=` per #352: the strict-equality version was the
+    // load-bearing #336 release-blocker. A retried serial-describe block
+    // re-created the tab + payments, doubling each value, and
+    // `.toBe(partialAmount)` failed with `cashDelta=1224 vs 612`. The
+    // critical project now sets `retries: 0` (see playwright.config.ts)
+    // so within-run doubling can't happen, but concurrent runs (cron +
+    // PR + dispatch all firing on the same day) can still contribute to
+    // the aggregate. The deterministic no-double-counting proof lives
+    // at `__tests__/services/financial-report-service.partial-payment-no-double-count.test.ts`;
+    // this E2E proves the bill/payment writes land on the UI flow.
+    expect(cashDelta).toBeGreaterThanOrEqual(partialAmount);
+    expect(cardDelta).toBeGreaterThanOrEqual(finalAmount);
+    expect(totalDelta).toBeGreaterThanOrEqual(tabTotal);
 
-    // Final payment (card) must appear in POS / Card column
-    expect(cardDelta).toBe(finalAmount);
-
-    // Total revenue must increase by exactly the tab total — no double-counting
-    expect(totalDelta).toBe(tabTotal);
-
-    // Cross-check: partial + final = tab total
+    // Cross-check: partial + final = tab total (deterministic — not a
+    // delta against the report, just basic arithmetic).
     expect(partialAmount + finalAmount).toBe(tabTotal);
+  });
+
+  // Cleanup the tab + its orders so subsequent runs (schedule, dispatch,
+  // or another PR) don't see this tab's contribution in their baselines.
+  // See SDLC/test-isolation.md.
+  test.afterAll(async () => {
+    if (tabId) {
+      try {
+        const { deleteTabById } = await import('../helpers/db-assertions');
+        await deleteTabById(tabId);
+      } catch {
+        /* best-effort cleanup */
+      }
+    }
   });
 });
 
@@ -440,5 +460,18 @@ test.describe
     // REQ-017: Total Revenue must also include partial payments
     // (totalRevenue = paymentBreakdown.total, not item-based)
     expect(totalDelta).toBeGreaterThanOrEqual(openPartialAmount);
+  });
+
+  // Cleanup the open tab + its orders so subsequent runs don't see this
+  // tab's partial payment in their baselines. See SDLC/test-isolation.md.
+  test.afterAll(async () => {
+    if (openTabId) {
+      try {
+        const { deleteTabById } = await import('../helpers/db-assertions');
+        await deleteTabById(openTabId);
+      } catch {
+        /* best-effort cleanup */
+      }
+    }
   });
 });

--- a/e2e/critical/express-tip-capture.spec.ts
+++ b/e2e/critical/express-tip-capture.spec.ts
@@ -2,27 +2,36 @@
  * @requirement REQ-035 — Tip recording at express checkout
  *
  * Verifies that the express create-order flow captures a tip and the
- * tip's payment method independently, and that the resulting Order
- * persists both fields.
+ * tip's payment method INDEPENDENTLY of the bill's payment method, and
+ * that the resulting Order persists both fields.
  *
- * The test exercises the realistic case the feature targets: customer
- * pays card while leaving a cash tip. Asserts the Daily Financial
- * Report's new "Tips Received" section shows the tip under the cash
- * bucket — independent of where the bill itself was attributed.
+ * Exercise scenario: customer pays card while leaving a cash tip.
  *
- * Skips gracefully if admin auth state isn't present (CI without seeded
- * admin credentials, or local dev without the auth.setup having run).
+ * Retry-safe assertion model (#352): instead of asserting on a daily-
+ * report aggregate delta (which retry-doubles when describe.serial
+ * blocks re-run after a failure), captures a timestamp before the UI
+ * flow and queries Mongo directly for the order with the exact
+ * (tipAmount + tipPaymentMethod + paymentMethod) shape created after
+ * that timestamp. The aggregation correctness is unit-tested at
+ * `__tests__/services/financial-report-service.tip.test.ts`.
+ *
+ * Cleanup in afterEach deletes the captured order — subsequent runs
+ * (retry, schedule, dispatch) start from a deterministic state.
+ *
+ * See SDLC/test-isolation.md for the contract.
  */
 import { test as base, expect, Page } from '@playwright/test';
 import path from 'path';
+import {
+  findRecentOrderWithTip,
+  deleteOrderById,
+} from '../helpers/db-assertions';
 
 const ADMIN_FILE = path.join(__dirname, '../../.auth/admin.json');
 
 const test = base.extend({
   storageState: ADMIN_FILE,
 });
-
-test.describe.configure({ mode: 'serial' });
 
 async function isAuthenticated(page: Page): Promise<boolean> {
   try {
@@ -34,87 +43,9 @@ async function isAuthenticated(page: Page): Promise<boolean> {
   }
 }
 
-async function readTipsBreakdown(page: Page): Promise<{
-  total: number;
-  cash: number;
-  card: number;
-  transfer: number;
-}> {
-  return page.evaluate(() => {
-    const result = { total: 0, cash: 0, card: 0, transfer: 0 };
-
-    const parseNGN = (s: string): number | null => {
-      const m = s.match(/(?:₦|NGN)\s*([\d,]+(?:\.\d+)?)/);
-      return m ? parseFloat(m[1].replace(/,/g, '')) : null;
-    };
-
-    const sectionHeading = Array.from(document.querySelectorAll('h3')).find(
-      (h) => /Tips Received/i.test(h.textContent ?? '')
-    );
-    if (!sectionHeading) return result;
-    const totalAmount = parseNGN(sectionHeading.textContent ?? '');
-    if (totalAmount != null) result.total = totalAmount;
-
-    const grid = sectionHeading.nextElementSibling;
-    if (!grid) return result;
-
-    // Same robust strategy as the close-tab-tip-capture sibling spec:
-    // find the title element by its known text + walk up its ancestor
-    // chain to the nearest container with a ₦amount that doesn't also
-    // mention "total" (the section-wide total).
-    const labels: Array<{ label: string; key: 'cash' | 'card' | 'transfer' }> =
-      [
-        { label: 'Cash tips', key: 'cash' },
-        { label: 'POS / Card tips', key: 'card' },
-        { label: 'Transfer tips', key: 'transfer' },
-      ];
-
-    const all = Array.from(grid.querySelectorAll('*')) as HTMLElement[];
-    for (const { label, key } of labels) {
-      const titleEl = all.find((el) => {
-        const txt = (el.textContent ?? '').trim();
-        return txt === label || txt.startsWith(label + '\n');
-      });
-      if (!titleEl) continue;
-      let node: HTMLElement | null = titleEl.parentElement;
-      while (node && node !== grid) {
-        const amount = parseNGN(node.textContent ?? '');
-        // Discriminate the section-wide total (h3 reads "Tips Received
-        // ₦300.00 total") from the per-card amount whose subtitle reads
-        // "100.0% of total tips" by requiring the section-total shape
-        // (only digits/commas/dots/whitespace between ₦ and "total").
-        if (
-          amount != null &&
-          !/₦[\d,.\s]+\s*total/i.test(node.textContent ?? '') &&
-          !labels.some(
-            (l) =>
-              l.label !== label && (node?.textContent ?? '').includes(l.label)
-          )
-        ) {
-          result[key] = amount;
-          break;
-        }
-        node = node.parentElement;
-      }
-    }
-    return result;
-  });
-}
-
-async function openTodayReport(page: Page) {
-  await page.goto('/dashboard/reports/daily');
-  await page.waitForLoadState('networkidle');
-  await page.getByRole('button', { name: 'Today' }).click();
-  await page.waitForLoadState('networkidle');
-  await page
-    .getByText('Generating report...')
-    .waitFor({ state: 'hidden', timeout: 15000 })
-    .catch(() => {});
-}
-
-test.describe.serial('REQ-035: express order tip capture', () => {
-  let baselineCashTips = 0;
+test.describe('REQ-035: express order tip capture', () => {
   const TIP = 500;
+  let createdOrderId: string | null = null;
 
   test.beforeEach(async ({ page }, testInfo) => {
     if (!(await isAuthenticated(page))) {
@@ -122,15 +53,22 @@ test.describe.serial('REQ-035: express order tip capture', () => {
     }
   });
 
-  test('AC7 baseline — read current cash-tip total', async ({ page }) => {
-    await openTodayReport(page);
-    const { cash } = await readTipsBreakdown(page);
-    baselineCashTips = cash;
+  test.afterEach(async () => {
+    if (createdOrderId) {
+      await deleteOrderById(createdOrderId).catch(() => {
+        /* idempotent cleanup — best-effort */
+      });
+      createdOrderId = null;
+    }
   });
 
-  test('AC1 + AC4 — record ₦500 cash tip on a card-paid express order', async ({
+  test('AC1 + AC4 — ₦500 cash tip on a card-paid express order persists with tipPaymentMethod:cash, paymentMethod:card', async ({
     page,
   }) => {
+    // Capture timestamp BEFORE the UI flow so the DB query that runs
+    // after creation can scope to "the order I just created".
+    const since = new Date();
+
     await page.goto('/dashboard/orders/express/create-order');
     await page.waitForLoadState('networkidle');
 
@@ -153,22 +91,16 @@ test.describe.serial('REQ-035: express order tip capture', () => {
     await expect(posBtn).toBeVisible({ timeout: 5000 });
     await posBtn.click();
 
-    // Enter the tip amount and override the method to cash.
+    // Enter the tip amount and override the tip method to cash.
     const tipInput = page.locator('#tip-amount');
     await expect(tipInput).toBeVisible();
     await tipInput.fill(String(TIP));
+
     // Tip method dropdown defaults to the bill method (POS / 'card');
-    // override to 'cash' to exercise AC4.
-    //
-    // The previous locator was `[id="tip-amount"] ~ * button` (CSS general-
-    // sibling), but `#tip-amount` is the <Input> itself, and the Select
-    // trigger button is a sibling of the input's *parent* div in the
-    // TipInputRow grid (components/features/orders/tip-input-row.tsx). The
-    // locator matched 0 elements, `isVisible()` returned false, the
-    // `if`-fallback silently skipped the override, the tip recorded under
-    // the bill's method (card), and AC7 read 0 cash tips. Use a
-    // document-order XPath to find the first combobox after the input, and
-    // fail loudly if the override path is missing.
+    // override to 'cash' to exercise AC4. Document-order XPath finds
+    // the first combobox after the tip input — fails loudly if the
+    // override path moves so we catch the regression before the test
+    // silently records the tip under the bill's method.
     const tipMethodTrigger = page
       .locator('#tip-amount')
       .locator('xpath=following::button[@role="combobox"][1]');
@@ -185,17 +117,20 @@ test.describe.serial('REQ-035: express order tip capture', () => {
 
     await page.waitForURL(/\/dashboard\/orders/, { timeout: 15000 });
     await page.waitForLoadState('networkidle');
-  });
 
-  test('AC7 — Daily Report Tips Received cash card increased by ₦500', async ({
-    page,
-  }) => {
-    await openTodayReport(page);
-    await expect(
-      page.locator('h3').filter({ hasText: /Tips Received/i })
-    ).toBeVisible({ timeout: 15000 });
-    const { cash, total } = await readTipsBreakdown(page);
-    expect(cash - baselineCashTips).toBeGreaterThanOrEqual(TIP);
-    expect(total).toBeGreaterThanOrEqual(cash);
+    // Direct DB assertion — retry-safe and concurrency-safe.
+    const order = await findRecentOrderWithTip({
+      since,
+      tipAmount: TIP,
+      tipPaymentMethod: 'cash',
+      paymentMethod: 'card',
+    });
+    expect(order).toBeTruthy();
+    expect(order.tipAmount).toBe(TIP);
+    expect(order.tipPaymentMethod).toBe('cash');
+    expect(order.paymentMethod).toBe('card');
+    expect(order.paymentStatus).toBe('paid');
+
+    createdOrderId = String(order._id);
   });
 });

--- a/e2e/helpers/db-assertions.ts
+++ b/e2e/helpers/db-assertions.ts
@@ -1,0 +1,207 @@
+/**
+ * Direct DB query helpers — replacement for daily-report-delta assertions.
+ *
+ * Pattern adopted per #352: critical-tier specs that previously asserted
+ * "daily report aggregate after X = baseline + X" suffered retry-doubling
+ * when their `describe.serial` blocks failed partway and re-ran (each
+ * iteration's DB writes accumulated into the global aggregate). The fix
+ * is to drop the aggregate-delta assertion in favour of:
+ *
+ *   1. Direct DB queries for the specific entity the test created
+ *      (orderNumber / tabId / paidAt-since-timestamp + tipAmount).
+ *   2. Cleanup of that entity in `afterEach` so the next attempt starts
+ *      from a deterministic state.
+ *
+ * The aggregation logic (daily report sums) is unit-tested separately at
+ * `__tests__/services/financial-report-service.partial-payment-no-double-count.test.ts`
+ * + `financial-report-service.tip.test.ts`, so we don't lose coverage —
+ * we move the aggregation correctness check to a layer that doesn't
+ * depend on shared CI Mongo state.
+ *
+ * See SDLC/test-isolation.md for the contract + worked examples.
+ */
+import { MongoClient, ObjectId } from 'mongodb';
+
+export interface MongoConn {
+  uri: string;
+  dbName: string;
+}
+
+export function mongoConn(): MongoConn {
+  return {
+    uri:
+      process.env.MONGODB_URI ||
+      process.env.MONGODB_WAWAGARDENBAR_APP_URI ||
+      'mongodb://localhost:27017',
+    dbName: process.env.MONGODB_DB_NAME || 'wawagardenbar_test',
+  };
+}
+
+/**
+ * Run a block of work inside a Mongo client lifecycle. Connects, runs,
+ * closes the client even on error.
+ */
+export async function withMongo<T>(work: (db: any) => Promise<T>): Promise<T> {
+  const conn = mongoConn();
+  const client = new MongoClient(conn.uri);
+  try {
+    await client.connect();
+    return await work(client.db(conn.dbName));
+  } finally {
+    await client.close();
+  }
+}
+
+/**
+ * Poll a Mongo query until it returns a non-null result or the timeout
+ * elapses. Used after a UI flow that creates a record asynchronously,
+ * where the test needs to find THAT record (not just "some matching
+ * record exists in the day's aggregate").
+ *
+ * Returns the first matching document, or null on timeout.
+ */
+export async function pollForDoc<T = any>(
+  collection: string,
+  filter: Record<string, unknown>,
+  options?: { timeoutMs?: number; intervalMs?: number }
+): Promise<T | null> {
+  const timeoutMs = options?.timeoutMs ?? 5000;
+  const intervalMs = options?.intervalMs ?? 200;
+  const deadline = Date.now() + timeoutMs;
+  return withMongo(async (db) => {
+    while (Date.now() < deadline) {
+      const doc = await db.collection(collection).findOne(filter);
+      if (doc) return doc as T;
+      await new Promise((r) => setTimeout(r, intervalMs));
+    }
+    return null;
+  });
+}
+
+/**
+ * Find an Order created (paidAt) after `since` matching the given
+ * tip / payment-method shape. Returns the first match — assumes the
+ * test's parameters are distinctive enough that only ONE recent order
+ * matches.
+ *
+ * Use this in place of "daily-report tipsBreakdown.cash delta = TIP"
+ * assertions. The aggregation is unit-tested separately.
+ */
+export async function findRecentOrderWithTip(opts: {
+  since: Date;
+  tipAmount: number;
+  tipPaymentMethod?: 'cash' | 'card' | 'transfer';
+  paymentMethod?: 'cash' | 'card' | 'transfer';
+  timeoutMs?: number;
+}): Promise<any | null> {
+  const filter: Record<string, unknown> = {
+    paidAt: { $gte: opts.since },
+    tipAmount: opts.tipAmount,
+  };
+  if (opts.tipPaymentMethod !== undefined) {
+    filter.tipPaymentMethod = opts.tipPaymentMethod;
+  }
+  if (opts.paymentMethod !== undefined) {
+    filter.paymentMethod = opts.paymentMethod;
+  }
+  return pollForDoc('orders', filter, { timeoutMs: opts.timeoutMs ?? 8000 });
+}
+
+/**
+ * Find a Tab closed (closedAt) after `since` whose partialPayments
+ * include a row with the given tipAmount + paymentType. Use in place of
+ * close-tab tip aggregate-delta assertions.
+ */
+export async function findRecentTabWithTip(opts: {
+  since: Date;
+  tipAmount: number;
+  paymentType: 'cash' | 'card' | 'transfer';
+  timeoutMs?: number;
+}): Promise<any | null> {
+  return pollForDoc(
+    'tabs',
+    {
+      closedAt: { $gte: opts.since },
+      partialPayments: {
+        $elemMatch: {
+          tipAmount: opts.tipAmount,
+          paymentType: opts.paymentType,
+        },
+      },
+    },
+    { timeoutMs: opts.timeoutMs ?? 8000 }
+  );
+}
+
+/**
+ * Find an Order paid after `since` with the given total + paymentMethod.
+ * Used by revenue-tracking specs to find the order they just created
+ * (without depending on a daily-report aggregate).
+ */
+export async function findRecentPaidOrder(opts: {
+  since: Date;
+  total: number;
+  paymentMethod: 'cash' | 'card' | 'transfer';
+  timeoutMs?: number;
+}): Promise<any | null> {
+  return pollForDoc(
+    'orders',
+    {
+      paidAt: { $gte: opts.since },
+      total: opts.total,
+      paymentMethod: opts.paymentMethod,
+      paymentStatus: 'paid',
+    },
+    { timeoutMs: opts.timeoutMs ?? 8000 }
+  );
+}
+
+/**
+ * Delete an Order by _id (cleanup helper for afterEach / afterAll).
+ * Idempotent — safe to call even if the order has already been removed.
+ */
+export async function deleteOrderById(
+  orderId: string | ObjectId
+): Promise<void> {
+  await withMongo(async (db) => {
+    const _id = typeof orderId === 'string' ? new ObjectId(orderId) : orderId;
+    await db.collection('orders').deleteOne({ _id });
+  });
+}
+
+/**
+ * Delete a Tab by _id (cleanup helper for afterEach / afterAll).
+ * Cascades to orders attached to the tab to prevent orphans.
+ */
+export async function deleteTabById(tabId: string | ObjectId): Promise<void> {
+  await withMongo(async (db) => {
+    const _id = typeof tabId === 'string' ? new ObjectId(tabId) : tabId;
+    const tab = await db.collection('tabs').findOne({ _id });
+    if (tab?.orders?.length) {
+      await db.collection('orders').deleteMany({
+        _id: { $in: tab.orders.map((id: any) => new ObjectId(String(id))) },
+      });
+    }
+    await db.collection('tabs').deleteOne({ _id });
+  });
+}
+
+/**
+ * Delete all Orders whose `paymentReference` matches the given prefix.
+ * Useful for bulk-cleanup of test-prefixed payment references like
+ * `E2E-POS-${Date.now()}` or `REQ035-TIP-TEST`.
+ */
+export async function deleteOrdersByReferencePrefix(
+  prefix: string
+): Promise<number> {
+  return withMongo(async (db) => {
+    const result = await db
+      .collection('orders')
+      .deleteMany({ paymentReference: { $regex: `^${escapeRegExp(prefix)}` } });
+    return result.deletedCount ?? 0;
+  });
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -64,6 +64,19 @@ export default defineConfig({
     // Selects e2e/smoke/ + e2e/critical/ + the cross-REQ verification spec.
     // ~10-15 min wall-clock target per the 3-tier model (devaudit v0.1.53,
     // see SDLC/Test_Strategy.md § "E2E gating model — three tiers").
+    //
+    // `retries: 0` is load-bearing per #352: the retry-amplification of
+    // `describe.serial` blocks that write to the DB (create tab + record
+    // partial payment + close tab → daily-report-delta assertions) was
+    // the load-bearing #336 release-blocker. A retried serial group re-
+    // creates DB state, doubling the contribution to aggregate
+    // assertions. The critical tier's specs are refactored to use direct
+    // entity assertions (see SDLC/test-isolation.md) so they don't need
+    // retries to be reliable. Transient flakes manifest as a single PR-
+    // gate failure that the operator manually reruns — accepted trade for
+    // eliminating the spurious-doubling class entirely. Regression tier
+    // keeps `retries: 2` (top-level config) because the post-merge auto-
+    // issue safety net handles its noise.
     {
       name: 'critical',
       use: { ...devices['Desktop Chrome'] },
@@ -72,6 +85,7 @@ export default defineConfig({
         /e2e\/critical\/.*\.spec\.ts$/,
         /requirements-verification\.spec\.ts$/,
       ],
+      retries: 0,
       dependencies: ['auth-setup'],
     },
     // Regression — the full suite (smoke + critical + every authenticated


### PR DESCRIPTION
## Summary

Closes #352 — UAT shared-state pollution amplified by Playwright `serial`-describe retries. The load-bearing #336 release-blocker was a retry chain that re-created DB state inside `describe.serial` blocks, doubling the contribution to aggregate assertions (`cashDelta=1224, expected=612` — exactly 2×).

This PR adopts a **four-layer defense** documented in `SDLC/test-isolation.md`:

| Layer | Mechanism | Where applied |
|---|---|---|
| **1** | `retries: 0` on the `critical` Playwright project | `playwright.config.ts` (foundation — eliminates within-run retry-doubling entirely) |
| **2** | Entity-specific DB queries replacing daily-report-aggregate deltas | `express-tip-capture.spec.ts`, `close-tab-tip-capture.spec.ts` |
| **3** | Relaxed `>=` assertions for revenue-reporting E2Es (strict math moves to unit tests) | `daily-report-payments.spec.ts` (3 strict `.toBe()` → `.toBeGreaterThanOrEqual()`) |
| **4** | `afterAll` cleanup of test-created entities | `daily-report-payments.spec.ts` (both serial blocks) |

## Why four layers (cheapest first)

Layer 1 alone fixes within-run retry-doubling — the actual #336 trigger. But same-day concurrent runs (cron + PR + dispatch) can still contribute to the same daily aggregate. Layer 2 (DB queries scoped to `paidAt >= since`) is **concurrency-safe**. Layer 3 (`>=`) keeps integration coverage of "the report includes my payment" while the strict no-double-counting check moves to the unit-test layer (pinned at #353). Layer 4 (cleanup) is hygiene — bounds residue load on shared CI Mongo.

## Files changed

| File | Why |
|---|---|
| `playwright.config.ts` | `retries: 0` on `critical` project + ~10 lines of rationale comment |
| **`e2e/helpers/db-assertions.ts`** (new, 207 lines) | `findRecentOrderWithTip` / `findRecentTabWithTip` / `findRecentPaidOrder` / `deleteOrderById` / `deleteTabById` / `deleteOrdersByReferencePrefix` / `pollForDoc` / `withMongo` |
| **`e2e/critical/express-tip-capture.spec.ts`** | Rewritten Layer 2 — 3 tests → 1 test, entity-specific DB assertion, `afterEach` cleanup |
| **`e2e/critical/close-tab-tip-capture.spec.ts`** | Rewritten Layer 2 — 2 tests → 1 test, entity-specific DB assertion, `afterEach` *restores* the open-tab fixture (cleanup that preserves the seed) |
| `e2e/critical/daily-report-payments.spec.ts` | Layer 3 + Layer 4 — relaxed 3 strict `.toBe()` to `.toBeGreaterThanOrEqual()` with rationale comment + `afterAll` cleanup for both serial blocks |
| **`SDLC/test-isolation.md`** (new, 185 lines) | The contract — all four layers, helper reference, anti-patterns, where each layer applies in the 3-tier model |

## Out of scope (intentional)

- **`express-order-report.spec.ts`** (6 serial blocks) and **`dashboard-revenue.spec.ts`** (1 serial block) — already use `>=` assertions, so are retry-safe via Layers 1+3. Cleanup is hygiene-only; deferred as follow-up if residue load becomes an issue.
- **Refactor of regression-tier specs** — per the 3-tier model's cost philosophy, those have the post-merge auto-issue safety net; operator triages each on its own merit. This contract is mandatory for critical-tier but only recommended for regression-tier.

## Verification

```
npx tsc --noEmit                                     → clean
npx playwright test --project=critical --list        → 254 tests in 28 files
                                                       (was 257 — minus 3 from consolidating tip-capture
                                                        multi-test patterns into single tests per Layer 2)
```

## Risk

**MEDIUM** — changes release-gating spec assertions. Mitigation:
- Layer 1 alone is a 1-line change that demonstrably eliminates the #336 failure class
- Layer 2 specs assert on stronger contracts (the actual REQ-035 fields) than the deltas they replaced
- Layer 3 specs keep the integration shape proof; strict math is unit-tested
- Layer 4 cleanup is best-effort wrapped in catch — cleanup failure never fails the spec

## Refs

- Issue [#352](https://github.com/metasession-dev/wawagardenbar-app/issues/352) — the motivating bug (closes via this PR)
- PR [#336](https://github.com/metasession-dev/wawagardenbar-app/pull/336) — REQ-076 release that surfaced this
- PR [#353](https://github.com/metasession-dev/wawagardenbar-app/pull/353) — the unit-test pin that lets the E2E drop the strict no-double-counting check
- PR [#361](https://github.com/metasession-dev/wawagardenbar-app/pull/361) — 3-tier adoption (this PR is the critical-tier hardening that pairs with it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)