### PR TITLE
fix(ci): grant statuses write to CI Status Fallback

### DIFF
--- a/.github/workflows/ci-status-fallback.yml
+++ b/.github/workflows/ci-status-fallback.yml
@@ -41,6 +41,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  statuses: write
+
 jobs:
   quality-gates:
     name: Quality Gates


### PR DESCRIPTION
## Summary
Grant the generated `CI Status Fallback` workflow the missing `statuses: write` permission so it can emit the synthetic `Quality Gates` commit status on docs/compliance-only commits.

## Problem
The fallback workflow currently calls the commit-status API with the default workflow token but does not request `statuses: write`, so GitHub returns `403 Resource not accessible by integration`.

Observed failure:
- run `29145995350`
- job `86527538615`
- workflow `CI Status Fallback`

This left the close-out follow-up state red even though `REQ-090` itself was already closed out correctly.

## Change
Added to `.github/workflows/ci-status-fallback.yml`:

```yaml
permissions:
  contents: read
  statuses: write
```

## Upstream follow-up
Template defect filed in `DevAudit-Installer#327` so the generated workflow source is fixed and future `devaudit update` syncs do not regress this.
