### PR TITLE
chore: devaudit update to 0.1.73

### DIFF
--- a/.claude/skills/e2e-test-engineer/SKILL.md
+++ b/.claude/skills/e2e-test-engineer/SKILL.md
@@ -10,16 +10,18 @@ Maintain or bootstrap a project's e2e and visual regression test suite. Given an
 ## Scope
 
 **In scope**
+
 - End-to-end tests (UI-driven, user-flow level) in any framework.
 - Visual regression tests in any tool.
 - Maintaining an existing test pack — adding, updating, retiring tests.
 - Bootstrapping a new e2e suite when none exists, including framework selection, structure, configuration, a starter smoke test, and (optionally) CI integration.
 
 **Out of scope**
+
 - Unit, component, or API-only tests.
 - Performance, load, or accessibility audits, unless the project's e2e pack already includes them — in which case follow its lead.
 
-**Transport-layer specs that live in `e2e/`** (Node `fetch` against webhooks, `MongoClient` queries, `socket.io-client` assertions) ARE in scope — they exercise the deployed system end-to-end, just at the transport boundary rather than the UI. Their evidence form is `test-execution-summary.md`, not `evidenceShot` (see *Specs with no page object* below). The "API-only tests" exclusion above means **unit-level** API contract tests that exercise a route handler in isolation, not transport-boundary integration tests against the running system.
+**Transport-layer specs that live in `e2e/`** (Node `fetch` against webhooks, `MongoClient` queries, `socket.io-client` assertions) ARE in scope — they exercise the deployed system end-to-end, just at the transport boundary rather than the UI. Their evidence form is `test-execution-summary.md`, not `evidenceShot` (see _Specs with no page object_ below). The "API-only tests" exclusion above means **unit-level** API contract tests that exercise a route handler in isolation, not transport-boundary integration tests against the running system.
 
 ## The workflow
 
@@ -31,10 +33,10 @@ Three things must be in hand before designing tests: the **test stack**, the **c
 
 **Detect the test stack** from the repo:
 
-- *E2E framework signals* — `playwright.config.*`, `cypress.config.*`, `wdio.conf.*`, `nightwatch.conf.*`, `codecept.conf.*`, `testcafe.config.*`. Failing that, check `package.json` dependencies for `@playwright/test`, `cypress`, `webdriverio`, `puppeteer`, `selenium-webdriver`, or Python equivalents (`pytest-playwright`, `selenium`, `splinter`).
-- *Test location* — common patterns: `e2e/`, `tests/e2e/`, `cypress/e2e/`, `playwright/`, `test/e2e/`, `__tests__/e2e/`.
-- *Visual regression tool* — Playwright or Cypress built-in snapshots, `cypress-image-snapshot`, `cypress-visual-regression`, `percy`, `applitools-eyes-*`, `chromatic`, `backstop.json`, `loki`, `reg-suit`. If none of these are present, the project doesn't do visual regression and you should only add it if the issue explicitly asks for it.
-- *Run command* — search `package.json` scripts for `e2e`, `test:e2e`, `cy:run`, `pw:test`. Failing that, check `Makefile`, `justfile`, `tox.ini`, `pyproject.toml`, CI config. If still unclear, ask.
+- _E2E framework signals_ — `playwright.config.*`, `cypress.config.*`, `wdio.conf.*`, `nightwatch.conf.*`, `codecept.conf.*`, `testcafe.config.*`. Failing that, check `package.json` dependencies for `@playwright/test`, `cypress`, `webdriverio`, `puppeteer`, `selenium-webdriver`, or Python equivalents (`pytest-playwright`, `selenium`, `splinter`).
+- _Test location_ — common patterns: `e2e/`, `tests/e2e/`, `cypress/e2e/`, `playwright/`, `test/e2e/`, `__tests__/e2e/`.
+- _Visual regression tool_ — Playwright or Cypress built-in snapshots, `cypress-image-snapshot`, `cypress-visual-regression`, `percy`, `applitools-eyes-*`, `chromatic`, `backstop.json`, `loki`, `reg-suit`. If none of these are present, the project doesn't do visual regression and you should only add it if the issue explicitly asks for it.
+- _Run command_ — search `package.json` scripts for `e2e`, `test:e2e`, `cy:run`, `pw:test`. Failing that, check `Makefile`, `justfile`, `tox.ini`, `pyproject.toml`, CI config. If still unclear, ask.
 
 **Detect the issue tracker** so you can read the input issue now and file defect issues later:
 
@@ -79,7 +81,7 @@ The bootstrap workflow:
 
 5. **Lay out the directory structure** for the project's expected scale: a top-level test directory (`e2e/` or whatever the framework's installer chose), with subfolders for specs, fixtures, page objects (or fixture-based equivalent), helpers, and visual specs if applicable. Write the structure as a short tree in your reply so the user can see what was created.
 
-6. **Configure for best practice** — base URL pointing at the project's dev server, retries on CI only, parallel workers, an HTML reporter, trace on first retry, `screenshot: 'only-on-failure'` (failure forensics — see *Evidence vs failure forensics* below for per-AC evidence capture), video retention on failure, and (if the framework supports it) auto-starting the dev server before the suite runs. Specifics per framework are in `references/bootstrap.md`.
+6. **Configure for best practice** — base URL pointing at the project's dev server, retries on CI only, parallel workers, an HTML reporter, trace on first retry, `screenshot: 'only-on-failure'` (failure forensics — see _Evidence vs failure forensics_ below for per-AC evidence capture), video retention on failure, and (if the framework supports it) auto-starting the dev server before the suite runs. Specifics per framework are in `references/bootstrap.md`.
 
 7. **Establish the abstraction pattern** — write one Page Object Model (or one fixture, depending on framework idioms) as a worked example so the change's tests in Phase 5 have a template to follow.
 
