### PR TITLE
fix(admin): [REQ-081] bypass category picker when search query typed at step 1

### DIFF
--- a/components/features/admin/category-cascade-filter.tsx
+++ b/components/features/admin/category-cascade-filter.tsx
@@ -100,32 +100,35 @@ export function CategoryCascadeFilter({
         data-testid="category-cascade"
         className="space-y-3 rounded-lg border bg-muted/20 p-4"
       >
-        {renderSearchInput('Search main categories...')}
-        <div>
-          <p className="text-sm font-medium">Main Menu Categories</p>
-          <p className="text-xs text-muted-foreground">
-            Choose a main category to continue.
-          </p>
-        </div>
-        <div
-          data-testid="category-cascade-main-options"
-          className="flex flex-wrap gap-2"
-        >
-          {filteredMainCategories.map((category) => (
-            <Button
-              key={category.slug}
-              variant="outline"
-              size="sm"
-              onClick={() => onMainCategoryChange(category.slug)}
+        {renderSearchInput(
+          normalizedSearchQuery
+            ? 'Search menu items...'
+            : 'Search main categories...'
+        )}
+        {!normalizedSearchQuery && (
+          <>
+            <div>
+              <p className="text-sm font-medium">Main Menu Categories</p>
+              <p className="text-xs text-muted-foreground">
+                Choose a main category to continue.
+              </p>
+            </div>
+            <div
+              data-testid="category-cascade-main-options"
+              className="flex flex-wrap gap-2"
             >
-              {category.label}
-            </Button>
-          ))}
-        </div>
-        {filteredMainCategories.length === 0 && (
-          <div className="rounded-md border border-dashed p-3 text-sm text-muted-foreground">
-            No main categories match your search.
-          </div>
+              {filteredMainCategories.map((category) => (
+                <Button
+                  key={category.slug}
+                  variant="outline"
+                  size="sm"
+                  onClick={() => onMainCategoryChange(category.slug)}
+                >
+                  {category.label}
+                </Button>
+              ))}
+            </div>
+          </>
         )}
       </div>
     );


### PR DESCRIPTION
## Summary

Follow-up fix to PR #390. When a user types a search query before selecting any main category, the category buttons are now hidden and the search fires across all available menu items. Clearing the query restores the category picker.

**Root cause:** `CategoryCascadeFilter` was always rendering category-label filter UI at step 1, even when a `normalizedSearchQuery` was present. The AC11 server/filter changes in #390 only applied once a sub-category was already selected.

## Risk

**LOW** — single component, pure UI rendering change. No auth, payment, schema, or permission changes. Self-merge permitted after CI passes.

## Change

- `components/features/admin/category-cascade-filter.tsx` — at step 1 (no main category selected), category buttons and heading are hidden when `normalizedSearchQuery` is non-empty; placeholder updates to 'Search menu items...'

## Ref

Ref: REQ-081