### PR TITLE
fix: ci-status-fallback.yml actually emit Quality Gates status check

### DIFF
--- a/.github/workflows/ci-status-fallback.yml
+++ b/.github/workflows/ci-status-fallback.yml
@@ -51,3 +51,15 @@ jobs:
           echo "Commit ${{ github.sha }} only touches docs/compliance paths."
           echo "Heavy quality-gates workflow (ci.yml) was correctly skipped."
           echo "This fallback emits the 'Quality Gates' status so branch protection is satisfied."
+      - name: Create passing Quality Gates status
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            repos/metasession-dev/wawagardenbar-app/statuses/${{ github.sha }} \
+            -f state=success \
+            -f context="Quality Gates" \
+            -f description="Docs/compliance-only commit - gates skipped per paths-ignore" \
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

The CI Status Fallback workflow was only logging but not creating the GitHub status check. This caused PRs to main to fail with 'CI Status Fallback expected' error because branch protection requires the 'Quality Gates' status check.

## Solution

Added a step to POST a success status to the commit via GitHub API with context 'Quality Gates'. This satisfies branch protection for docs/compliance-only commits without running the heavy gates.

## Impact

- Unblocks PR #462 (REQ-089 + REQ-090 release) from merging to main
- No code changes, only workflow fix