### PR TITLE
fix(admin): [REQ-081] allow express item browsing during cross-category search

### DIFF
--- a/app/dashboard/orders/express/create-order/page.tsx
+++ b/app/dashboard/orders/express/create-order/page.tsx
@@ -273,7 +273,9 @@ function ExpressCreateOrderContent() {
   const selectedMain =
     mainCategories.find((category) => category.slug === selectedMainCategory) ??
     null;
-  const canBrowseItems = Boolean(selectedMainCategory && selectedCategory);
+  const canBrowseItems = Boolean(
+    (selectedMainCategory && selectedCategory) || searchQuery.trim()
+  );
 
   async function handleSubmit() {
     if (cart.length === 0) return;
@@ -465,7 +467,9 @@ function ExpressCreateOrderContent() {
               {menuItems.length === 0 && (
                 <p className="py-8 text-center text-muted-foreground">
                   {searchQuery
-                    ? 'No matching menu items were found in this sub category.'
+                    ? selectedCategory
+                      ? 'No matching menu items were found in this sub category.'
+                      : 'No matching menu items were found.'
                     : 'No available menu items were found in this sub category.'}
                 </p>
               )}


### PR DESCRIPTION
## Summary

Follow-up fix to PRs #390 and #391. Cross-category search on the express create-order page returned matching items from the server, but the page never rendered them because the `canBrowseItems` gate required **both** a main and sub category to be selected.

## Root cause

The AC11 change (#390) fixed the `searchMenu` server-call guard, and #391 hid the category picker when a query is typed — but the express page's render gate was missed:

```ts
const canBrowseItems = Boolean(selectedMainCategory && selectedCategory);
```

With no category selected, this stayed `false`, so the page showed 'Choose a main category to start browsing menu items' instead of the search results.

## Change

- `app/dashboard/orders/express/create-order/page.tsx`:
  - `canBrowseItems` now also returns true when a non-empty `searchQuery` is present
  - empty-state message generalised to 'No matching menu items were found.' when no sub-category is selected

## Risk

**LOW** — single page, render-gate logic only. No auth, payment, schema, or permission changes. Self-merge permitted after CI passes.

## Ref

Ref: REQ-081