### PR TITLE
test(e2e): [REQ-081] navigate category cascade in express critical specs

### DIFF
--- a/e2e/critical/dashboard-revenue.spec.ts
+++ b/e2e/critical/dashboard-revenue.spec.ts
@@ -14,6 +14,7 @@
  */
 import { test as base, expect, Page } from '@playwright/test';
 import path from 'path';
+import { revealFirstExpressMenuCard } from '../helpers/express-menu';
 
 const SUPER_ADMIN_FILE = path.join(__dirname, '../../.auth/super-admin.json');
 const ADMIN_FILE = path.join(__dirname, '../../.auth/admin.json');
@@ -159,8 +160,7 @@ adminTest.describe.serial(
       await page.goto('/dashboard/orders/express/create-order');
       await page.waitForLoadState('networkidle');
 
-      const menuCard = page.locator('.grid .cursor-pointer').first();
-      await expect(menuCard).toBeVisible({ timeout: 10000 });
+      const menuCard = await revealFirstExpressMenuCard(page);
       await menuCard.click();
 
       const checkoutBtn = page.getByRole('button', { name: /Checkout/i });

--- a/e2e/critical/express-order-report.spec.ts
+++ b/e2e/critical/express-order-report.spec.ts
@@ -15,6 +15,7 @@
  */
 import { test as base, expect, Page } from '@playwright/test';
 import path from 'path';
+import { revealFirstExpressMenuCard } from '../helpers/express-menu';
 
 const ADMIN_FILE = path.join(__dirname, '../../.auth/admin.json');
 
@@ -129,9 +130,8 @@ test.describe.serial('Express standalone order — Cash payment', () => {
     await page.goto('/dashboard/orders/express/create-order');
     await page.waitForLoadState('networkidle');
 
-    // Wait for menu grid and add first item
-    const menuCard = page.locator('.grid .cursor-pointer').first();
-    await expect(menuCard).toBeVisible({ timeout: 10000 });
+    // Reveal the menu grid via the REQ-081 category cascade, then add first item
+    const menuCard = await revealFirstExpressMenuCard(page);
 
     // Read the item price before adding
     const priceText = await menuCard.locator('.font-bold').last().textContent();
@@ -206,8 +206,7 @@ test.describe.serial('Express standalone order — POS payment', () => {
     await page.goto('/dashboard/orders/express/create-order');
     await page.waitForLoadState('networkidle');
 
-    const menuCard = page.locator('.grid .cursor-pointer').first();
-    await expect(menuCard).toBeVisible({ timeout: 10000 });
+    const menuCard = await revealFirstExpressMenuCard(page);
     await menuCard.click();
 
     const checkoutBtn = page.getByRole('button', { name: /Checkout/i });
@@ -276,8 +275,7 @@ test.describe.serial('Express standalone order — Transfer payment', () => {
     await page.goto('/dashboard/orders/express/create-order');
     await page.waitForLoadState('networkidle');
 
-    const menuCard = page.locator('.grid .cursor-pointer').first();
-    await expect(menuCard).toBeVisible({ timeout: 10000 });
+    const menuCard = await revealFirstExpressMenuCard(page);
     await menuCard.click();
 
     const checkoutBtn = page.getByRole('button', { name: /Checkout/i });
@@ -393,9 +391,8 @@ async function expressAddOrderToTab(
 ): Promise<number> {
   await page.waitForLoadState('networkidle');
 
-  // Menu items should already be loaded
-  const menuCard = page.locator('.grid .cursor-pointer').first();
-  await expect(menuCard).toBeVisible({ timeout: 10000 });
+  // Reveal the menu grid via the REQ-081 category cascade, then add first item
+  const menuCard = await revealFirstExpressMenuCard(page);
   await menuCard.click();
 
   const checkoutBtn = page.getByRole('button', { name: /Checkout/i });
@@ -700,8 +697,7 @@ test.describe.serial('Express tab with multiple orders — single close', () => 
     await page.waitForLoadState('networkidle');
 
     // Select menu item
-    const menuCard = page.locator('.grid .cursor-pointer').first();
-    await expect(menuCard).toBeVisible({ timeout: 10000 });
+    const menuCard = await revealFirstExpressMenuCard(page);
     await menuCard.click();
 
     // Add a second unit
@@ -796,8 +792,7 @@ test.describe('Express orders appear on orders page', () => {
     await page.goto('/dashboard/orders/express/create-order');
     await page.waitForLoadState('networkidle');
 
-    const menuCard = page.locator('.grid .cursor-pointer').first();
-    await expect(menuCard).toBeVisible({ timeout: 10000 });
+    const menuCard = await revealFirstExpressMenuCard(page);
     await menuCard.click();
 
     const checkoutBtn = page.getByRole('button', { name: /Checkout/i });

--- a/e2e/critical/express-tip-capture.spec.ts
+++ b/e2e/critical/express-tip-capture.spec.ts
@@ -26,6 +26,7 @@ import {
   findRecentOrderWithTip,
   deleteOrderById,
 } from '../helpers/db-assertions';
+import { revealFirstExpressMenuCard } from '../helpers/express-menu';
 
 const ADMIN_FILE = path.join(__dirname, '../../.auth/admin.json');
 
@@ -72,9 +73,8 @@ test.describe('REQ-035: express order tip capture', () => {
     await page.goto('/dashboard/orders/express/create-order');
     await page.waitForLoadState('networkidle');
 
-    // Pick the first menu item.
-    const menuCard = page.locator('.grid .cursor-pointer').first();
-    await expect(menuCard).toBeVisible({ timeout: 10000 });
+    // Pick the first menu item (walks the REQ-081 category cascade).
+    const menuCard = await revealFirstExpressMenuCard(page);
     await menuCard.click();
 
     // Proceed to checkout.

--- a/e2e/critical/reconciliation.spec.ts
+++ b/e2e/critical/reconciliation.spec.ts
@@ -10,6 +10,7 @@
  */
 import { test as base, expect, Page } from '@playwright/test';
 import path from 'path';
+import { revealFirstExpressMenuCard } from '../helpers/express-menu';
 
 const ADMIN_FILE = path.join(__dirname, '../../.auth/admin.json');
 
@@ -144,9 +145,8 @@ test.describe('REQ-014: Orders Page — Reconciliation', () => {
     await page.goto('/dashboard/orders/express/create-order');
     await page.waitForLoadState('networkidle');
 
-    // Wait for menu items to load and click the first card to add to cart
-    const menuCard = page.locator('.grid .cursor-pointer').first();
-    await expect(menuCard).toBeVisible({ timeout: 10000 });
+    // Reveal the menu grid via the REQ-081 category cascade, then add first item
+    const menuCard = await revealFirstExpressMenuCard(page);
     await menuCard.click();
 
     // The checkout button should appear (shows cart count)

--- a/e2e/helpers/express-menu.ts
+++ b/e2e/helpers/express-menu.ts
@@ -1,0 +1,58 @@
+/**
+ * @requirement REQ-081 - Main-category to sub-category cascade across express
+ * order entry. Shared helper so pre-cascade express specs can reveal the menu
+ * grid by walking the category cascade before selecting an item.
+ */
+import { expect, type Locator, type Page } from '@playwright/test';
+
+const MENU_CARD_SELECTOR = '.grid .cursor-pointer';
+
+/**
+ * Reveal the express create-order menu grid by walking the REQ-081 category
+ * cascade, then return the first available (in-stock) menu card.
+ *
+ * The express picker hides items until a main category and sub-category are
+ * selected. This helper tries each main -> sub path until available items
+ * render, mirroring the production cascade a staff member would use.
+ *
+ * @param page - Playwright page already navigated to the express create-order page
+ * @returns Locator for the first available menu card
+ * @throws If no category path yields an available menu item
+ */
+export async function revealFirstExpressMenuCard(page: Page): Promise<Locator> {
+  const menuCard = page.locator(MENU_CARD_SELECTOR).first();
+  if (await menuCard.isVisible().catch(() => false)) {
+    return menuCard;
+  }
+
+  await expect(page.getByTestId('category-cascade')).toBeVisible({
+    timeout: 10000,
+  });
+
+  const mainButtons = page
+    .getByTestId('category-cascade-main-options')
+    .getByRole('button');
+  const mainCount = await mainButtons.count();
+
+  for (let mainIndex = 0; mainIndex < mainCount; mainIndex += 1) {
+    await mainButtons.nth(mainIndex).click();
+    const subButtons = page
+      .getByTestId('category-cascade-sub-options')
+      .getByRole('button');
+    const subCount = await subButtons.count();
+
+    for (let subIndex = 0; subIndex < subCount; subIndex += 1) {
+      await subButtons.nth(subIndex).click();
+      if (await menuCard.isVisible({ timeout: 3000 }).catch(() => false)) {
+        return menuCard;
+      }
+      await page.getByRole('button', { name: 'Sub Categories' }).click();
+    }
+
+    await page.getByRole('button', { name: 'Main Categories' }).click();
+  }
+
+  throw new Error(
+    'No available express menu items were found in any category path'
+  );
+}

--- a/e2e/menu-customization-picker.spec.ts
+++ b/e2e/menu-customization-picker.spec.ts
@@ -12,6 +12,7 @@
 
 import { test as base, expect, Page } from '@playwright/test';
 import path from 'path';
+import { revealFirstExpressMenuCard } from './helpers/express-menu';
 
 const SUPER_ADMIN_FILE = path.join(__dirname, '../.auth/super-admin.json');
 
@@ -40,10 +41,11 @@ superAdminTest.describe('REQ-031: Customization picker — user journeys', () =>
       await page.goto('/dashboard/orders/express/create-order');
       await page.waitForLoadState('networkidle');
 
-      // Look for any menu-item card on the express page. Items with
-      // customization groups will open the picker dialog when clicked.
-      const cardsCount = await page.getByRole('button').count();
-      if (cardsCount === 0) {
+      // REQ-081 cascade: reveal the menu grid by walking the category
+      // cascade before searching for a card that opens the picker.
+      try {
+        await revealFirstExpressMenuCard(page);
+      } catch {
         testInfo.skip(true, 'No menu items found on UAT — skipping');
         return;
       }


### PR DESCRIPTION
## Summary

Fixes the E2E Regression failure on PR #393 (run 27678161216). The REQ-081 category cascade hides express menu items until a main and sub category are selected, but several critical-tier specs predated the cascade and assumed `.grid .cursor-pointer` cards render immediately on `/dashboard/orders/express/create-order`.

These specs passed on `develop` because that branch only runs the **smoke** tier. They only failed when the **PR-to-main critical tier** first exercised the cascade — exactly the safety-net behaviour the three-tier model describes, but caught late (see DevAudit-Installer #174).

## Root cause

REQ-081 (PR #389) changed the express picker to require category selection before showing items. The pre-cascade critical specs were never reconciled with that change (e2e-test-engineer Phase 4 gap).

## Change

New shared helper `e2e/helpers/express-menu.ts` → `revealFirstExpressMenuCard(page)` walks main → sub category options until available items render, then returns the first in-stock card. Applied to:

- `e2e/critical/express-order-report.spec.ts` (6 call sites)
- `e2e/critical/express-tip-capture.spec.ts`
- `e2e/critical/dashboard-revenue.spec.ts`
- `e2e/critical/reconciliation.spec.ts`
- `e2e/menu-customization-picker.spec.ts` (regression tier; preserves graceful skip)

## Verification

- `npx tsc --noEmit` — 0 errors
- `npx eslint` on changed files — 0 errors
- Full critical-tier E2E will run on this PR via the regression workflow

## Risk

**LOW** — test-only changes, no application code touched.

## Ref

Ref: REQ-081