@@ -89,7 +91,7 @@ The bootstrap workflow:
 
 10. **Offer a CI job** — write the YAML (or equivalent) for the project's CI system, but **do not commit it without confirmation**. Show it inline first. On a **DevAudit** project, `.github/workflows/ci.yml` is generated and marked do-not-edit-manually — don't hand-edit it; instead drive the E2E gate from `sdlc-config.json`. If the suite must run against a **disposable local database** (the rule on any project with no separate test instance — never test against prod), set `e2e_setup_command` (e.g. `supabase start` + load schema + seed) and `e2e_env` (e.g. `E2E_LOCAL=1`, local coords, a dummy email key) so the gate severs production. See [Local-database E2E in CI](https://github.com/metasession-dev/DevAudit-Installer/blob/main/docs/e2e-local-db-ci.md), then `devaudit update` to regenerate.
 
-    **Upload both artefact shapes.** Playwright writes per-test artefacts to *two* places: `test-results/<spec>-<title>[-retryN]/{trace.zip, video.webm, *.png, error-context.md}` — **spec-named**, human-mappable — and `playwright-report/data/<content-hash>.zip` — **hash-named**, indexed by the HTML report. Ensure the project's CI uploads **both** `playwright-report/` (for the HTML viewer) and `test-results/` (for spec-named traces / videos / error-context). If only one is uploaded, propose a small follow-up PR to add the other — it costs ~80 MB of artefact storage and saves the operator from walking the HTML report's hash index to find a specific trace.
+    **Upload both artefact shapes.** Playwright writes per-test artefacts to _two_ places: `test-results/<spec>-<title>[-retryN]/{trace.zip, video.webm, *.png, error-context.md}` — **spec-named**, human-mappable — and `playwright-report/data/<content-hash>.zip` — **hash-named**, indexed by the HTML report. Ensure the project's CI uploads **both** `playwright-report/` (for the HTML viewer) and `test-results/` (for spec-named traces / videos / error-context). If only one is uploaded, propose a small follow-up PR to add the other — it costs ~80 MB of artefact storage and saves the operator from walking the HTML report's hash index to find a specific trace.
 
 11. **Write a short README** in the test directory explaining structure, how to run, how to add new tests, and how to update visual baselines. Future contributors (and the skill itself, on next invocation) will thank you.
 
@@ -109,11 +111,11 @@ You cannot write the right tests without understanding what changed and why. Spe
 
 3. **Read the surrounding app** enough to know how a real user reaches the changed area. Look at routing, navigation, and the one or two most adjacent features.
 
-4. **Write a short mental model** in your reply: *trigger → new behaviour → expected outcomes → likely side-effects*. If anything is ambiguous, ask the user before designing scenarios. Guesses here cascade into bad tests.
+4. **Write a short mental model** in your reply: _trigger → new behaviour → expected outcomes → likely side-effects_. If anything is ambiguous, ask the user before designing scenarios. Guesses here cascade into bad tests.
 
 ### Phase 3 — Design scenarios
 
-The goal is the *minimum* set of scenarios that, if they all pass, would give a reasonable person high confidence the change works as intended and hasn't broken adjacent functionality. "Minimum" is load-bearing: e2e tests are slow to run and expensive to maintain, and a bloated suite gets ignored.
+The goal is the _minimum_ set of scenarios that, if they all pass, would give a reasonable person high confidence the change works as intended and hasn't broken adjacent functionality. "Minimum" is load-bearing: e2e tests are slow to run and expensive to maintain, and a bloated suite gets ignored.
 
 Derive scenarios from these sources, in this order:
 
@@ -129,17 +131,17 @@ Derive scenarios from these sources, in this order:
 
 Resist padding. A new endpoint doesn't need a test that re-verifies login if login is already covered. Match the project's existing depth — if it covers one happy path per feature, don't add six.
 
-For each scenario, write a one-line description. Present the full grouped list to the user before writing any code: *"Here's the coverage I'd propose — anything to add or drop?"*
+For each scenario, write a one-line description. Present the full grouped list to the user before writing any code: _"Here's the coverage I'd propose — anything to add or drop?"_
 
 #### Classify each spec into a tier (devaudit#152 follow-up, v0.1.53)
 
-When designing each scenario, also pick the tier it'll live in. Three tiers map to MoSCoW priority + gating point (see `Test_Strategy.md` § *E2E gating model*):
+When designing each scenario, also pick the tier it'll live in. Three tiers map to MoSCoW priority + gating point (see `Test_Strategy.md` § _E2E gating model_):
 
-| Tier | File location | Picks this when… |
-|---|---|---|
-| **smoke** | `e2e/smoke/*.spec.ts` | Cross-cutting sanity that proves the app is up: login, basic nav, one canonical CRUD per main domain. Runs on every push to the integration branch. Keep small — total smoke wall-clock target is ~3–5 min. |
-| **critical** | `e2e/critical/*.spec.ts` | Must-priority SRS item that breaks a headline flow if it regresses. Examples: payment authorisation, order completion, admin permission editing, RBAC enforcement on financial surfaces. Runs on PR-to-release-branch. Total critical wall-clock target ~10–15 min (includes smoke). |
-| **regression** | `e2e/<area>/*.spec.ts` | Should/Could-priority SRS item, edge cases, less-load-bearing flows. Runs nightly + post-merge + dispatch. Total full pack can be 30+ min; that's the point of the tier. |
+| Tier           | File location            | Picks this when…                                                                                                                                                                                                                                                                     |
+| -------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **smoke**      | `e2e/smoke/*.spec.ts`    | Cross-cutting sanity that proves the app is up: login, basic nav, one canonical CRUD per main domain. Runs on every push to the integration branch. Keep small — total smoke wall-clock target is ~3–5 min.                                                                          |
+| **critical**   | `e2e/critical/*.spec.ts` | Must-priority SRS item that breaks a headline flow if it regresses. Examples: payment authorisation, order completion, admin permission editing, RBAC enforcement on financial surfaces. Runs on PR-to-release-branch. Total critical wall-clock target ~10–15 min (includes smoke). |
+| **regression** | `e2e/<area>/*.spec.ts`   | Should/Could-priority SRS item, edge cases, less-load-bearing flows. Runs nightly + post-merge + dispatch. Total full pack can be 30+ min; that's the point of the tier.                                                                                                             |
 
 Decision tree, applied per scenario:
 
@@ -149,7 +151,7 @@ Decision tree, applied per scenario:
 
 When you can't decide between critical and regression, default to **regression** — promoting a spec from regression → critical later is cheap (move the file); demoting in the other direction is rarely needed but equally cheap. The cost of putting a Should spec in critical is everyone waiting longer on every PR-to-main for a low-value signal.
 
-Record the tier choice in the eventual `test-execution-summary.md` § *Test design* (devaudit#50) — Layers covered should name which tier each new spec landed in. Reviewers verify the tier choice is defensible during the WAIT CHECKPOINT.
+Record the tier choice in the eventual `test-execution-summary.md` § _Test design_ (devaudit#50) — Layers covered should name which tier each new spec landed in. Reviewers verify the tier choice is defensible during the WAIT CHECKPOINT.
 
 ### Phase 4 — Reconcile with existing tests
 
@@ -167,6 +169,7 @@ For the area touched by the change, look at what's already there.
 3. **Needs updating** — existing tests where the scenario is still valid but selectors, routes, or assertions have shifted.
 
 Present three lists to the user:
+
 - **To add** — new scenarios not already covered.
 - **To update** — existing tests needing adjustment.
 - **To delete** — genuinely obsolete tests, each with a one-line rationale.
@@ -191,7 +194,7 @@ Every test spec covering an in-scope REQ **must** call `tagTest()` at the top of
 import { tagTest } from './helpers/test-tags';
 
 test('verification code submit', async ({ page }) => {
-  tagTest('REQ-083', 1);  // REQ-083, acceptance criterion 1
+  tagTest('REQ-083', 1); // REQ-083, acceptance criterion 1
   // ... test body
 });
 ```
@@ -205,6 +208,7 @@ For transport-layer specs (no `page` object), `tagTest` works identically — it
 The helper is synced to `e2e/helpers/test-tags.ts` by `devaudit update` alongside `evidence.ts`. Do not inline annotation logic — use the helper so the annotation format stays consistent with what the portal parser expects.
 
 For **visual regression** specifically:
+
 - New tests need baseline images. Generate them, but **do not auto-approve** — surface them for the user to verify before they're committed.
 - Use the project's existing breakpoints, viewports, and element-masking conventions.
 
@@ -232,7 +236,9 @@ Before running the suite (Phase 6), verify that the evidence traceability wiring
 **If any check fails:**
 
 Halt and report the gap to the user:
+
 > Evidence wiring incomplete for REQ-XXX:
+>
 > - Missing `@requirement REQ-XXX` annotation in `e2e/<area>/foo.spec.ts`
 > - Missing `evidenceShot()` call for AC2 in `e2e/<area>/bar.spec.ts`
 > - Missing `tagTest('REQ-XXX', …)` call in `e2e/<area>/baz.spec.ts`
@@ -250,7 +256,7 @@ Run the suite. Strategy:
 3. **For CI-driven verification, ensure the workflow accepts a subset input.** A `workflow_dispatch.inputs.specs` (or equivalent) lets a developer fire a scoped run without local infrastructure. Recommend setting this up if the project doesn't have it — the speed-up (~5–10 min vs ~30–60 min) is the difference between a tractable loop and a hated one.
 4. **For visual regression**, run the project's normal comparison mode against existing baselines.
 
-Triage every failure into one of these buckets *before* taking any action:
+Triage every failure into one of these buckets _before_ taking any action:
 
 **0. Read the page snapshot first.** Modern Playwright writes `test-results/<spec>-<title>[-retryN]/error-context.md` — a markdown accessibility-tree snapshot of the page at failure time. It's enough to triage selector / role / wait-condition failures without extracting the trace zip. Reach for the trace only when the snapshot is ambiguous (e.g. the failure depends on a transition or a network race the snapshot can't show).
 
@@ -265,7 +271,7 @@ Then bucket each failure:
 - **Visual diff — intended** — the snapshot changed because the change intentionally changed the UI. Update the baseline and surface it for user approval.
 - **Visual diff — unintended** — a snapshot changed somewhere the change shouldn't have affected. File it as a regression.
 
-**Then check for missed requirements.** For each numbered acceptance criterion from Phase 2, confirm at least one *passing* test covers it. **Classify each missed AC (devaudit-installer#212 Gap 4):**
+**Then check for missed requirements.** For each numbered acceptance criterion from Phase 2, confirm at least one _passing_ test covers it. **Classify each missed AC (devaudit-installer#212 Gap 4):**
 
 - **AC not tested** (no test was written) — file a defect as today. The implementation may be correct but untested. This is a testing gap, not a requirements gap.
 - **AC test fails** (test exists but fails) — file a defect as today. The implementation doesn't match the AC. This is a defect.
@@ -280,7 +286,7 @@ After Phase 6 succeeds — green run, all ACs proved, defects filed for anything
 
 > **Every `*.spec.ts` (and `*.spec.tsx`) under `tests/e2e/` or `e2e/`.**
 
-There is no `regression/` sub-directory, no `@regression` tag, no manifest file. Being committed and merged to `develop` *is* the graduation step. Once that happens:
+There is no `regression/` sub-directory, no `@regression` tag, no manifest file. Being committed and merged to `develop` _is_ the graduation step. Once that happens:
 
 1. The next CI run (on this branch's PR, or on `develop` after merge) executes the new spec alongside every existing one.
 2. The evidenceShot helper sees `process.env.E2E_NEW_SPECS` (computed by CI as `git diff --diff-filter=A <merge-base>...HEAD`) and tags this branch's captures as `origin: 'feature'`.
@@ -288,13 +294,27 @@ There is no `regression/` sub-directory, no `@regression` tag, no manifest file.
 
 You don't need to do anything explicit for this step — it's a property of the pipeline, not an action. Surface it in the final report so the reviewer knows the new tests are now load-bearing for every future release.
 
+**Write the E2E gate sentinel (devaudit-installer#226).** After a successful full regression run (Phase 6 step 2), write a `.e2e-gate-passed` sentinel file in the repo root so the pre-push hook and `sdlc-implementer` Phase 2 step 5b can verify the E2E gate ran:
+
+```bash
+echo "PASSED $(date -u +%Y-%m-%dT%H:%M:%SZ) ${{ github.run_id }}" > .e2e-gate-passed
+```
+
+If you determined e2e is not needed for this REQ (schema-only, API-only, no UI surface), write the sentinel with a `NOT_NEEDED` reason instead:
+
+```bash
+echo "NOT_NEEDED $(date -u +%Y-%m-%dT%H:%M:%SZ) <reason>" > .e2e-gate-passed
+```
+
+The file is gitignored and never committed — it's a local-only signal that the gate was run in this working directory.
+
 ### Filing defects
 
 Use whatever tracker integration you found in Phase 1: `gh issue create`, `glab issue create`, a Jira or Linear MCP tool, `az boards work-item create`. If nothing is available, produce a markdown report with each defect formatted ready to paste.
 
 Each filed issue needs:
 
-- **Title** — short, specific, describes the symptom not the cause. *"Filter by status shows zero results when status=pending"*, not *"Filter broken"*.
+- **Title** — short, specific, describes the symptom not the cause. _"Filter by status shows zero results when status=pending"_, not _"Filter broken"_.
 - **Steps to reproduce** — numbered, minimal, exact.
 - **Expected vs actual** — on separate lines, no ambiguity.
 - **Environment** — branch, commit SHA, test command, browser/viewport if relevant.
@@ -309,13 +329,13 @@ Every defect filed from Phase 6 becomes `incident_report` evidence when (a) the 
 
 Classify the defect against this table when filing — the canonical version lives at `governance-doc-author/references/incident-classification.md`, mirrored here for the e2e workflow:
 
-| Defect characteristic | Frameworks/clauses attributed |
-|---|---|
-| **Any test failure / defect** (baseline — always) | `ISO29119.3.5.4` Test incident report |
-| **Ops impact** (downtime, persistent errors, perf regression, data corruption) | + `SOC2.CC7.2` System monitoring and incident response |
-| **Security vulnerability** (auth bypass, injection, data exposure) | + `SOC2.CC7.2` + relevant ISO 27001 controls |
-| **Personal data exposed / lost / mishandled** | + `GDPR.Art-33` (always — 72h supervisory notification) + `GDPR.Art-34` (when data subjects need notification) |
-| **AI/ML failure** (model hallucination, biased output, oversight bypass) | + relevant EU AI Act articles (`Art-9` risk, `Art-14` human oversight, `Art-15` accuracy/robustness) |
+| Defect characteristic                                                          | Frameworks/clauses attributed                                                                                  |
+| ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| **Any test failure / defect** (baseline — always)                              | `ISO29119.3.5.4` Test incident report                                                                          |
+| **Ops impact** (downtime, persistent errors, perf regression, data corruption) | + `SOC2.CC7.2` System monitoring and incident response                                                         |
+| **Security vulnerability** (auth bypass, injection, data exposure)             | + `SOC2.CC7.2` + relevant ISO 27001 controls                                                                   |
+| **Personal data exposed / lost / mishandled**                                  | + `GDPR.Art-33` (always — 72h supervisory notification) + `GDPR.Art-34` (when data subjects need notification) |
+| **AI/ML failure** (model hallucination, biased output, oversight bypass)       | + relevant EU AI Act articles (`Art-9` risk, `Art-14` human oversight, `Art-15` accuracy/robustness)           |
 
 **Baseline rule:** the first row is **mandatory**. Even a defect with no specific framework impact STILL produces a valid incident_report attributed to `ISO29119.3.5.4`. Never silently drop the artefact because "it's just a bug".
 
@@ -346,6 +366,7 @@ This defect, once closed with the `incident` label, will be auto-exported as `in
 - [ ] `EUAIA.Art-9 / Art-14 / Art-15` — AI failure: <REPLACE — yes/no, which article(s)>
 
 Once closed, the `incident-export.yml` workflow exports this issue's body to `compliance/governance/incident-report-<N>.md`. Routing depends on the Framework attribution ticks (DevAudit-Installer#200 Fix 1):
+
 - **Path A (baseline-only — only `ISO29119.3.5.4` ticked):** direct-committed to `develop`, no PR. GDPR triage pre-filled as N/A. Next `compliance-evidence.yml` run uploads as `incident_report`.
 - **Path B (any of SOC2/GDPR/EUAIA ticked):** auto-files a PR with the GDPR triage + sign-off sections to fill in. Merge that PR → `compliance-evidence.yml` uploads as `incident_report`.
 ```
@@ -387,7 +408,7 @@ Wrap up with a summary the user can drop into the PR or ticket:
 - Requirements gap reports — count, with details (devaudit-installer#212 Gap 4). These are ACs classified as "impossible to test" or "missing AC" — returned to `sdlc-implementer` for the requirements gap flow, not filed as defects.
 - Missed requirements — count, with links.
 
-**Then feed the test-design record (devaudit#50).** The Stage 3 `test-execution-summary.md` (generated per `3-compile-evidence.md` Step 1a) carries a `## Test design` section at the top. Before Stage 3 finalises the file, populate that section with the design-time decisions this skill made, so the SDLC has a recorded trace that scope was *decided*, not implicit:
+**Then feed the test-design record (devaudit#50).** The Stage 3 `test-execution-summary.md` (generated per `3-compile-evidence.md` Step 1a) carries a `## Test design` section at the top. Before Stage 3 finalises the file, populate that section with the design-time decisions this skill made, so the SDLC has a recorded trace that scope was _decided_, not implicit:
 
 - **Layers planned** — which of `unit | integration | e2e | visual | manual` applied to this REQ
 - **Layers covered** — same list with ✓ or `deferred`
@@ -420,7 +441,7 @@ test('AC1: edit dialog opens with fields pre-filled', async ({ page }) => {
 - Call `evidenceShot` **immediately after** the AC-proving assertion, before navigating, closing dialogs, or any further interaction.
 - AC number is a separate argument (`ac: number`) — the helper composes the filename `REQ-XXX-AC<n>-<slug>.png`. The slug describes what the screenshot proves (`edit-dialog-prefilled`), NOT the AC number.
 - Slug is kebab-case lowercase (`[a-z0-9-]+`). Capitalised slugs, underscores, or spaces throw.
-- One **canonical** screenshot per AC; additional stage screenshots are tier-gated — see *Screenshot density per spec role* below.
+- One **canonical** screenshot per AC; additional stage screenshots are tier-gated — see _Screenshot density per spec role_ below.
 - Failure forensics stays untouched (`screenshot: 'only-on-failure'` + `trace: 'on-first-retry'`).
 
 The helper is shipped automatically into `e2e/helpers/evidence.ts` by the SDLC sync (node-stack consumers). Output lands at `compliance/evidence/<REQ-ID>/screenshots/REQ-XXX-AC<n>-<slug>.png` — commit these PNGs as part of the evidence pack so reviewers can corroborate the test-plan AC mapping.
@@ -443,7 +464,7 @@ test('AC7: stock dial completes the transition', async ({ page }) => {
   // Stage screenshots — fire while the spec is a feature artefact;
   // auto-suppress once it graduates into the regression pack.
   await openStockDial(page, item.id);
-  await evidenceShot(page, 'REQ-066', 7, 'dial-open',  { tier: 'feature' });
+  await evidenceShot(page, 'REQ-066', 7, 'dial-open', { tier: 'feature' });
   await advanceDial(page);
   await evidenceShot(page, 'REQ-066', 7, 'in-progress', { tier: 'feature' });
 
@@ -462,7 +483,7 @@ A reasonable default per AC:
 
 When to deviate:
 
-- **Single-shot ACs** (one assertion that's its own proof — e.g. *"the form submits and returns to the list"*) need only the canonical anchor. Don't manufacture stages just to hit the 1–3 band.
+- **Single-shot ACs** (one assertion that's its own proof — e.g. _"the form submits and returns to the list"_) need only the canonical anchor. Don't manufacture stages just to hit the 1–3 band.
 - **Long flows** (>3 meaningful transitions) keep all stages tier `'feature'`. The post-merge regression run still has the canonical anchor to corroborate the AC; the dense journey is on the feature PR for reviewers and in the audit-pack download for that release forever.
 - **Reviewer pushback that evidence feels thin** (single-shot per AC across a HIGH-risk REQ) almost always means tier `'feature'` stages are missing — add them on the feature branch where they actually fire, not after.
 
@@ -480,7 +501,7 @@ Discipline for transport specs:
 
 - Name the asserted behaviour in the test title using the same `[REQ-XXX][ACn]` bracket convention UI specs use. Reviewers grep on that.
 - The `test-execution-summary.md` table row should describe what the spec verified in operator-facing terms ("signature mismatch returns 401; payment row unchanged"), not in TypeScript-spec terms ("`expect(response.status).toBe(401)`").
-- If a transport spec *can* be paired with a thin UI shim that screenshots the user-visible outcome (e.g. an admin dashboard surface that shows the rejected payment as "Failed — signature mismatch"), pair them — that buys back the screenshot evidence at the surface level. Otherwise: transport spec stands alone.
+- If a transport spec _can_ be paired with a thin UI shim that screenshots the user-visible outcome (e.g. an admin dashboard surface that shows the rejected payment as "Failed — signature mismatch"), pair them — that buys back the screenshot evidence at the surface level. Otherwise: transport spec stands alone.
 - The portal's release-detail "screenshots" panel will show zero entries for purely-transport REQs; that's correct. Reviewers cross-reference `test-execution-summary.md` instead.
 
 This is **observation**, not gate-relaxation — these specs satisfy the SDLC evidence requirement; the screenshot mechanism doesn't apply.

--- a/.claude/skills/sdlc-implementer/SKILL.md
+++ b/.claude/skills/sdlc-implementer/SKILL.md
@@ -96,7 +96,7 @@ When the user asks for a change that goes beyond the current REQ's acceptance cr
 
 4. **Wait for the user to confirm one of:**
    - **(a) File a separate issue** (new REQ) — ship the current REQ as-is. The agent continues with the original scope.
-   - **(b) Amend REQ-XXX's scope** — explicitly expand `test-scope.md` / `implementation-plan.md`, update the plan, invalidate existing evidence, and re-walk Stage 3. This option carries a warning: _"Amending scope after evidence is compiled (Stage 3+) invalidates the existing test-execution-summary, screenshots, and UAT verification. All Stage 3 evidence must be re-compiled."_
+   - **(b) Amend REQ-XXX's scope** — explicitly expand `test-scope.md` / `test-plan.md` / `implementation-plan.md`, update the plan, invalidate existing evidence, and re-walk Stage 3. Re-extract both `test-scope.md` and `test-plan.md` from the updated plan (Phase 1 step 5b drift management). This option carries a warning: _"Amending scope after evidence is compiled (Stage 3+) invalidates the existing test-execution-summary, screenshots, and UAT verification. All Stage 3 evidence must be re-compiled."_
    - **(c) Abandon the request** — do nothing, continue with the original scope.
 
 **Do not implement the out-of-scope change before the user picks (a), (b), or (c).** The inertia trap is real: the agent is mid-flow, the codebase is open, and the request sounds reasonable. The gate exists to interrupt that inertia — STOP, surface the scope gap, and let the user decide.
@@ -141,10 +141,11 @@ Amendment steps:
 2. Re-invoke `requirements-aligner` → propose new/updated SRS stubs
 3. Operator edits SRS stubs into canonical Given/When/Then prose in `docs/SRS.md`
 4. Update `compliance/RTM.md`
-5. Commit: `compliance: [REQ-XXX] amend ACs — requirements gap <description>`
-6. If Phase 2+: re-run affected tests (delegating to `e2e-test-engineer` if e2e)
-7. If Phase 3+: re-compile affected evidence
-8. Continue from current phase
+5. Re-extract `compliance/evidence/REQ-XXX/test-scope.md` and `compliance/evidence/REQ-XXX/test-plan.md` from the updated plan (Phase 1 step 5b drift management, devaudit-installer#226)
+6. Commit: `compliance: [REQ-XXX] amend ACs — requirements gap <description>`
+7. If Phase 2+: re-run affected tests (delegating to `e2e-test-engineer` if e2e)
+8. If Phase 3+: re-compile affected evidence
+9. Continue from current phase
 
 **(c) File a follow-up REQ** — ship the current REQ as-is, file a separate issue for the requirements gap. Appropriate when the gap is a genuine new behaviour that deserves its own cycle. Continue with the current REQ unchanged.
 
@@ -255,7 +256,7 @@ Runs **first**, before any `REQ-XXX` is assigned. It decides which of the six ch
 3. **Announce a "Workflow Decision" block** (template below): change-type, commit-type, whether a `REQ-XXX` is needed, risk class, which stages/gates run, which approvals the **operator** must perform (UAT four-eyes, Production approval), and what is **skipped**.
 4. **Pause policy — pause-when-it-matters.** Pause for explicit confirmation on **tracked / heavier** paths, or when classification is **ambiguous**; **announce-and-auto-proceed** on trivial / housekeeping. The operator can always reclassify ("treat this as housekeeping" / "this is HIGH risk").
 5. **Route — and stay on to completion.** A route is a choice of _which workflow to drive_, never a hand-off that abandons the operator. Whatever the path, the skill keeps guiding step by step until no further action is required (typically: merged).
-   - **tracked** (feature / bug fix / refactor / perf) → continue into Phase 1 below (full Stages 1–5).
+   - **tracked** (feature / bug fix / refactor / perf) → continue into Phase 1 below (full Stages 1–5). **Write the skill-invocation sentinel** (devaudit-installer#226): `echo "INVOKED $(date -u +%Y-%m-%dT%H:%M:%SZ)" > .sdlc-implementer-invoked`. This file is gitignored and never committed — it's a local-only signal that the pre-push hook checks before allowing `feat`/`fix`/`refactor`/`perf` commits to be pushed. Without this sentinel, the pre-push hook will refuse the push and `validate-commits.sh` in CI will flag missing RTM provenance.
    - **housekeeping / trivial** → drive the **Lightweight path** below to completion. No `REQ-XXX`, no RTM row, no evidence pack, no portal release approvals — but the skill still branches, runs the gates, opens the PR, and walks the operator through review → merge.
    - **compliance-doc-only** → drive the same Lightweight path as a docs push (or PR, per the project's flow) referencing the **existing** `REQ-XXX`: no new requirement and no quality-gate ceremony, but driven through to merge.
 6. **Write labels back.** Apply the inferred `type:*` / `risk:*` labels so the issue ends up labelled — `gh label create <label> --force` to ensure the label exists (idempotent; no failure if a label-seeding step never ran), then `gh issue edit <N> --add-label <label>`. Future triage is then a glance.
@@ -356,6 +357,15 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
 
    **Don't delete sections** — mark with `N/A — <reason>` if a clause genuinely doesn't apply (e.g. UI-only change with no personal-data scope). Empty stubs commit-then-upload as placeholder evidence and break the audit trail.
 
+5b. **Extract `test-scope.md` and `test-plan.md` from the implementation plan (devaudit-installer#226).** After step 5, extract two artefacts from the plan into `compliance/evidence/REQ-XXX/` so CI's `validate-compliance-artifacts.sh` finds them in the expected location:
+
+- **`compliance/evidence/REQ-XXX/test-scope.md`** — the AC table with SRS-IDs, risk class, and verification method per AC. Extracted from the plan's "Acceptance criteria" table.
+- **`compliance/evidence/REQ-XXX/test-plan.md`** — the test file listing with AC coverage mapping: which test file covers which AC, test type (unit/integration/e2e), and whether each AC has at least one test. Extracted from the plan's "Test scope" section.
+
+These files are the CI validator's expected artefacts. Without them, `validate-compliance-artifacts.sh` fails and the pre-push hook blocks the push. The plan directory (`compliance/plans/REQ-XXX/`) retains the full plan; these are extracted subsets for CI validation.
+
+**Drift management (devaudit-installer#226).** If the plan's AC table changes after step 5b (requirements gap flow option (b), scope-expansion halt gate option (b), or plan deviation), re-extract both `test-scope.md` and `test-plan.md` from the updated plan. The extracted files must always match the plan's current AC table. Phase 2 step 5b checks plan ↔ test-scope AC consistency before running E2E.
+
 6. **Invoke `requirements-aligner` to populate the SRS-ID column on the AC table.** The plan's "Acceptance criteria" table carries an SRS-ID column per AC; `requirements-aligner` fuzzy-matches each AC against `docs/SRS.md` and proposes new `REQ-AREA-NNN` stubs, flags stale items, or annotates `@srs-deferred`. Don't author the SRS-ID column inline — call via the standard Claude Code Skill mechanism (`Skill(name: "requirements-aligner", …)`). Block plan APPROVAL until every AC has a resolved SRS-ID per the skill's Phase 1 contract (configurable via `sdlc-config.json:requirements_aligner.block_on_stage_1`; ramp-up mode default-on for legacy projects).
 
    **SRS stub editing (devaudit-installer#212 Gap 5).** After `requirements-aligner` returns, the plan's SRS items proposed/touched section may contain N new stubs and M stale items. The operator must edit `docs/SRS.md` to flesh out the stubs into canonical Given/When/Then prose and update stale items. Do not proceed to Phase 2 until the SRS is updated. The skill enforces this by checking that no stub placeholders remain in `docs/SRS.md` for the proposed SRS-IDs before auto-continuing. A stub placeholder is any SRS entry containing `<TODO>` or the `@srs-stub` marker.
@@ -369,7 +379,7 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
 - **`adr-author` fails**: Warn and continue — ADR is advisory by default. Mark the plan's "Architecture decisions" section as "ADR assessment skipped — <error>".
 - **`risk-register-keeper` fails**: If `block_on_stage_1` is true, halt. If false, warn and continue — mark the plan's "Risk register entries" section as "Risk assessment skipped — <error>".
 
-9. **Update `compliance/RTM.md`** with the new entry: REQ-XXX, title, risk class, linked issue, linked test cases (placeholder).
+9. **Update `compliance/RTM.md`** with the new entry: REQ-XXX, title, risk class, linked issue, linked test cases (placeholder), and a provenance marker `sdlc-implementer@<version>` (devaudit-installer#226). The provenance column is the last column in the RTM row — `validate-commits.sh` in CI checks for its presence when `feat`/`fix`/`refactor`/`perf` commits cite a REQ-XXX. Without the stamp, CI fails with "no sdlc-implementer provenance in RTM.md." If the RTM table doesn't have a provenance column, add one with header `Provenance`.
 10. **Post plan summary as an issue comment.** Format: TL;DR; Risk class + signals; Acceptance criteria (with SRS-IDs); Architectural decisions (ADR-NNN reference or no-ADR rationale); Risk register entries (RISK-NNN list); Technical approach (one paragraph); Dependencies; Test scope.
 11. **Checkpoint** — pause for human approval **iff** risk class is HIGH or CRITICAL. LOW and MEDIUM pass through to Phase 2 automatically. The checkpoint can be forced on for all classes via the `--require-plan-approval` flag (or `DEVAUDIT_REQUIRE_PLAN_APPROVAL=1` env var) for orgs that want it always-on.
 12. **Update SDLC status sticky** before exiting Phase 1: `bash scripts/update-sdlc-status.sh "$ISSUE_NUM" "Phase 1 complete — plan written to compliance/plans/REQ-XXX/implementation-plan.md (risk class <CLASS>)" "Phase 2 — sdlc-implementer auto-continuing"` (or "Operator action — review plan + ping resume" if the HIGH/CRITICAL checkpoint paused).
@@ -407,6 +417,20 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
 
    **E2E gate** — run _once_, after the fast gates are clean:
    - `npx playwright test` (delegated to `e2e-test-engineer`, which has its own focused-iteration discipline for within-e2e fix-and-verify loops)
+
+5b. **E2E gate verification — mandatory before commit (devaudit-installer#226).** After running gates in step 5, verify the E2E gate actually ran before proceeding to step 7 (commit). This is the skill-level enforcement that backs the pre-push hook.
+
+Check whether the change touches UI-facing files:
+
+```bash
+git diff --name-only "$INTEGRATION_BRANCH"...HEAD -- 'app/**/*.tsx' 'src/**/*.tsx' 'pages/**/*.tsx' 'app/**/*.jsx' 'src/**/*.jsx' 'pages/**/*.jsx'
+```
+
+- **If UI-facing files are present:** check for `.e2e-gate-passed` sentinel file (written by `e2e-test-engineer` after a successful run) or `playwright-report/` directory with recent content. If neither exists, **HALT**: "E2E gate was not run. The change touches UI-facing files. Run `npx playwright test` (or invoke `e2e-test-engineer`) before committing. The pre-push hook will also block this push."
+- **If no UI-facing files (API-only, config, docs):** skip the check. Note the exemption in the commit body: "E2E gate skipped — no UI-facing files in this change."
+- **If `e2e-test-engineer` was invoked and determined e2e is not needed** (e.g. schema-only change): the skill writes `.e2e-gate-passed` with a `NOT_NEEDED` reason. The sentinel check passes. Note the exemption in the commit body: "E2E gate not needed — e2e-test-engineer assessed no UI surface (turn N)."
+
+**Plan ↔ test-scope AC consistency check (devaudit-installer#226 drift management).** Before running E2E, verify the AC table in `compliance/plans/REQ-XXX/implementation-plan.md` matches `compliance/evidence/REQ-XXX/test-scope.md`. Compare the AC IDs in both files — if they diverge (new AC added to plan but not re-extracted, or AC removed from plan but still in test-scope), **HALT**: "test-scope.md is out of sync with implementation-plan.md. AC IDs differ: <diff>. Re-extract test-scope.md and test-plan.md from the updated plan (Phase 1 step 5b) before running E2E."
 
 6. **On gate failure**, iterate up to N=3 attempts. Each iteration: read the failure output, propose a fix, apply, re-run. On exhausted attempts, halt with the full failure output and explicit resume instructions: "Gate <name> failed after N=3 attempts. Last failure: <output>. Operator action — fix the failure, commit to the feature branch, push, then ping `resume REQ-XXX`. The skill will re-run the gate from where it left off." Update the sticky with the same. Never use `--no-verify`, `eslint-disable`, `@ts-expect-error`, `xfail`, or any other bypass.
 7. **Commit** using Conventional Commits with `Ref: REQ-XXX` trailer and `Co-Authored-By: Claude` trailer. One commit per logical step; never amend a commit that's already been pushed.
@@ -468,6 +492,9 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
 
    ```
    compliance/evidence/REQ-XXX/
+   ├── test-scope.md                     ← extracted in Phase 1 step 5b
+   ├── test-plan.md                      ← extracted in Phase 1 step 5b
+   ├── implementation-plan.md            ← copied from compliance/plans/ in step 6b
    ├── srs-alignment.md                  ← produced in step 1 by requirements-aligner
    ├── architecture-decision.md          ← produced in step 2 by adr-author
    ├── risk-assessment.md                ← produced in step 3 by risk-register-keeper
@@ -480,7 +507,15 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
 
    Copy Playwright's `test-results/` folder verbatim into `YYYY-MM-DD_traces/` so trace-by-test-name is available for audit without walking the HTML report's hash-name index. For HIGH/CRITICAL releases the traces are part of the audit trail — _"what state was the page in when test X failed and was overridden?"_ answers in one `ls` instead of an HTML-report walk.
 
-7. **Upload each artefact to the portal** — retry each upload up to 3 times with backoff (5s, 15s, 45s). If an upload still fails after 3 retries, mark it in the RTM as `UPLOAD_FAILED` and surface a warning. Do not mark the RTM as verified for failed uploads. On `resume REQ-XXX`, re-attempt failed uploads before proceeding to Phase 4.
+6b. **Copy `implementation-plan.md` from `compliance/plans/` to `compliance/evidence/` (devaudit-installer#226).** The CI validator (`validate-compliance-artifacts.sh`) expects `implementation-plan.md` in `compliance/evidence/REQ-XXX/`, not in `compliance/plans/REQ-XXX/`. Copy (not move) the file so the plan directory retains the original:
+
+```bash
+cp compliance/plans/REQ-XXX/implementation-plan.md compliance/evidence/REQ-XXX/implementation-plan.md
+```
+
+This ensures the pre-push hook's compliance validator check passes. The plan directory retains the original for in-flight reference; the evidence directory has the copy for CI validation and audit.
+
+6. **Upload each artefact to the portal** — retry each upload up to 3 times with backoff (5s, 15s, 45s). If an upload still fails after 3 retries, mark it in the RTM as `UPLOAD_FAILED` and surface a warning. Do not mark the RTM as verified for failed uploads. On `resume REQ-XXX`, re-attempt failed uploads before proceeding to Phase 4.
    ```bash
    devaudit push <project-slug> REQ-XXX <evidence-type> <file> \
      --release "v$(date +%Y.%m.%d)" --create-release-if-missing \
@@ -489,9 +524,9 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
      --branch "$(git rev-parse --abbrev-ref HEAD)"
    ```
    Evidence types: `screenshot`, `e2e_result`, `test_report`, `audit_log`, `compliance_document`, `manual_upload`, `srs_alignment` (from step 1), `architecture_decision` (from step 2), `risk_assessment` (from step 3).
-8. **Verify uploads landed.** `gh api` or `curl` against `https://devaudit.metasession.co/projects/<slug>/requirements/REQ-XXX/evidence` should show every artefact. Any artefact marked `UPLOAD_FAILED` in step 6 should be re-attempted here.
-9. **Update `compliance/RTM.md`** with portal links for each evidence row. Rows with `UPLOAD_FAILED` status remain marked as failed — do not mark them verified.
-10. **Update SDLC status sticky** before exiting Phase 3: `bash scripts/update-sdlc-status.sh "$ISSUE_NUM" "Phase 3 complete — evidence uploaded; SRS-alignment + ADR + risk-assessment artefacts attached" "Phase 4 — sdlc-implementer auto-continuing (open release PR)"`.
+7. **Verify uploads landed.** `gh api` or `curl` against `https://devaudit.metasession.co/projects/<slug>/requirements/REQ-XXX/evidence` should show every artefact. Any artefact marked `UPLOAD_FAILED` in step 6 should be re-attempted here.
+8. **Update `compliance/RTM.md`** with portal links for each evidence row. Rows with `UPLOAD_FAILED` status remain marked as failed — do not mark them verified.
+9. **Update SDLC status sticky** before exiting Phase 3: `bash scripts/update-sdlc-status.sh "$ISSUE_NUM" "Phase 3 complete — evidence uploaded; SRS-alignment + ADR + risk-assessment artefacts attached" "Phase 4 — sdlc-implementer auto-continuing (open release PR)"`.
 
 ### Phase 4 — Submit for UAT review (SDLC stage 4)
 
@@ -535,6 +570,12 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
 
 Invoked separately by the user after UAT activity on the portal. Trigger: "resume REQ-XXX", "REQ-XXX UAT done", or just re-firing the skill on the same issue.
 
+0. **Re-read state (devaudit-installer#226).** On resume, reconstruct state from the filesystem before acting:
+   - Re-read `compliance/RTM.md` to check the REQ-XXX row's current status.
+   - Check whether `compliance/pending-releases/RELEASE-TICKET-REQ-XXX.md` still exists (not yet moved to `approved-releases/`).
+   - Check `git log` for the merge commit on `$RELEASE_BRANCH`.
+   - If resuming after an environment detour (not a UAT approval), re-read `compliance/evidence/REQ-XXX/` to see which artefacts already exist and resume at the appropriate phase.
+
 1. **Read portal state.** `curl` `https://devaudit.metasession.co/api/projects/<slug>/releases/<version>` and inspect the approval status. Retry up to 3 times with exponential backoff (5s, 15s, 45s) on 5xx responses. If all retries fail, halt — "Portal unreachable at <URL>. Cannot determine UAT approval state. Operator action — verify portal availability + API key, then ping `resume REQ-XXX`." If the API returns 401/403, halt — "Portal API key rejected (HTTP 401/403). The `DEVAUDIT_API_KEY` secret may be expired or revoked. Operator action — rotate the API key, then ping `resume REQ-XXX`." Never guess the portal state.
 
 2. **Branch on state:**
@@ -548,7 +589,16 @@ Invoked separately by the user after UAT activity on the portal. Trigger: "resum
        - If `released` (Option B): PATCH directly to `released` — `PATCH /releases/<version>` with `{"status": "released"}`.
        - If `prod_review` (Option A, default): after `post-deploy-prod.yml` completes, the release is at `prod_review`. Update the sticky to "Phase 5 — production deployed; awaiting prod approval on portal" and halt. The operator clicks "Approve Production" (`prod_review` → `prod_approved`) then "Mark as Released" (`prod_approved` → `released`) in the portal. On next `resume REQ-XXX`, the skill reads the portal state — if `released`, finalise (close issue, update sticky to terminal). If `prod_approved`, prompt the operator to click "Mark as Released". If still `prod_review`, report "awaiting production approval" and stop.
      - Comment on the issue: "Released. Production smoke evidence: <link>." (only after release status is `released`)
-     - **Update SDLC status sticky** to the terminal state: `bash scripts/update-sdlc-status.sh "$ISSUE_NUM" "Phase 5 complete — release marked Released; production smoke evidence uploaded" "Done — close issue + retire feature branch (sdlc-implementer halts)"`.
+     - **Phase 5 close-out — mandatory post-merge compliance steps (devaudit-installer#226).** After the release is marked `released` on the portal, perform the close-out:
+       1. **Update RTM status** — change the REQ-XXX row from `TESTED - PENDING SIGN-OFF` to `APPROVED - DEPLOYED` in `compliance/RTM.md`.
+       2. **Move release ticket** — move `compliance/pending-releases/RELEASE-TICKET-REQ-XXX.md` to `compliance/approved-releases/`. This prevents CI's `upload-evidence` job from treating the REQ as in-scope for subsequent releases.
+       3. **Verify portal approval** — confirm the DevAudit portal release record is in `released` status.
+       4. **Commit the close-out** — `git add compliance/RTM.md compliance/pending-releases/ compliance/approved-releases/ && git commit -m "compliance: [REQ-XXX] close out release — RTM updated to APPROVED - DEPLOYED, ticket moved to approved-releases/"`.
+       5. **Push the close-out commit** to `$INTEGRATION_BRANCH`.
+
+       These steps are mandatory — the native agent must not treat "PR merged" or "release marked Released" as completion without performing the close-out. Without moving the release ticket to `approved-releases/`, CI continues uploading evidence for the REQ on every subsequent release, polluting the portal's audit trail.
+
+     - **Update SDLC status sticky** to the terminal state: `bash scripts/update-sdlc-status.sh "$ISSUE_NUM" "Phase 5 complete — release marked Released; production smoke evidence uploaded; close-out committed (RTM → APPROVED - DEPLOYED, ticket → approved-releases/)" "Done — close issue + retire feature branch (sdlc-implementer halts)"`.
      - Close the issue.
      - If production smoke fails: do NOT mark as Released. **Delegate incident filing to `governance-doc-author` (devaudit-installer#210 §6c)** — invoke `Skill(name: "governance-doc-author", args: "Production smoke failure for REQ-XXX. File an incident issue with the `incident`label +`### Framework attribution`section (ISO29119.3.5.4 + SOC2.CC7.2), severity`blocker`. Include the production URL, git SHA, testCycleId (CI run ID), and smoke results in the issue body.")`. Page the on-call per the project's incident playbook, follow the rollback plan from the implementation plan. If the rollback also fails: update the sticky to "Phase 5 CRITICAL — production smoke failed AND rollback failed. Production is in a broken state. Operator action — page on-call immediately, engage hosting platform support, declare incident per the project's incident playbook. This is beyond the skill's scope." Do NOT attempt further automated remediation. **Update the sticky** to reflect the incident state: `… "Phase 5 BLOCKED — production smoke failed; INCIDENT issue #N filed" "Operator action — read INCIDENT #N + execute rollback per plan"`.
 
@@ -576,6 +626,61 @@ Invoked separately by the user after UAT activity on the portal. Trigger: "resum
    - **Still pending UAT (no approval, no change-request)** → report "UAT review still pending on the portal at <link>" and stop. Do not act.
 
    - **UAT rejected** → halt. Post on the issue: "UAT rejected this release. Options: (a) close PR and re-plan from scratch, (b) escalate to a different reviewer, (c) appeal the rejection with new context." See [`references/change-request-loop.md`](./references/change-request-loop.md) §"If the change-request is a rejection" for details. Do not attempt to address — the reviewer has marked the release fundamentally broken. Wait for the user to decide.
+
+## Native agent responsibilities and re-invocation protocol (devaudit-installer#226)
+
+The `skill` tool is a **stateless instruction injection** — not a persistent sub-agent. When invoked, the skill's markdown is loaded into the native agent's context. The native agent executes the steps. But the skill has no persistent state, no execution monitoring, and no re-invoke triggers. The following protocol bridges this gap.
+
+### Native agent responsibilities
+
+The native agent (the AI coding assistant executing this skill) is responsible for:
+
+- **Command execution** — running `npx playwright test`, `npm run dev`, `mongod`, etc.
+- **Environment debugging** — port conflicts, stale locks, missing binaries, Playwright browser installs
+- **Browser inspection** — reading page snapshots, DOM state, error dialogs during E2E debugging
+- **External service interaction** — Railway deploy status, UAT health checks, DevAudit portal (human-only)
+- **Git operations** — merge conflicts, push retries, branch management
+
+The skill is responsible for workflow decisions, compliance checklists, and phase transitions. The native agent executes; the skill decides what to do next.
+
+### Re-invocation protocol
+
+After any **environment detour** — service startup failure, test debugging iteration loop, CI failure fix — the native agent must re-invoke this skill to get back on track:
+
+```
+Skill(name: "sdlc-implementer", args: "resume REQ-XXX — <detour description>, re-enter at Phase N")
+```
+
+The skill re-reads state from the filesystem and continues from where it left off. It is idempotent on re-entry:
+
+- Re-read `compliance/RTM.md` to confirm the REQ-XXX row exists and has a provenance stamp.
+- Re-read `compliance/evidence/REQ-XXX/` to see which artefacts already exist.
+- Check `git log` for commits already made on this branch.
+- Resume at the appropriate phase: if Phase 2 implementation is complete but Phase 3 artefacts are missing, resume at Phase 3 step 1.
+
+The native agent must NOT continue to the next phase (Phase 3 → Phase 4, Phase 2 → Phase 3) without re-invoking the skill. The only exception is the skill's own auto-continue steps (Phase 2 step 11) where the skill explicitly says it will continue to the next phase in the same turn.
+
+**PR merged to main ≠ done.** After the release PR is merged to `main`, the native agent must re-invoke the skill for Phase 5 close-out (see Phase 5 step 0 below). The merge is not the end of the workflow — post-merge compliance steps are mandatory.
+
+### Commit-scoping rule for SRS updates (devaudit-installer#226)
+
+When a commit is authored as part of REQ-XXX's SDLC flow, the commit subject must cite `[REQ-XXX]` — the **active REQ** driving the current SDLC flow — regardless of which other REQs the content touches. Other REQs may appear in the body for traceability, but never in the subject.
+
+**Correct:**
+
+```
+docs: [REQ-085] add SRS stubs for REQ-083/084/085 — order status revert, checkout separation, tab payment
+
+Ref: REQ-083, REQ-084
+```
+
+**Incorrect:**
+
+```
+docs: [REQ-083/084] update SRS with order status revert fix and checkout separation
+```
+
+The portal's commit scanner parses `REQ-XXX` tags from commit subjects within a PR's diff. Citing the wrong REQ in the subject causes the portal to associate out-of-scope REQs with the current release.
 
 ## Compliance constraints
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,10 @@ jobs:
           E2E_SUPER_ADMIN_PASSWORD: E2eTest@2026!
           E2E_CSR_USERNAME: e2e-csr
           E2E_CSR_PASSWORD: E2eTest@2026!
+          INTERNAL_API_SECRET: ${{ secrets.INTERNAL_API_SECRET }}
+          MONNIFY_SECRET_KEY: ${{ secrets.MONNIFY_SECRET_KEY }}
+          PAYSTACK_SECRET_KEY: ${{ secrets.PAYSTACK_SECRET_KEY }}
+          ENABLE_E2E_PIN_INTERCEPT: true
         run: |
           npx tsx scripts/seed-e2e-admins.ts
           npx tsx scripts/seed-food-menu.ts
@@ -187,10 +191,9 @@ jobs:
           E2E_CSR_USERNAME: e2e-csr
           E2E_CSR_PASSWORD: E2eTest@2026!
           INTERNAL_API_SECRET: ${{ secrets.INTERNAL_API_SECRET }}
-          # REQ-074 — skip the real SMS/email dispatch in sendPinAction so the
-          # customer passwordless PIN-login flow completes in CI. The PIN is
-          # persisted to Mongo; specs read it back via getVerificationPinByPhone.
-          ENABLE_E2E_PIN_INTERCEPT: 'true'
+          MONNIFY_SECRET_KEY: ${{ secrets.MONNIFY_SECRET_KEY }}
+          PAYSTACK_SECRET_KEY: ${{ secrets.PAYSTACK_SECRET_KEY }}
+          ENABLE_E2E_PIN_INTERCEPT: true
         run: npm run dev &
 
       - name: Wait for dev server
@@ -242,10 +245,7 @@ jobs:
           INTERNAL_API_SECRET: ${{ secrets.INTERNAL_API_SECRET }}
           MONNIFY_SECRET_KEY: ${{ secrets.MONNIFY_SECRET_KEY }}
           PAYSTACK_SECRET_KEY: ${{ secrets.PAYSTACK_SECRET_KEY }}
-          # REQ-074 — skip the real SMS/email dispatch in sendPinAction so the
-          # customer passwordless PIN-login flow completes in CI. The PIN is
-          # persisted to Mongo; specs read it back via getVerificationPinByPhone.
-          ENABLE_E2E_PIN_INTERCEPT: 'true'
+          ENABLE_E2E_PIN_INTERCEPT: true
         run: npx playwright test --project=smoke --reporter=json,html
       # ── Gate 5: Build ──
 
@@ -360,14 +360,18 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Release version: ${VERSION}"
 
-      - name: Ensure release exists
+      - name: Check release exists (no creation — deferred to upload-evidence)
         if: env.DEVAUDIT_BASE_URL != ''
         run: |
+          # Release creation is deferred to the upload-evidence job (which
+          # runs after gates pass) so the portal never shows a release from
+          # a push where gates weren't verified (devaudit-installer#226).
+          # This step only checks whether the release already exists (e.g.
+          # created earlier by sdlc-implementer Phase 1 step 3).
           chmod +x scripts/upload-evidence.sh 2>/dev/null || true
-          # Create the release in DevAudit (no evidence yet — just registration)
           bash scripts/upload-evidence.sh \
             wgb _compliance-docs release_registration README.md \
-            --release ${{ steps.version.outputs.version }} --create-release-if-missing \
+            --release ${{ steps.version.outputs.version }} \
             --environment uat --category planning \
             --git-sha ${{ github.sha }} --branch ${{ github.ref_name }} || true
 
@@ -392,12 +396,7 @@ jobs:
           echo "Scanning bundled changes since ${SINCE_REF} for ${VERSION}"
           BUNDLED_FILE="compliance/pending-releases/BUNDLED-CHANGES-${VERSION}.md"
           mkdir -p compliance/pending-releases
-          bash scripts/generate-bundled-changes.sh "$SINCE_REF" "$VERSION" > "$BUNDLED_FILE" 2>/dev/null || {
-            echo "::warning::generate-bundled-changes.sh failed for ${SINCE_REF} — writing stub."
-            echo "# Bundled Changes — ${VERSION}" > "$BUNDLED_FILE"
-            echo "" >> "$BUNDLED_FILE"
-            echo "No bundled changes generated (ref ${SINCE_REF} not available)." >> "$BUNDLED_FILE"
-          }
+          bash scripts/generate-bundled-changes.sh "$SINCE_REF" "$VERSION" > "$BUNDLED_FILE"
           # Upload as bundled_changes evidence against the REQ release.
           bash scripts/upload-evidence.sh \
             wgb _compliance-docs bundled_changes "$BUNDLED_FILE" \
@@ -515,6 +514,11 @@ jobs:
         if: env.DEVAUDIT_BASE_URL != ''
         run: |
           chmod +x scripts/upload-evidence.sh 2>/dev/null || true
+          # --create-release-if-missing is intentionally here (post-gate) rather
+          # than in register-release. This ensures the portal release record only
+          # appears after gates have run — even if gates failed, the release
+          # record is created here so failure evidence attaches to it.
+          # (devaudit-installer#226)
           FLAGS="--git-sha ${{ github.sha }} --ci-run-id ${{ github.run_id }} --branch ${{ github.ref_name }}"
           FLAGS="${FLAGS} --release ${{ needs.register-release.outputs.version }} --create-release-if-missing"
           FLAGS="${FLAGS} --environment uat"

--- a/.github/workflows/compliance-evidence.yml
+++ b/.github/workflows/compliance-evidence.yml
@@ -909,7 +909,12 @@ jobs:
 
               echo "  [INCIDENT] $TEST_NAME — filing with incident label"
 
-              ISSUE_BODY="## E2E Regression Failure — ${CLASSIFICATION}
+              # DevAudit-Installer#228 — heredoc to keep markdown content
+              # inside the YAML literal block scalar (0-indent continuation
+              # lines were terminating the block and ** was parsed as YAML
+              # alias references).
+              ISSUE_BODY=$(cat <<EOF
+              ## E2E Regression Failure — ${CLASSIFICATION}
 
               **Test name:** ${TEST_NAME}
               **Error message:**
@@ -937,9 +942,11 @@ jobs:
               - [ ] \`EUAIA.Art-9 / Art-14 / Art-15\` — AI failure: <REPLACE — yes/no, which article(s)>
 
               Once closed, the \`incident-export.yml\` workflow exports this issue's body to \`compliance/governance/incident-report-<N>.md\`.
-              "
-
+              EOF
+              )
+              # Strip the 14-space heredoc indentation so the issue body is clean.
               ISSUE_BODY=$(echo "$ISSUE_BODY" | sed 's/^              //')
+
               gh issue create \
                 --title "[REGRESSION] ${TEST_NAME}" \
                 --label "incident,${CLASSIFICATION}" \
@@ -948,7 +955,9 @@ jobs:
             elif [ "$FILE_LABEL" = "test-bug" ]; then
               echo "  [TEST-BUG] $TEST_NAME — filing with test-bug label (no incident label)"
 
-              ISSUE_BODY="## E2E Regression Failure — ${CLASSIFICATION}
+              # DevAudit-Installer#228 — heredoc (see comment above).
+              ISSUE_BODY=$(cat <<EOF
+              ## E2E Regression Failure — ${CLASSIFICATION}
 
               **Test name:** ${TEST_NAME}
               **Error message:**
@@ -964,9 +973,10 @@ jobs:
               **Git SHA:** ${GIT_SHA}
 
               This failure appears to be a ${CLASSIFICATION} (not an application defect). A human should confirm and fix the ${CLASSIFICATION}, not the application. Filed with the \`test-bug\` label — this does NOT produce \`incident_report\` evidence.
-              "
-
+              EOF
+              )
               ISSUE_BODY=$(echo "$ISSUE_BODY" | sed 's/^              //')
+
               gh issue create \
                 --title "[TEST-BUG] ${TEST_NAME}" \
                 --label "test-bug" \
@@ -976,15 +986,20 @@ jobs:
           done <<< "$FAILING_TESTS"
 
           # --- Post summary comment on the workflow run ---
-          SUMMARY="E2E Regression triage summary:
-              - Flakes (not filed): ${FLAKE_COUNT}
-              - Test bugs (filed without incident label): ${TEST_BUG_COUNT}
-              - Seed-data gaps (filed without incident label): ${SEED_GAP_COUNT}
-              - Visual diffs intended (not filed): ${VISUAL_INTENDED_COUNT}
-              - Visual diffs unintended (filed as incident): ${VISUAL_UNINTENDED_COUNT}
-              - Application defects (filed as incident): ${APP_DEFECT_COUNT}"
+          # DevAudit-Installer#228 — heredoc to keep continuation lines
+          # inside the YAML literal block scalar.
+          SUMMARY=$(cat <<EOF
+          E2E Regression triage summary:
+          - Flakes (not filed): ${FLAKE_COUNT}
+          - Test bugs (filed without incident label): ${TEST_BUG_COUNT}
+          - Seed-data gaps (filed without incident label): ${SEED_GAP_COUNT}
+          - Visual diffs intended (not filed): ${VISUAL_INTENDED_COUNT}
+          - Visual diffs unintended (filed as incident): ${VISUAL_UNINTENDED_COUNT}
+          - Application defects (filed as incident): ${APP_DEFECT_COUNT}
+          EOF
+          )
+          SUMMARY=$(echo "$SUMMARY" | sed 's/^          //')
 
-          SUMMARY=$(echo "$SUMMARY" | sed 's/^              //')
           echo "$SUMMARY"
           # Post summary as a workflow run comment (using gh api).
           gh api "${{ github.repository }}/actions/runs/${CI_RUN_ID}/comments" \

--- a/.github/workflows/feature-e2e.yml
+++ b/.github/workflows/feature-e2e.yml
@@ -92,6 +92,10 @@ jobs:
           E2E_SUPER_ADMIN_PASSWORD: E2eTest@2026!
           E2E_CSR_USERNAME: e2e-csr
           E2E_CSR_PASSWORD: E2eTest@2026!
+          INTERNAL_API_SECRET: ${{ secrets.INTERNAL_API_SECRET }}
+          MONNIFY_SECRET_KEY: ${{ secrets.MONNIFY_SECRET_KEY }}
+          PAYSTACK_SECRET_KEY: ${{ secrets.PAYSTACK_SECRET_KEY }}
+          ENABLE_E2E_PIN_INTERCEPT: true
         run: |
           npx tsx scripts/seed-e2e-admins.ts
           npx tsx scripts/seed-food-menu.ts
@@ -111,6 +115,10 @@ jobs:
           E2E_SUPER_ADMIN_PASSWORD: E2eTest@2026!
           E2E_CSR_USERNAME: e2e-csr
           E2E_CSR_PASSWORD: E2eTest@2026!
+          INTERNAL_API_SECRET: ${{ secrets.INTERNAL_API_SECRET }}
+          MONNIFY_SECRET_KEY: ${{ secrets.MONNIFY_SECRET_KEY }}
+          PAYSTACK_SECRET_KEY: ${{ secrets.PAYSTACK_SECRET_KEY }}
+          ENABLE_E2E_PIN_INTERCEPT: true
         run: npm run dev &
 
       - name: Wait for dev server
@@ -151,6 +159,10 @@ jobs:
           E2E_SUPER_ADMIN_PASSWORD: E2eTest@2026!
           E2E_CSR_USERNAME: e2e-csr
           E2E_CSR_PASSWORD: E2eTest@2026!
+          INTERNAL_API_SECRET: ${{ secrets.INTERNAL_API_SECRET }}
+          MONNIFY_SECRET_KEY: ${{ secrets.MONNIFY_SECRET_KEY }}
+          PAYSTACK_SECRET_KEY: ${{ secrets.PAYSTACK_SECRET_KEY }}
+          ENABLE_E2E_PIN_INTERCEPT: true
         run: |
           REQ_ID="${{ needs.detect-req.outputs.req_id }}"
           npx playwright test --grep "$REQ_ID" --reporter=json,html

--- a/.github/workflows/incident-export.yml
+++ b/.github/workflows/incident-export.yml
@@ -198,15 +198,25 @@ jobs:
             MERGE_SHA=$(echo "$CLOSING_PRS" | jq -r '.mergeCommit.oid // .mergeCommit // "unknown"' 2>/dev/null | head -1)
             PR_TITLE=$(echo "$CLOSING_PRS" | jq -r '.title' 2>/dev/null | head -1)
             PR_NUM=$(echo "$CLOSING_PRS" | jq -r '.number' 2>/dev/null | head -1)
-            CONTAINMENT="- **Containment actions:** auto-derived from PR #${PR_NUM}: ${PR_TITLE}
-- **Mitigation deployed:** [PR #${PR_NUM}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${PR_NUM}) (${MERGE_SHA})
-- **Recovery actions:** REPLACE — if additional recovery steps were taken
-- **Verification that the incident is resolved:** REPLACE — how was the fix verified (re-run E2E, manual check, etc.)"
+            # DevAudit-Installer#228 — heredoc to keep markdown content
+            # inside the YAML literal block scalar.
+            CONTAINMENT=$(cat <<EOF
+            - **Containment actions:** auto-derived from PR #${PR_NUM}: ${PR_TITLE}
+            - **Mitigation deployed:** [PR #${PR_NUM}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${PR_NUM}) (${MERGE_SHA})
+            - **Recovery actions:** REPLACE — if additional recovery steps were taken
+            - **Verification that the incident is resolved:** REPLACE — how was the fix verified (re-run E2E, manual check, etc.)
+            EOF
+            )
+            CONTAINMENT=$(echo "$CONTAINMENT" | sed 's/^            //')
           else
-            CONTAINMENT="- **Containment actions:** REPLACE — no linked PR found
-- **Mitigation deployed:** REPLACE
-- **Recovery actions:** REPLACE
-- **Verification that the incident is resolved:** REPLACE"
+            CONTAINMENT=$(cat <<EOF
+            - **Containment actions:** REPLACE — no linked PR found
+            - **Mitigation deployed:** REPLACE
+            - **Recovery actions:** REPLACE
+            - **Verification that the incident is resolved:** REPLACE
+            EOF
+            )
+            CONTAINMENT=$(echo "$CONTAINMENT" | sed 's/^            //')
           fi
 
           # §4g — Lessons learned: scan comments for follow-up issue references.

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,8 @@ next-env.d.ts
 # which are version-controlled (refreshed by `devaudit update`).
 .claude/*
 !.claude/skills/
+
+
+# DevAudit sentinel files (devaudit-installer#226)
+.e2e-gate-passed
+.sdlc-implementer-invoked

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,9 +1,21 @@
-#!/usr/bin/env bash
-# Husky pre-push hook — runs TypeScript check as a fast gate before push.
-# The full test suite (E2E, SAST, dependency audit) runs in CI.
+#!/bin/sh
+# Husky pre-push hook — fast gates + E2E evidence + skill-invocation sentinel + compliance validator.
+#
+# Runs four checks before allowing a push:
+# 1. TypeScript check (fast gate)
+# 2. E2E evidence check — if UI-facing files changed, verify Playwright ran
+# 3. Skill-invocation sentinel — if feat/fix/refactor/perf commits present,
+#    verify sdlc-implementer was invoked
+# 4. Compliance artifact validation — if feat/fix/refactor/perf commits present,
+#    run validate-compliance-artifacts.sh to catch missing evidence files
+#
+# Bypass with --no-verify (last resort, not a habit).
 #
 # Install: cp this file to .husky/pre-push && chmod +x .husky/pre-push
 
+set -eu
+
+# ── 1. TypeScript check ──────────────────────────────────────────────
 echo "Pre-push: running TypeScript check..."
 npx tsc --noEmit
 if [ $? -ne 0 ]; then
@@ -13,3 +25,109 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 echo "Pre-push: TypeScript check passed."
+
+# ── 2. E2E evidence check (devaudit-installer#226) ───────────────────
+# Only fires if UI-facing files are in the push. Checks for either
+# playwright-report/ directory or .e2e-gate-passed sentinel (written by
+# e2e-test-engineer after a successful run).
+INTEGRATION_BRANCH=$(jq -r '.integration_branch // "develop"' sdlc-config.json 2>/dev/null || echo "develop")
+
+# Read stdin to get the pushed refs (husky pre-push protocol)
+while read -r local_ref local_sha remote_ref remote_sha; do
+  # Check if pushing to the integration branch
+  case "$remote_ref" in
+    *"refs/heads/$INTEGRATION_BRANCH") ;;
+    *) continue ;;
+  esac
+
+  # Determine the commit range being pushed
+  if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+    RANGE="$local_sha"
+  else
+    RANGE="${remote_sha}..${local_sha}"
+  fi
+
+  # Check for UI-facing files in the push
+  UI_FILES=$(git diff --name-only "$RANGE" -- 'app/**/*.tsx' 'src/**/*.tsx' 'pages/**/*.tsx' 'app/**/*.jsx' 'src/**/*.jsx' 'pages/**/*.jsx' 2>/dev/null || true)
+
+  if [ -n "$UI_FILES" ]; then
+    E2E_PASSED=false
+    if [ -f .e2e-gate-passed ]; then
+      E2E_PASSED=true
+    elif [ -d playwright-report ] && [ "$(find playwright-report -type f -newer .git/HEAD 2>/dev/null | head -1)" ]; then
+      E2E_PASSED=true
+    fi
+
+    if [ "$E2E_PASSED" = "false" ]; then
+      echo ""
+      echo "ERROR: E2E gate was not run before pushing."
+      echo "       UI-facing files changed in this push:"
+      echo "$UI_FILES" | sed 's/^/         /'
+      echo ""
+      echo "       Run 'npx playwright test' (or invoke e2e-test-engineer) before pushing."
+      echo "       Bypass with --no-verify (last resort, not a habit)."
+      exit 1
+    fi
+    echo "Pre-push: E2E evidence check passed."
+  fi
+done
+
+# ── 3. Skill-invocation sentinel (devaudit-installer#226) ────────────
+# If feat/fix/refactor/perf commits are in the push, verify the
+# sdlc-implementer skill was invoked (writes .sdlc-implementer-invoked).
+# Housekeeping types (docs/chore/ci/build/test/revert) are exempt.
+TRACKED_TYPES='^(feat|fix|refactor|perf)(\(.+\))?!?:'
+HAS_TRACKED=false
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+  case "$remote_ref" in
+    *"refs/heads/$INTEGRATION_BRANCH") ;;
+    *) continue ;;
+  esac
+  if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+    RANGE="$local_sha"
+  else
+    RANGE="${remote_sha}..${local_sha}"
+  fi
+  COMMITS=$(git log "$RANGE" --format='%s' 2>/dev/null || true)
+  if echo "$COMMITS" | grep -qE "$TRACKED_TYPES"; then
+    HAS_TRACKED=true
+  fi
+done
+
+if [ "$HAS_TRACKED" = "true" ]; then
+  if [ ! -f .sdlc-implementer-invoked ]; then
+    echo ""
+    echo "ERROR: sdlc-implementer skill was not invoked."
+    echo "       This push contains feat/fix/refactor/perf commits which require"
+    echo "       the SDLC skill flow. Invoke sdlc-implementer to drive the process,"
+    echo "       or use --no-verify to bypass (not recommended — CI will also check"
+    echo "       RTM provenance via validate-commits.sh)."
+    exit 1
+  fi
+  echo "Pre-push: skill-invocation sentinel check passed."
+fi
+
+# ── 4. Compliance artifact validation (devaudit-installer#226) ──────
+# If feat/fix/refactor/perf commits are in the push, run
+# validate-compliance-artifacts.sh to catch missing test-scope.md,
+# test-plan.md, implementation-plan.md in compliance/evidence/.
+# Reuses HAS_TRACKED from check 3.
+if [ "$HAS_TRACKED" = "true" ]; then
+  if [ -f scripts/validate-compliance-artifacts.sh ]; then
+    echo "Pre-push: running compliance artifact validation..."
+    if ! bash scripts/validate-compliance-artifacts.sh "origin/$INTEGRATION_BRANCH"; then
+      echo ""
+      echo "ERROR: Compliance artifact validation failed."
+      echo "       Missing or incomplete artifacts in compliance/evidence/."
+      echo "       Run 'bash scripts/validate-compliance-artifacts.sh' locally to see details."
+      echo "       Bypass with --no-verify (last resort, not a habit)."
+      exit 1
+    fi
+    echo "Pre-push: compliance artifact validation passed."
+  else
+    echo "Pre-push: compliance artifact validation skipped (script not found)."
+  fi
+fi
+
+echo "Pre-push: all checks passed."

--- a/scripts/validate-commits.sh
+++ b/scripts/validate-commits.sh
@@ -74,6 +74,29 @@ while IFS= read -r sha; do
         EXIT_CODE=1
         continue
       fi
+
+      # RTM provenance check (devaudit-installer#226): verify the REQ-XXX
+      # cited in the commit has an sdlc-implementer@<version> provenance
+      # stamp in compliance/RTM.md. Without the stamp, the skill was not
+      # invoked and the RTM row was created manually.
+      REQ_ID=$(echo "$SUBJECT" | grep -oP '\[REQ-\d{3,}\]' | tr -d '[]' || true)
+      if [ -z "$REQ_ID" ]; then
+        REQ_ID=$(echo "$BODY" | grep -oiP 'Ref:\s*REQ-\d{3,}' | grep -oP 'REQ-\d{3,}' | tail -1 || true)
+      fi
+      if [ -n "$REQ_ID" ] && [ -f compliance/RTM.md ]; then
+        RTM_ROW=$(grep -m1 -E "^\| ${REQ_ID} " compliance/RTM.md || true)
+        if [ -n "$RTM_ROW" ]; then
+          if ! echo "$RTM_ROW" | grep -q 'sdlc-implementer@'; then
+            echo "ERROR [$SHORT]: $REQ_ID in commit message has no sdlc-implementer provenance in RTM.md."
+            echo "       The RTM row for $REQ_ID was not created by the sdlc-implementer skill."
+            echo "       Either invoke sdlc-implementer and re-run, or add the provenance marker"
+            echo "       'sdlc-implementer@<version>' to the RTM row manually with operator sign-off."
+            FAILED=$((FAILED + 1))
+            EXIT_CODE=1
+            continue
+          fi
+        fi
+      fi
       ;;
   esac
 


### PR DESCRIPTION
DevAudit CLI sync from 0.1.71 to 0.1.73.

## Changes

- **ci.yml** — Release creation deferred to post-gate upload-evidence job (#226); adds MONNIFY/PAYSTACK secrets to seed steps; ENABLE_E2E_PIN_INTERCEPT simplified
- **compliance-evidence.yml** — Heredoc fixes for YAML literal block scalars (#228); permissions whitespace
- **feature-e2e.yml** — Adds missing INTERNAL_API_SECRET, MONNIFY_SECRET_KEY, PAYSTACK_SECRET_KEY, ENABLE_E2E_PIN_INTERCEPT env vars
- **incident-export.yml** — Heredoc fixes for YAML literal block scalars (#228)
- **.husky/pre-push** — Major upgrade: 4 checks (TypeScript + E2E evidence + skill-invocation sentinel + compliance artifact validation); POSIX/dash compatibility fix in 0.1.73
- **scripts/validate-commits.sh** — RTM provenance check (#226): verifies sdlc-implementer@<version> stamp in RTM
- **.gitignore** — Sentinel files (.e2e-gate-passed, .sdlc-implementer-invoked)
- **.claude/skills/** — sdlc-implementer + e2e-test-engineer skill doc updates

No compliance/ changes. No application source modified.