### PR TITLE
release: REQ-081 category cascade with AC11 cross-category search and E2E fixes

### DIFF
--- a/components/features/admin/inventory-items-client.tsx
+++ b/components/features/admin/inventory-items-client.tsx
@@ -112,6 +112,11 @@ function InventoryTabContent({
     );
   }
 
+  const normalizedSearchQuery = searchQuery.trim().toLowerCase();
+  const canBrowseItems = Boolean(
+    (selectedMainCategory && selectedCategory) || normalizedSearchQuery
+  );
+
   return (
     <div className="space-y-4">
       <CategoryCascadeFilter
@@ -136,15 +141,17 @@ function InventoryTabContent({
             : undefined
         }
       />
-      {selectedMainCategory && !selectedCategory ? (
-        <div className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
-          Select a sub category to view sellable inventory items.
-        </div>
-      ) : (
+      {canBrowseItems ? (
         <InventoryTable
           inventory={filteredItems}
           renderRowActions={renderRowActions}
         />
+      ) : (
+        <div className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
+          {selectedMain
+            ? 'Select a sub category to view sellable inventory items.'
+            : 'Select a main category to start browsing sellable inventory items.'}
+        </div>
       )}
     </div>
   );

--- a/components/features/admin/menu-items-client.tsx
+++ b/components/features/admin/menu-items-client.tsx
@@ -38,9 +38,9 @@ export function MenuItemsClient({
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
 
-  const filteredItems = useMemo(() => {
-    const normalizedSearchQuery = searchQuery.trim().toLowerCase();
+  const normalizedSearchQuery = searchQuery.trim().toLowerCase();
 
+  const filteredItems = useMemo(() => {
     return menuItems.filter(
       (item) =>
         (!selectedMainCategory || item.mainCategory === selectedMainCategory) &&
@@ -52,11 +52,20 @@ export function MenuItemsClient({
             tag.toLowerCase().includes(normalizedSearchQuery)
           ))
     );
-  }, [menuItems, searchQuery, selectedMainCategory, selectedCategory]);
+  }, [
+    menuItems,
+    normalizedSearchQuery,
+    selectedMainCategory,
+    selectedCategory,
+  ]);
 
   const selectedMain =
     mainCategories.find((category) => category.slug === selectedMainCategory) ??
     null;
+
+  const canBrowseItems = Boolean(
+    (selectedMainCategory && selectedCategory) || normalizedSearchQuery
+  );
 
   return (
     <div className="space-y-4">
@@ -82,12 +91,14 @@ export function MenuItemsClient({
             : undefined
         }
       />
-      {selectedMainCategory && !selectedCategory ? (
-        <div className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
-          Select a sub category to view menu items.
-        </div>
-      ) : (
+      {canBrowseItems ? (
         <MenuItemsTable menuItems={filteredItems} />
+      ) : (
+        <div className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
+          {selectedMain
+            ? 'Select a sub category to view menu items.'
+            : 'Select a main category to start browsing menu items.'}
+        </div>
       )}
     </div>
   );

--- a/e2e/menu-category-cascade.spec.ts
+++ b/e2e/menu-category-cascade.spec.ts
@@ -202,6 +202,8 @@ superAdminTest.describe('REQ-081: category cascade', () => {
           .first()
           .locator('td')
           .nth(1)
+          .locator('p')
+          .first()
           .textContent()) ?? ''
       ).trim();
       expect(firstItemName).not.toBe('');


### PR DESCRIPTION
REQ-081 implementation with category cascade across express order, menu management, and sellable inventory.

**Changes:**
- Main-category to sub-category cascade picker (shared component)
- AC11: Cross-category search (search across all categories when none selected, or within selected category)
- canBrowseItems gate: show prompt when no category selected and no search query
- E2E test fixes for menu-category-cascade.spec.ts (item name extraction fix)

**E2E verification:**
- Scoped regression run passed: https://github.com/metasession-dev/wawagardenbar-app/actions/runs/27747493670

Ref: REQ-081