### PR TITLE
fix(ci): tolerate zero-match evidence scans for REQ completeness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -855,13 +855,13 @@ jobs:
                 # "zero traceable evidence" even though well-written, REQ-tagged
                 # specs exist on disk. If specs are found but weren't run in
                 # this tier, emit a non-blocking warning instead of an error.
-                SPECS_ON_DISK=$(grep -rl --include='*.spec.ts' -e "@requirement ${REQ}" -e "tagTest.*${REQ}" -e "'${REQ}'" e2e/ 2>/dev/null | wc -l)
+                SPECS_ON_DISK=$( (grep -rl --include='*.spec.ts' -e "@requirement ${REQ}" -e "tagTest.*${REQ}" -e "'${REQ}'" e2e/ 2>/dev/null || true) | wc -l )
 
                 # devaudit-installer#237 — also scan unit test files for
                 # @requirement REQ-XXX annotations. A REQ with thorough unit
                 # test coverage but no E2E specs (legitimate for API-only or
                 # backend-only changes) should not be hard-blocked.
-                UNIT_TESTS_ON_DISK=$(grep -rl --include='*.test.ts' --include='*.test.tsx' -e "@requirement ${REQ}" -e "'${REQ}'" e2e/ __tests__/ tests/ src/ 2>/dev/null | wc -l)
+                UNIT_TESTS_ON_DISK=$( (grep -rl --include='*.test.ts' --include='*.test.tsx' -e "@requirement ${REQ}" -e "'${REQ}'" e2e/ __tests__/ tests/ src/ 2>/dev/null || true) | wc -l )
 
                 # devaudit-installer#237 — check for test-execution-summary.md
                 # as a secondary signal. This is a human-authored document and


### PR DESCRIPTION
## Summary

Fixes the release-path `Upload Evidence` workflow so the REQ evidence-completeness fallback does not abort under `set -e` / `pipefail` when grep finds zero matches.

- wraps the E2E spec scan in a tolerant subshell before `wc -l`
- wraps the unit-test scan in the same way
- preserves the existing warning/error decision tree instead of exiting early

## Why this is needed

Release PR #467 is currently blocked by a failing `Upload Evidence` step.

For `REQ-090`, that step reaches the fallback evidence-completeness logic after finding no per-AC screenshots. It is supposed to:
- check for tagged tests in the run output
- fall back to scanning specs / unit tests on disk
- emit a warning for legitimate non-E2E/unit-tested cases

Instead, the shell exits immediately because `grep -rl ... | wc -l` runs under `set -e` / `pipefail`, and `grep` returns non-zero when there are no E2E spec matches. That prevents the workflow from reaching its own warning/error logic.

## Verification

Local shell reproduction under `set -euo pipefail` now completes and reports:
- `specs=0`
- `unit=1`

That is the expected state for `REQ-090` after PR #468 added the unit coverage file.

## Release impact

Once merged to `develop`, release PR #467 should stop failing on this brittle workflow path and move on to the remaining review/provenance checks.