### PR TITLE
test(e2e): [REQ-081] AC11 cross-category search for E2E reliability

### DIFF
--- a/e2e/helpers/express-menu.ts
+++ b/e2e/helpers/express-menu.ts
@@ -1,23 +1,22 @@
 /**
- * @requirement REQ-081 - Main-category to sub-category cascade across express
- * order entry. Shared helper so pre-cascade express specs can reveal the menu
- * grid by walking the category cascade before selecting an item.
+ * @requirement REQ-081 - Cross-category search for express order entry.
+ * Shared helper that uses the search field (AC11) to find menu items by name,
+ * bypassing the cascade when non-deterministic inventory makes category paths
+ * unreliable. Falls back to cascade navigation only when search fails.
  */
 import { expect, type Locator, type Page } from '@playwright/test';
 
 const MENU_CARD_SELECTOR = '.grid .cursor-pointer';
 
 /**
- * Reveal the express create-order menu grid by walking the REQ-081 category
- * cascade, then return the first available (in-stock) menu card.
- *
- * The express picker hides items until a main category and sub-category are
- * selected. This helper tries each main -> sub path until available items
- * render, mirroring the production cascade a staff member would use.
+ * Reveal the express create-order menu grid using REQ-081 cross-category
+ * search (AC11). Types a known item name into the search field to surface
+ * matching items across all categories, avoiding non-deterministic inventory
+ * issues that can leave category paths empty.
  *
  * @param page - Playwright page already navigated to the express create-order page
  * @returns Locator for the first available menu card
- * @throws If no category path yields an available menu item
+ * @throws If no available menu items are found via search or cascade
  */
 export async function revealFirstExpressMenuCard(page: Page): Promise<Locator> {
   const menuCard = page.locator(MENU_CARD_SELECTOR).first();
@@ -29,6 +28,23 @@ export async function revealFirstExpressMenuCard(page: Page): Promise<Locator> {
     timeout: 10000,
   });
 
+  // AC11: Use cross-category search to find items by name (bypasses cascade)
+  // Known seeded items: Efo, Ogbono (food), Gulder, 33 (drinks)
+  const searchTerms = ['Efo', 'Ogbono', 'Gulder', '33'];
+  const searchInput = page.getByTestId('category-cascade-search');
+
+  for (const term of searchTerms) {
+    await searchInput.fill(term);
+    await page.waitForTimeout(400); // Debounce + fetch time
+
+    if (await menuCard.isVisible({ timeout: 3000 }).catch(() => false)) {
+      return menuCard;
+    }
+
+    await searchInput.clear();
+  }
+
+  // Fallback: try cascade navigation if search fails
   const mainButtons = page
     .getByTestId('category-cascade-main-options')
     .getByRole('button');
@@ -43,6 +59,8 @@ export async function revealFirstExpressMenuCard(page: Page): Promise<Locator> {
 
     for (let subIndex = 0; subIndex < subCount; subIndex += 1) {
       await subButtons.nth(subIndex).click();
+      await page.waitForTimeout(400);
+
       if (await menuCard.isVisible({ timeout: 3000 }).catch(() => false)) {
         return menuCard;
       }
@@ -53,6 +71,6 @@ export async function revealFirstExpressMenuCard(page: Page): Promise<Locator> {
   }
 
   throw new Error(
-    'No available express menu items were found in any category path'
+    'No available express menu items found via search or category cascade'
   );
 }


### PR DESCRIPTION
## Problem

The E2E tests are still failing because  randomizes stock levels (10% chance of out-of-stock per item), making the cascade navigation non-deterministic.

## Solution

Use REQ-081 AC11 cross-category search to find items by name, bypassing the cascade entirely. Falls back to cascade if search fails.

## Changes

- : Added AC11 search using known seeded item names (Efo, Ogbono, Gulder, 33)

## Testing

- Verified TypeScript compiles
- Ready for E2E regression verification after merge

Ref: REQ-081 AC11