### PR TITLE
chore: sync DevAudit SDLC framework templates v0.3.11 (#476)

### DIFF
--- a/.claude/skills/sdlc-implementer/SKILL.md
+++ b/.claude/skills/sdlc-implementer/SKILL.md
@@ -553,7 +553,17 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
 
 ### Phase 4 — Submit for UAT review (SDLC stage 4)
 
-1. **Open the release PR** — the PR that carries the UAT four-eyes approval gate (`check-release-approval.yml`), always into `$RELEASE_BRANCH`: `gh pr create --base "$RELEASE_BRANCH" --head "$INTEGRATION_BRANCH"` (e.g. `develop → main`). The implementation already landed on `$INTEGRATION_BRANCH` in Phase 2; this promotes it. (Note: if other work is also waiting on `$INTEGRATION_BRANCH`, this is a bundled release — every in-scope REQ keeps its own release record and Production approval.)
+1. **Prepare the truthful release PR** — the PR that carries the UAT four-eyes approval gate (`check-release-approval.yml`), always into `$RELEASE_BRANCH` from `$INTEGRATION_BRANCH` (e.g. `develop → main`). The implementation already landed on `$INTEGRATION_BRANCH` in Phase 2; this promotes it. (Note: if other work is also waiting on `$INTEGRATION_BRANCH`, this is a bundled release — every in-scope REQ keeps its own release record and Production approval.)
+
+   Before creating a PR manually, run the synced helper:
+
+   ```bash
+   ./scripts/prepare-release-pr.sh --apply --mode=update
+   ```
+
+   This is mandatory for devaudit-installer#312. It detects an existing open `$INTEGRATION_BRANCH → $RELEASE_BRANCH` PR, derives the current governing release from the current head, and ensures there is exactly one truthful release PR. If the existing PR is stale, the default `update` mode rewrites the title/body and comments with the refresh. Use `--mode=recreate` only when the operator explicitly wants the older PR closed and a new PR opened.
+
+   If the helper reports multiple open release PRs, halt with: "Multiple open release PRs for `$INTEGRATION_BRANCH → $RELEASE_BRANCH`; operator action — close duplicates or choose the authoritative PR, then resume REQ-XXX." Do not open another PR.
 
    PR body per the SDLC PR template (see [`.github/pull_request_template.md`](../../../../../.github/pull_request_template.md)):
    - Closes #N
@@ -571,8 +581,30 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
 
 3. **Apply labels** — `awaiting-uat-review`, `risk:<class>`.
 4. **Comment on the issue**: "Implementation complete. PR #M opened. Evidence on portal: <link>. UAT review requested. Resume with `resume REQ-XXX` once UAT approval is granted on the portal."
-5. **Hard stop.** Phase 4 ends here. Do not proceed to merge; the human's next action is reviewing on the portal.
-6. **Update SDLC status sticky** before halting: `bash scripts/update-sdlc-status.sh "$ISSUE_NUM" "Phase 4 — release PR #<N> opened against $RELEASE_BRANCH; CI running" "Operator action — review PR #<N> + approve UAT release on the portal; sdlc-implementer halts until you ping resume REQ-XXX"`. This is a critical handoff — the sticky must reflect that the agent has stopped + the operator is on the hook.
+5. **Inspect PR blockers before handoff (devaudit-installer#304).** Run `gh pr view <N> --json mergeStateStatus,reviewDecision,statusCheckRollup,url` and categorize the state:
+   - `reviewDecision` not approved → human approval blocker; hand off to the reviewer.
+   - Release Approval Gate failing while portal state is not `uat_approved` → portal approval blocker; hand off to portal UAT reviewer.
+   - Release Approval Gate failing while portal state is `uat_approved` → retry path below.
+   - Compliance validation / evidence completeness failing → real workflow or evidence defect; fix or create a follow-up PR before handoff.
+   - Checks pending → wait/poll until terminal before declaring the PR ready.
+   - Stale PR context detected by `prepare-release-pr.sh` → rerun the helper in `--apply` mode and repeat this blocker inspection.
+
+   **Executable loop (devaudit-installer#304).** Use the bundled watcher rather than a one-shot `gh` read when the PR is blocked or waiting:
+
+   ```bash
+   node SDLC/bin/devaudit-sdlc.js \
+     --watch-pr=<N> \
+     --repo <owner/name> \
+     --req XXX \
+     --release REQ-XXX \
+     --project-slug <project-slug> \
+     --base-url <devaudit-base-url>
+   ```
+
+   The watcher persists retry state in `.sdlc-pr-watch.json`, polls `gh pr view` + `gh pr checks`, re-runs likely flaky workflows automatically, and re-runs the Release Approval Gate when the portal is already approved but GitHub has not converged yet. Use `--once` when you only need a single classification pass.
+
+6. **Hard stop only after blocker classification.** Phase 4 ends here. Do not proceed to merge; the human's next action is reviewing on the portal or clearing the categorized blocker above.
+7. **Update SDLC status sticky** before halting: `bash scripts/update-sdlc-status.sh "$ISSUE_NUM" "Phase 4 — truthful release PR #<N> prepared against $RELEASE_BRANCH; blockers classified" "Operator action — review PR #<N> + approve UAT release on the portal; sdlc-implementer halts until you ping resume REQ-XXX"`. This is a critical handoff — the sticky must reflect that the agent has stopped + the operator is on the hook.
 
 **When an external gate hangs or fails for unrelated reasons.** A required gate may fail for reasons outside the change's scope — flaky infra, an unrelated regression test that hangs at hour-plus runtime with no log activity, a known-failing suite. When this happens:
 
@@ -684,6 +716,10 @@ The skill re-reads state from the filesystem and continues from where it left of
 The native agent must NOT continue to the next phase (Phase 3 → Phase 4, Phase 2 → Phase 3) without re-invoking the skill. The only exception is the skill's own auto-continue steps (Phase 2 step 11) where the skill explicitly says it will continue to the next phase in the same turn.
 
 **PR merged to main ≠ done.** After the release PR is merged to `main`, the native agent must re-invoke the skill for Phase 5 close-out (see Phase 5 step 0 below). The merge is not the end of the workflow — post-merge compliance steps are mandatory.
+
+### Commit-history hygiene recovery (devaudit-installer#315)
+
+Commit-level `[REQ-XXX]` hygiene is preventive, not the strongest source of release truth after history has already merged to a protected integration branch. If CI reports a missing commit-level REQ after the branch has exactly one active tracked release ticket or one matching RTM row, treat the release ticket / RTM context as authoritative and add a follow-up compliance note instead of rewriting protected history. The generated `validate-commits.sh` implements this as a warning in the exactly-one-active-release case. If there are zero or multiple active tracked releases, the validation remains a hard error because the release context is ambiguous.
 
 ### Commit-scoping rule for SRS updates (devaudit-installer#226)
 

--- a/.github/workflows/ci-status-fallback.yml
+++ b/.github/workflows/ci-status-fallback.yml
@@ -55,15 +55,3 @@ jobs:
           echo "Commit ${{ github.sha }} only touches docs/compliance paths."
           echo "Heavy quality-gates workflow (ci.yml) was correctly skipped."
           echo "This fallback emits the 'Quality Gates' status so branch protection is satisfied."
-      - name: Create passing Quality Gates status
-        run: |
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github.v3+json" \
-            repos/metasession-dev/wawagardenbar-app/statuses/${{ github.sha }} \
-            -f state=success \
-            -f context="Quality Gates" \
-            -f description="Docs/compliance-only commit - gates skipped per paths-ignore" \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -855,13 +855,13 @@ jobs:
                 # "zero traceable evidence" even though well-written, REQ-tagged
                 # specs exist on disk. If specs are found but weren't run in
                 # this tier, emit a non-blocking warning instead of an error.
-                SPECS_ON_DISK=$( (grep -rl --include='*.spec.ts' -e "@requirement ${REQ}" -e "tagTest.*${REQ}" -e "'${REQ}'" e2e/ 2>/dev/null || true) | wc -l )
+                SPECS_ON_DISK=$( { grep -rl --include='*.spec.ts' -e "@requirement ${REQ}" -e "tagTest.*${REQ}" -e "'${REQ}'" e2e/ 2>/dev/null || true; } | wc -l | tr -d ' ')
 
                 # devaudit-installer#237 — also scan unit test files for
                 # @requirement REQ-XXX annotations. A REQ with thorough unit
                 # test coverage but no E2E specs (legitimate for API-only or
                 # backend-only changes) should not be hard-blocked.
-                UNIT_TESTS_ON_DISK=$( (grep -rl --include='*.test.ts' --include='*.test.tsx' -e "@requirement ${REQ}" -e "'${REQ}'" e2e/ __tests__/ tests/ src/ 2>/dev/null || true) | wc -l )
+                UNIT_TESTS_ON_DISK=$( { grep -rl --include='*.test.ts' --include='*.test.tsx' -e "@requirement ${REQ}" -e "'${REQ}'" e2e/ __tests__/ tests/ src/ 2>/dev/null || true; } | wc -l | tr -d ' ')
 
                 # devaudit-installer#237 — check for test-execution-summary.md
                 # as a secondary signal. This is a human-authored document and

--- a/.github/workflows/compliance-evidence.yml
+++ b/.github/workflows/compliance-evidence.yml
@@ -638,6 +638,7 @@ jobs:
     permissions:
       contents: read
       actions: read
+      issues: write
     env:
       DEVAUDIT_BASE_URL_VAR: ${{ vars.DEVAUDIT_BASE_URL }}
       DEVAUDIT_API_KEY: ${{ secrets.DEVAUDIT_API_KEY }}
@@ -682,7 +683,7 @@ jobs:
           name: e2e-regression-report
           path: e2e-artifacts/
           run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
         continue-on-error: true
 
       - name: Derive release version
@@ -726,8 +727,9 @@ jobs:
           FLAGS="${FLAGS} --test-cycle ${{ github.event.workflow_run.id }}"
 
           # In-scope REQs from pending release tickets at the triggering
-          # SHA. Fall back to `_compliance-docs` if no tickets present so
-          # the artefact at least lands somewhere visible.
+          # SHA. If the ticket was created after the triggering E2E run,
+          # recover REQs from the Playwright JSON artifact before falling
+          # back to `_compliance-docs` (DevAudit-Installer#311).
           REQS=()
           if [ -d compliance/pending-releases ]; then
             for TICKET in compliance/pending-releases/RELEASE-TICKET-REQ-*.md; do
@@ -742,6 +744,47 @@ jobs:
               REQS+=("$REQ_ID")
             done
           fi
+
+          if [ "${#REQS[@]}" -eq 0 ] && [ -f e2e-artifacts/e2e-regression-results.json ]; then
+            while IFS= read -r REQ_ID; do
+              [ -n "$REQ_ID" ] || continue
+              REQS+=("$REQ_ID")
+            done < <(python3 - <<'PY'
+            import json
+            import re
+            import sys
+
+            try:
+                with open('e2e-artifacts/e2e-regression-results.json', 'r', encoding='utf-8') as handle:
+                    data = json.load(handle)
+            except Exception:
+                sys.exit(0)
+
+            seen = set()
+
+            def walk(value):
+                if isinstance(value, str):
+                    for req in re.findall(r'REQ-[0-9]+', value):
+                        seen.add(req)
+                elif isinstance(value, dict):
+                    for item in value.values():
+                        walk(item)
+                elif isinstance(value, list):
+                    for item in value:
+                        walk(item)
+
+            walk(data)
+            for req in sorted(seen):
+                print(req)
+            PY
+            )
+          fi
+
+          if [ "${#REQS[@]}" -eq 1 ] && echo "$DERIVED_RELEASE" | grep -qE '^v[0-9]{4}\.[0-9]{2}\.[0-9]{2}([.][0-9]+)?$'; then
+            echo "E2E upload recovered tracked release ${REQS[0]} from artifact metadata; overriding bare-date release ${DERIVED_RELEASE}."
+            DERIVED_RELEASE="${REQS[0]}"
+          fi
+
           if [ "${#REQS[@]}" -eq 0 ]; then
             REQS=(_compliance-docs)
           fi
@@ -812,7 +855,9 @@ jobs:
       - name: Triage and file incidents on E2E Regression failure
         if: steps.resolve.outputs.skip != 'true' && github.event.workflow_run.conclusion == 'failure'
         env:
-          GH_TOKEN: ${{ secrets.DEVAUDIT_USER_TOKEN || github.token }}
+          # GitHub issue/label mutations use the workflow token. DevAudit
+          # user tokens are portal PATs, not guaranteed GitHub PATs (#305).
+          GH_TOKEN: ${{ github.token }}
           CI_RUN_ID: ${{ github.event.workflow_run.id }}
           WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}
           GIT_SHA: ${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/incident-export.yml
+++ b/.github/workflows/incident-export.yml
@@ -49,7 +49,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.DEVAUDIT_USER_TOKEN || github.token }}
+          # GitHub repo mutations use the workflow token. The DevAudit
+          # user token is for portal attribution, not GitHub checkout/push.
+          token: ${{ github.token }}
 
       - name: Classify routing (Path A vs Path B)
         id: route
@@ -436,7 +438,8 @@ jobs:
       - name: Direct commit to develop (Path A)
         if: steps.route.outputs.path == 'A'
         env:
-          GH_TOKEN: ${{ secrets.DEVAUDIT_USER_TOKEN || github.token }}
+          # GitHub push uses the workflow token plus job permissions.
+          GH_TOKEN: ${{ github.token }}
           OUT: ${{ steps.paths.outputs.out }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_URL: ${{ github.event.issue.html_url }}
@@ -454,7 +457,8 @@ jobs:
       - name: Open export PR (Path B)
         if: steps.route.outputs.path == 'B'
         env:
-          GH_TOKEN: ${{ secrets.DEVAUDIT_USER_TOKEN || github.token }}
+          # GitHub branch push + PR creation use the workflow token.
+          GH_TOKEN: ${{ github.token }}
           BRANCH: ${{ steps.paths.outputs.branch }}
           OUT: ${{ steps.paths.outputs.out }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/label-retention.yml
+++ b/.github/workflows/label-retention.yml
@@ -56,7 +56,9 @@ jobs:
       - name: Enforce label retention
         if: steps.opt.outputs.enabled == 'true'
         env:
-          GH_TOKEN: ${{ secrets.DEVAUDIT_USER_TOKEN || github.token }}
+          # GitHub issue/comment mutations use the workflow token. The
+          # DevAudit user token is reserved for portal attribution flows.
+          GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
           EVENT_ACTION: ${{ github.event.action }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/periodic-review.yml
+++ b/.github/workflows/periodic-review.yml
@@ -37,8 +37,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          # Need write access for the chore branch.
-          token: ${{ secrets.DEVAUDIT_USER_TOKEN || github.token }}
+          # Need write access for the chore branch. GitHub repo mutations
+          # use the workflow token; the DevAudit user token is portal auth.
+          token: ${{ github.token }}
 
       - name: Compute review period
         id: period
@@ -188,7 +189,8 @@ jobs:
 
       - name: Open / update review PR
         env:
-          GH_TOKEN: ${{ secrets.DEVAUDIT_USER_TOKEN || github.token }}
+          # GitHub branch push + PR creation use the workflow token.
+          GH_TOKEN: ${{ github.token }}
           BRANCH: ${{ steps.period.outputs.branch }}
           REVIEW_ID: ${{ steps.period.outputs.review_id }}
         run: |

--- a/.github/workflows/post-deploy-prod.yml
+++ b/.github/workflows/post-deploy-prod.yml
@@ -34,6 +34,9 @@ jobs:
   production-evidence:
     name: Production Evidence
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     env:
       DEVAUDIT_BASE_URL_VAR: ${{ vars.DEVAUDIT_BASE_URL }}
       DEVAUDIT_API_KEY: ${{ secrets.DEVAUDIT_API_KEY }}
@@ -151,7 +154,9 @@ jobs:
       - name: File incident on smoke failure
         if: failure()
         env:
-          GH_TOKEN: ${{ secrets.DEVAUDIT_USER_TOKEN || github.token }}
+          # GitHub issue/label mutations use the workflow token. DevAudit
+          # user tokens are portal PATs, not guaranteed GitHub PATs (#305).
+          GH_TOKEN: ${{ github.token }}
           PROD_URL: ${{ secrets.WAWAGARDENBAR_PROD_URL }}
           GIT_SHA: ${{ github.sha }}
           CI_RUN: ${{ github.run_id }}

--- a/.github/workflows/quality-gates-provenance.yml
+++ b/.github/workflows/quality-gates-provenance.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Verify prior Quality Gates success on head SHA
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           CURRENT_RUN_ID: ${{ github.run_id }}
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ next-env.d.ts
 .e2e-gate-passed
 .sdlc-implementer-invoked
 .e2e-evidence-wired
+.sdlc-pr-watch.json

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -38,6 +38,9 @@ echo "Pre-push: TypeScript check passed."
 # Previous code had two `while read` loops; the second consumed nothing
 # because stdin was already exhausted by the first (devaudit-installer#278).
 PUSH_REFS="$(cat)"
+PUSH_REFS_FILE=$(mktemp)
+trap 'rm -f "$PUSH_REFS_FILE"' EXIT HUP INT TERM
+printf '%s\n' "$PUSH_REFS" > "$PUSH_REFS_FILE"
 
 INTEGRATION_BRANCH=$(jq -r '.integration_branch // "develop"' sdlc-config.json 2>/dev/null || echo "develop")
 
@@ -49,7 +52,8 @@ INTEGRATION_BRANCH=$(jq -r '.integration_branch // "develop"' sdlc-config.json 2
 # (written by e2e-test-engineer Phase 5½ after validating tagTest/evidenceShot).
 # Scoped to integration-branch pushes (correct for the normal workflow).
 
-echo "$PUSH_REFS" | while read -r local_ref local_sha remote_ref remote_sha; do
+while read -r local_ref local_sha remote_ref remote_sha; do
+  [ -n "${local_ref:-}" ] || continue
   # Check if pushing to the integration branch
   case "$remote_ref" in
     *"refs/heads/$INTEGRATION_BRANCH") ;;
@@ -103,7 +107,7 @@ echo "$PUSH_REFS" | while read -r local_ref local_sha remote_ref remote_sha; do
     fi
     echo "Pre-push: E2E evidence wiring check passed."
   fi
-done
+done < "$PUSH_REFS_FILE"
 
 # ── 3. Skill-invocation sentinel (devaudit-installer#226) ────────────
 # If feat/fix/refactor/perf commits are in the push, verify the
@@ -115,8 +119,9 @@ done
 TRACKED_TYPES='^(feat|fix|refactor|perf)(\(.+\))?!?:'
 HAS_TRACKED=false
 
-# Parse stdin refs in the current shell (not a subshell) so HAS_TRACKED propagates.
+# Parse captured refs in the current shell so HAS_TRACKED propagates.
 while read -r local_ref local_sha remote_ref remote_sha; do
+  [ -n "${local_ref:-}" ] || continue
   if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
     RANGE="$local_sha"
   else
@@ -126,9 +131,7 @@ while read -r local_ref local_sha remote_ref remote_sha; do
   if echo "$COMMITS" | grep -qE "$TRACKED_TYPES"; then
     HAS_TRACKED=true
   fi
-done <<EOF
-$PUSH_REFS
-EOF
+done < "$PUSH_REFS_FILE"
 
 if [ "$HAS_TRACKED" = "true" ]; then
   if [ ! -f .sdlc-implementer-invoked ]; then
@@ -147,6 +150,7 @@ if [ "$HAS_TRACKED" = "true" ]; then
   # the sentinel must contain a phase "3" record. If it touches Phase 5
   # close-out (approved-releases/ or RTM RELEASED), sentinel must have phase "5".
   while read -r local_ref local_sha remote_ref remote_sha; do
+    [ -n "${local_ref:-}" ] || continue
     if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
       RANGE="$local_sha"
     else
@@ -177,9 +181,7 @@ if [ "$HAS_TRACKED" = "true" ]; then
         exit 1
       fi
     fi
-  done <<EOF
-$PUSH_REFS
-EOF
+  done < "$PUSH_REFS_FILE"
   echo "Pre-push: phase-progression check passed."
 fi
 

--- a/SDLC/bin/devaudit-sdlc.js
+++ b/SDLC/bin/devaudit-sdlc.js
@@ -1,25 +1,28 @@
 #!/usr/bin/env node
 const fs = require('fs');
 const path = require('path');
+const { spawnSync } = require('child_process');
 
 const args = process.argv.slice(2);
-let phase = null;
-let viewOnly = args.includes('--view');
-
-const phaseArg = args.find(arg => arg.startsWith('--phase='));
-if (phaseArg) {
-    phase = phaseArg.split('=')[1];
-} else {
-    const phaseIndex = args.indexOf('--phase');
-    if (phaseIndex !== -1 && args[phaseIndex + 1]) {
-        phase = args[phaseIndex + 1];
-    }
-}
-
-if (!phase) {
-    console.error("❌ ERROR: Missing required configuration property. Execution syntax: devaudit-sdlc --phase=<1-5|issue>");
-    process.exit(1);
-}
+const sentinelPath = path.join(process.cwd(), '.sdlc-implementer-invoked');
+const watchStatePath = path.join(process.cwd(), '.sdlc-pr-watch.json');
+const DEFAULT_POLL_INTERVAL_SECONDS = 30;
+const DEFAULT_MAX_POLLS = 40;
+const DEFAULT_FLAKY_PATTERNS = [
+    'playwright',
+    'e2e',
+    'regression',
+    'smoke',
+    'flaky',
+    'retry',
+];
+const RELEASE_APPROVAL_STATUSES = new Set([
+    'uat_approved',
+    'release_approved',
+    'prod_review',
+    'prod_approved',
+    'released',
+]);
 
 const phaseMap = {
     '1': '1-plan-requirement.raw.md',
@@ -30,53 +33,115 @@ const phaseMap = {
     'issue': 'implementing-an-sdlc-issue.raw.md'
 };
 
-const targetBlueprint = phaseMap[phase];
-if (!targetBlueprint) {
-    console.error(`❌ ERROR: Invalid phase argument [${phase}]. Supported options: 1, 2, 3, 4, 5, issue`);
+function getOption(name) {
+    const inline = args.find(arg => arg.startsWith(`--${name}=`));
+    if (inline) return inline.split('=').slice(1).join('=');
+    const index = args.indexOf(`--${name}`);
+    if (index !== -1 && args[index + 1] && !args[index + 1].startsWith('--')) {
+        return args[index + 1];
+    }
+    return null;
+}
+
+function hasFlag(name) {
+    return args.includes(`--${name}`);
+}
+
+function printUsageAndExit() {
+    console.error("❌ ERROR: Missing required configuration property. Execution syntax: devaudit-sdlc --phase=<1-5|issue> | --watch-pr=<number>");
     process.exit(1);
 }
 
-const blueprintPath = path.join(__dirname, '..', 'blueprints', targetBlueprint);
-const sentinelPath = path.join(process.cwd(), '.sdlc-implementer-invoked');
-
-if (viewOnly) {
-    if (!fs.existsSync(blueprintPath)) {
-        console.error("❌ ERROR: Target operational asset blueprint could not be resolved.");
-        process.exit(1);
-    }
-    const content = fs.readFileSync(blueprintPath, 'utf8');
-    console.log(content);
-    process.exit(0);
+function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-try {
-    // Detect the invoking agent type (devaudit-installer#278):
-    // - 'skill' when invoked via a skill mechanism (Claude Code Skill, etc.)
-    // - 'native-agent' when invoked directly by the native agent (Cursor, Windsurf, etc.)
-    // - 'cli' when invoked manually from the terminal
+function normalizeState(value) {
+    return String(value || '').trim().toLowerCase();
+}
+
+function isPendingState(value) {
+    const state = normalizeState(value);
+    return ['queued', 'in_progress', 'pending', 'waiting', 'requested', 'startup_failure', 'expected'].includes(state);
+}
+
+function isPassingState(value) {
+    const state = normalizeState(value);
+    return ['success', 'passed', 'pass', 'completed', 'neutral', 'skipped'].includes(state);
+}
+
+function isFailingState(value) {
+    const state = normalizeState(value);
+    return ['failure', 'failed', 'error', 'timed_out', 'cancelled', 'action_required'].includes(state);
+}
+
+function isReleaseApprovalState(value) {
+    return RELEASE_APPROVAL_STATUSES.has(normalizeState(value));
+}
+
+function isReleaseGateCheck(check) {
+    const haystack = `${check.name || ''} ${check.workflow || ''}`.toLowerCase();
+    return haystack.includes('release approval') || haystack.includes('uat approval');
+}
+
+function isFlakyCheck(check, patterns) {
+    const haystack = `${check.name || ''} ${check.workflow || ''}`.toLowerCase();
+    return patterns.some(pattern => haystack.includes(pattern));
+}
+
+function extractRunId(link) {
+    const match = String(link || '').match(/\/actions\/runs\/(\d+)/);
+    return match ? match[1] : null;
+}
+
+function formatCheckName(check) {
+    return check.workflow ? `${check.workflow} / ${check.name}` : String(check.name || 'unnamed-check');
+}
+
+function loadJsonFile(filePath, fallbackValue) {
+    if (!fs.existsSync(filePath)) return fallbackValue;
+    try {
+        return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    } catch (_error) {
+        return fallbackValue;
+    }
+}
+
+function saveJsonFile(filePath, value) {
+    fs.writeFileSync(filePath, JSON.stringify(value, null, 2), 'utf8');
+}
+
+function detectInvocationContext() {
     const invokedBySkill = !!(process.env.DEVAUDIT_SKILL_NAME || process.env.DEVAUDIT_SKILL_INVOKED);
     const invokedByAgent = !!(process.env.DEVAUDIT_AGENT || process.env.AI_AGENT_ID);
-    const initializedBy = invokedBySkill ? 'skill' : invokedByAgent ? 'native-agent' : 'cli';
+    return {
+        invokedBySkill,
+        invokedByAgent,
+        initializedBy: invokedBySkill ? 'skill' : invokedByAgent ? 'native-agent' : 'cli',
+        agentType: invokedBySkill
+            ? (process.env.DEVAUDIT_SKILL_NAME || 'skill')
+            : (invokedByAgent ? (process.env.DEVAUDIT_AGENT || 'native-agent') : 'manual'),
+    };
+}
 
-    // Extract REQ ID from args or environment (devaudit-installer#278)
-    let reqId = null;
-    const reqArg = args.find(arg => arg.startsWith('--req='));
-    if (reqArg) {
-        reqId = reqArg.split('=')[1];
-    } else if (process.env.DEVAUDIT_REQ_ID) {
-        reqId = process.env.DEVAUDIT_REQ_ID;
-    }
+function resolveReqId() {
+    return getOption('req') || process.env.DEVAUDIT_REQ_ID || null;
+}
+
+function appendPhaseRecord(phase) {
+    const blueprintPath = path.join(__dirname, '..', 'blueprints', phaseMap[phase]);
+    const context = detectInvocationContext();
+    const reqId = resolveReqId();
 
     const newRecord = {
         activatedAt: new Date().toISOString(),
         currentPhase: phase,
-        initializedBy: initializedBy,
+        initializedBy: context.initializedBy,
         status: 'active',
         reqId: reqId,
-        agentType: invokedBySkill ? (process.env.DEVAUDIT_SKILL_NAME || 'skill') : (invokedByAgent ? (process.env.DEVAUDIT_AGENT || 'native-agent') : 'manual'),
+        agentType: context.agentType,
     };
 
-    // Read existing sentinel and append, or create new array
     let phaseHistory = [];
     if (fs.existsSync(sentinelPath)) {
         try {
@@ -85,31 +150,402 @@ try {
             if (Array.isArray(parsed)) {
                 phaseHistory = parsed;
             } else {
-                // Legacy single-object format — migrate it into the array
                 console.warn('⚠️ WARNING: Sentinel file contained a legacy single-object format. Migrating to array format.');
                 phaseHistory = [parsed];
             }
-        } catch (parseError) {
-            // Corrupt or plain-text sentinel — start fresh
+        } catch (_parseError) {
             console.warn('⚠️ WARNING: Sentinel file was corrupt or in legacy plain-text format. Overwriting with fresh phase history.');
             phaseHistory = [];
         }
     }
 
     phaseHistory.push(newRecord);
-    fs.writeFileSync(sentinelPath, JSON.stringify(phaseHistory, null, 2), 'utf8');
+    saveJsonFile(sentinelPath, phaseHistory);
 
     console.log(`\n✅ SDLC Gateway Initialized: Appended phase ${phase} record to sentinel at ${sentinelPath}`);
     console.log(`🚀 Phase ${phase} orchestration active. Your local git commit gates are now open.`);
     console.log(`📋 Phase history: ${phaseHistory.map(r => r.currentPhase).join(' → ')}`);
-    console.log(`👤 Initialized by: ${initializedBy}${reqId ? ` (REQ-${reqId})` : ''}`);
+    console.log(`👤 Initialized by: ${context.initializedBy}${reqId ? ` (REQ-${reqId})` : ''}`);
 
     if (fs.existsSync(blueprintPath)) {
         console.log(`\n--- PHASE EXECUTION MANIFEST ---`);
         const content = fs.readFileSync(blueprintPath, 'utf8');
         console.log(content);
     }
-} catch (error) {
-    console.error("❌ SYSTEM ERROR: Failed to instantiate workspace sentinel tracking state:", error.message);
-    process.exit(1);
 }
+
+function runBlueprintView(phase) {
+    const blueprintPath = path.join(__dirname, '..', 'blueprints', phaseMap[phase]);
+    if (!fs.existsSync(blueprintPath)) {
+        console.error("❌ ERROR: Target operational asset blueprint could not be resolved.");
+        process.exit(1);
+    }
+    console.log(fs.readFileSync(blueprintPath, 'utf8'));
+}
+
+function runGhJson(ghArgs) {
+    const ghCommand = process.env.DEVAUDIT_GH_BIN || 'gh';
+    const result = process.env.DEVAUDIT_GH_BIN
+        ? spawnSync(process.execPath, [ghCommand, ...ghArgs], {
+            cwd: process.cwd(),
+            encoding: 'utf8',
+            env: process.env,
+        })
+        : spawnSync(ghCommand, ghArgs, {
+            cwd: process.cwd(),
+            encoding: 'utf8',
+            env: process.env,
+        });
+    if (result.error) {
+        throw new Error(`gh ${ghArgs.join(' ')} failed: ${result.error.message}`);
+    }
+    if (result.status !== 0) {
+        throw new Error((result.stderr || result.stdout || `gh ${ghArgs.join(' ')} exited ${result.status}`).trim());
+    }
+    const stdout = (result.stdout || '').trim();
+    return stdout ? JSON.parse(stdout) : null;
+}
+
+function runGh(ghArgs) {
+    const ghCommand = process.env.DEVAUDIT_GH_BIN || 'gh';
+    const result = process.env.DEVAUDIT_GH_BIN
+        ? spawnSync(process.execPath, [ghCommand, ...ghArgs], {
+            cwd: process.cwd(),
+            encoding: 'utf8',
+            env: process.env,
+        })
+        : spawnSync(ghCommand, ghArgs, {
+            cwd: process.cwd(),
+            encoding: 'utf8',
+            env: process.env,
+        });
+    if (result.error) {
+        throw new Error(`gh ${ghArgs.join(' ')} failed: ${result.error.message}`);
+    }
+    if (result.status !== 0) {
+        throw new Error((result.stderr || result.stdout || `gh ${ghArgs.join(' ')} exited ${result.status}`).trim());
+    }
+    return result.stdout || '';
+}
+
+function resolveRepoFromGh() {
+    const repo = runGh(['repo', 'view', '--json', 'nameWithOwner']);
+    const parsed = JSON.parse(repo);
+    if (!parsed || !parsed.nameWithOwner) {
+        throw new Error('Unable to resolve current GitHub repository nameWithOwner.');
+    }
+    return parsed.nameWithOwner;
+}
+
+async function resolvePortalStatus(baseUrl, projectSlug, releaseVersion, apiKeyEnvName) {
+    if (!baseUrl || !projectSlug || !releaseVersion) return null;
+    const apiKey = process.env[apiKeyEnvName || 'DEVAUDIT_API_KEY'];
+    if (!apiKey) return null;
+
+    const url = `${baseUrl.replace(/\/$/, '')}/api/ci/releases/resolve?projectSlug=${encodeURIComponent(projectSlug)}&versionPrefix=${encodeURIComponent(releaseVersion)}`;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10000);
+    try {
+        const response = await fetch(url, {
+            headers: { Authorization: `Bearer ${apiKey}` },
+            signal: controller.signal,
+        });
+        if (!response.ok) return null;
+        const body = await response.json();
+        return normalizeState(body && body.latest && body.latest.status);
+    } catch (_error) {
+        return null;
+    } finally {
+        clearTimeout(timeout);
+    }
+}
+
+function loadWatchState() {
+    const parsed = loadJsonFile(watchStatePath, { watches: {} });
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return { watches: {} };
+    }
+    if (!parsed.watches || typeof parsed.watches !== 'object' || Array.isArray(parsed.watches)) {
+        parsed.watches = {};
+    }
+    return parsed;
+}
+
+function getOrCreateWatch(state, key, seed) {
+    if (!state.watches[key]) {
+        state.watches[key] = {
+            prNumber: seed.prNumber,
+            repo: seed.repo,
+            reqId: seed.reqId || null,
+            releaseVersion: seed.releaseVersion || null,
+            projectSlug: seed.projectSlug || null,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            pollCount: 0,
+            reruns: {},
+            releaseGateReruns: 0,
+            lastClassification: null,
+            lastSummary: null,
+            lastPortalStatus: null,
+            history: [],
+        };
+    }
+    return state.watches[key];
+}
+
+function recordWatchHistory(watch, kind, summary, action) {
+    watch.updatedAt = new Date().toISOString();
+    watch.lastClassification = kind;
+    watch.lastSummary = summary;
+    watch.history = Array.isArray(watch.history) ? watch.history : [];
+    watch.history.push({
+        at: watch.updatedAt,
+        kind,
+        summary,
+        action: action || null,
+    });
+    if (watch.history.length > 25) {
+        watch.history = watch.history.slice(-25);
+    }
+}
+
+function classifyPrStatus(pr, checks, portalStatus, watch, options) {
+    const failingChecks = checks.filter(check => isFailingState(check.state || check.bucket));
+    const pendingChecks = checks.filter(check => isPendingState(check.state || check.bucket));
+    const releaseGate = checks.find(isReleaseGateCheck) || null;
+
+    if (normalizeState(pr.state) !== 'open') {
+        return {
+            kind: 'terminal',
+            exitCode: 0,
+            summary: `PR #${watch.prNumber} is ${normalizeState(pr.state) || 'not open'}. Watch complete.`,
+        };
+    }
+
+    if (pr.isDraft) {
+        return {
+            kind: 'waiting',
+            exitCode: 2,
+            summary: `PR #${watch.prNumber} is still a draft. Waiting for ready-for-review.`,
+        };
+    }
+
+    if (normalizeState(pr.reviewDecision) === 'changes_requested') {
+        return {
+            kind: 'blocked',
+            exitCode: 3,
+            summary: `PR #${watch.prNumber} has changes requested. Human action required before resume.`,
+        };
+    }
+
+    if (releaseGate && (isPendingState(releaseGate.state || releaseGate.bucket) || isFailingState(releaseGate.state || releaseGate.bucket))) {
+        if (portalStatus && isReleaseApprovalState(portalStatus)) {
+            const runId = extractRunId(releaseGate.link);
+            if (runId && watch.releaseGateReruns < 3) {
+                return {
+                    kind: 'action',
+                    exitCode: 4,
+                    summary: `Release approval is already ${portalStatus} on the portal. Re-running ${formatCheckName(releaseGate)}.`,
+                    action: { type: 'rerun-release-gate', runId, checkName: formatCheckName(releaseGate) },
+                };
+            }
+            return {
+                kind: 'blocked',
+                exitCode: 3,
+                summary: `Release approval is ${portalStatus} on the portal, but ${formatCheckName(releaseGate)} is still not green and cannot be auto-rerun further.`,
+            };
+        }
+        return {
+            kind: 'waiting',
+            exitCode: 2,
+            summary: `Release approval gate is not green yet. Portal status is ${portalStatus || 'unknown'}; waiting for review/approval on the portal.`,
+        };
+    }
+
+    for (const check of failingChecks) {
+        if (!isReleaseGateCheck(check) && isFlakyCheck(check, options.flakyPatterns || DEFAULT_FLAKY_PATTERNS)) {
+            const runId = extractRunId(check.link);
+            const checkKey = formatCheckName(check);
+            const priorReruns = Number((watch.reruns || {})[checkKey] || 0);
+            if (runId && priorReruns < 2) {
+                return {
+                    kind: 'action',
+                    exitCode: 4,
+                    summary: `Detected likely flaky failure in ${checkKey}. Re-running workflow.`,
+                    action: { type: 'rerun-flaky', runId, checkName: checkKey },
+                };
+            }
+        }
+    }
+
+    if (failingChecks.length > 0) {
+        return {
+            kind: 'blocked',
+            exitCode: 3,
+            summary: `PR #${watch.prNumber} has failing checks that need code fixes: ${failingChecks.map(formatCheckName).join(', ')}.`,
+        };
+    }
+
+    if (pendingChecks.length > 0) {
+        return {
+            kind: 'waiting',
+            exitCode: 2,
+            summary: `PR #${watch.prNumber} still has pending checks: ${pendingChecks.map(formatCheckName).join(', ')}.`,
+        };
+    }
+
+    if (normalizeState(pr.reviewDecision) !== 'approved') {
+        return {
+            kind: 'blocked',
+            exitCode: 3,
+            summary: `All checks are green, but PR #${watch.prNumber} still needs human review/approval.`,
+        };
+    }
+
+    return {
+        kind: 'ready',
+        exitCode: 0,
+        summary: `PR #${watch.prNumber} is approved and all observed checks are green. Ready for merge.`,
+    };
+}
+
+function performWatchAction(repo, watch, decision) {
+    if (!decision.action) return;
+    runGh(['run', 'rerun', decision.action.runId, '--repo', repo]);
+    if (decision.action.type === 'rerun-release-gate') {
+        watch.releaseGateReruns = Number(watch.releaseGateReruns || 0) + 1;
+    } else {
+        watch.reruns = watch.reruns || {};
+        watch.reruns[decision.action.checkName] = Number(watch.reruns[decision.action.checkName] || 0) + 1;
+    }
+}
+
+async function watchPullRequest() {
+    const prNumber = getOption('watch-pr');
+    if (!prNumber) printUsageAndExit();
+
+    const repo = getOption('repo') || resolveRepoFromGh();
+    const reqId = resolveReqId();
+    const releaseVersion = getOption('release') || (reqId ? `REQ-${reqId}` : null);
+    const baseUrl = getOption('base-url') || process.env.DEVAUDIT_BASE_URL || null;
+    const projectSlug = getOption('project-slug') || process.env.DEVAUDIT_PROJECT_SLUG || null;
+    const apiKeyEnvName = getOption('api-key-env') || 'DEVAUDIT_API_KEY';
+    const pollIntervalSeconds = Number.parseInt(getOption('poll-interval-seconds') || String(DEFAULT_POLL_INTERVAL_SECONDS), 10);
+    const maxPolls = Number.parseInt(getOption('max-polls') || String(DEFAULT_MAX_POLLS), 10);
+    const once = hasFlag('once');
+    const flakyPatterns = (getOption('flaky-patterns') || '')
+        .split(',')
+        .map(pattern => pattern.trim().toLowerCase())
+        .filter(Boolean);
+
+    const state = loadWatchState();
+    const watchKey = `${repo}#${prNumber}`;
+    const watch = getOrCreateWatch(state, watchKey, {
+        prNumber: Number(prNumber),
+        repo,
+        reqId,
+        releaseVersion,
+        projectSlug,
+    });
+    watch.repo = repo;
+    watch.reqId = reqId || watch.reqId || null;
+    watch.releaseVersion = releaseVersion || watch.releaseVersion || null;
+    watch.projectSlug = projectSlug || watch.projectSlug || null;
+
+    const options = {
+        flakyPatterns: flakyPatterns.length > 0 ? flakyPatterns : DEFAULT_FLAKY_PATTERNS,
+    };
+
+    let pollsRemaining = once ? 1 : maxPolls;
+    while (pollsRemaining > 0) {
+        watch.pollCount = Number(watch.pollCount || 0) + 1;
+
+        let pr;
+        let checks;
+        try {
+            pr = runGhJson(['pr', 'view', String(prNumber), '--repo', repo, '--json', 'state,isDraft,reviewDecision']);
+            checks = runGhJson(['pr', 'checks', String(prNumber), '--repo', repo, '--json', 'name,state,link,workflow,bucket']) || [];
+            if (!Array.isArray(checks)) checks = [];
+        } catch (error) {
+            recordWatchHistory(watch, 'error', `Failed to inspect PR state: ${error.message}`);
+            saveJsonFile(watchStatePath, state);
+            console.error(`❌ SYSTEM ERROR: ${error.message}`);
+            process.exit(1);
+        }
+
+        const portalStatus = await resolvePortalStatus(baseUrl, projectSlug || watch.projectSlug, releaseVersion || watch.releaseVersion, apiKeyEnvName);
+        watch.lastPortalStatus = portalStatus || watch.lastPortalStatus || null;
+
+        const decision = classifyPrStatus(pr || {}, checks, portalStatus, watch, options);
+        if (decision.kind === 'action') {
+            try {
+                performWatchAction(repo, watch, decision);
+                recordWatchHistory(watch, decision.kind, decision.summary, decision.action);
+                saveJsonFile(watchStatePath, state);
+                console.log(`🔁 ${decision.summary}`);
+            } catch (error) {
+                recordWatchHistory(watch, 'error', `Auto-rerun failed: ${error.message}`, decision.action);
+                saveJsonFile(watchStatePath, state);
+                console.error(`❌ SYSTEM ERROR: ${error.message}`);
+                process.exit(1);
+            }
+            if (once) {
+                process.exit(decision.exitCode);
+            }
+        } else {
+            recordWatchHistory(watch, decision.kind, decision.summary);
+            saveJsonFile(watchStatePath, state);
+            const prefix = decision.kind === 'ready' ? '✅' : decision.kind === 'blocked' ? '⛔' : '⏳';
+            console.log(`${prefix} ${decision.summary}`);
+            if (decision.kind === 'ready' || decision.kind === 'blocked' || decision.kind === 'terminal') {
+                process.exit(decision.exitCode);
+            }
+            if (once) {
+                process.exit(decision.exitCode);
+            }
+        }
+
+        pollsRemaining -= 1;
+        if (pollsRemaining <= 0) break;
+        await sleep(pollIntervalSeconds * 1000);
+    }
+
+    recordWatchHistory(watch, 'waiting', `Polling limit reached after ${watch.pollCount} observations. Re-run the watcher to continue monitoring.`);
+    saveJsonFile(watchStatePath, state);
+    console.log(`⏳ Polling limit reached after ${watch.pollCount} observations. Re-run the watcher to continue monitoring.`);
+    process.exit(2);
+}
+
+async function main() {
+    const phase = getOption('phase');
+    const viewOnly = hasFlag('view');
+    const watchPr = getOption('watch-pr');
+
+    if (!phase && !watchPr) {
+        printUsageAndExit();
+    }
+
+    if (watchPr) {
+        await watchPullRequest();
+        return;
+    }
+
+    if (!phaseMap[phase]) {
+        console.error(`❌ ERROR: Invalid phase argument [${phase}]. Supported options: 1, 2, 3, 4, 5, issue`);
+        process.exit(1);
+    }
+
+    if (viewOnly) {
+        runBlueprintView(phase);
+        return;
+    }
+
+    try {
+        appendPhaseRecord(phase);
+    } catch (error) {
+        console.error("❌ SYSTEM ERROR: Failed to instantiate workspace sentinel tracking state:", error.message);
+        process.exit(1);
+    }
+}
+
+main();

--- a/SDLC/joining-an-existing-project.md
+++ b/SDLC/joining-an-existing-project.md
@@ -152,9 +152,10 @@ Two distinct credentials exist; conflating them is what causes the silent-CI-tok
 |---|---|---|---|---|
 | **Personal PAT** | `mctok_…` | `~/.config/devaudit/auth.json` (per developer) | You (the user) | Your local CLI commands |
 | **Project API key** | `dak_…` | Repo secret `DEVAUDIT_API_KEY` | The project | CI's `devaudit push` calls |
-| **Operator's PAT** | `mctok_…` | Repo secret `DEVAUDIT_USER_TOKEN` | The operator (singular) | CI's mutation calls (release register, approval submit) |
+| **Operator's PAT** | `mctok_…` | Repo secret `DEVAUDIT_USER_TOKEN` | The operator (singular) | CI's DevAudit portal calls that need human attribution (release submit / approval flows) |
+| **GitHub workflow token** | `${{ github.token }}` | Issued automatically per workflow run | The GitHub Actions workflow | CI's GitHub repo mutations (checkout, branch push, PR, issue, comment, label, check-run updates) |
 
-**Never paste your personal PAT into a repo secret.** Repo `DEVAUDIT_USER_TOKEN` is operator-owned. CI portal mutations are attributed to whoever's PAT is there — if it's yours, your name shows up against every release the team ships, and the moment your PAT expires CI breaks. Rotation belongs to the operator: `devaudit install --force-team-config` on their machine.
+**Never paste your personal PAT into a repo secret.** Repo `DEVAUDIT_USER_TOKEN` is operator-owned and is not the default GitHub auth path for workflow repo mutations. CI portal mutations are attributed to whoever's PAT is there — if it's yours, your name shows up against every release the team ships, and the moment your PAT expires CI portal actions break. Rotation belongs to the operator: `devaudit install --force-team-config` on their machine.
 
 If `devaudit auth status` shows the wrong user, run `devaudit auth logout && devaudit auth login` and paste the right PAT.
 
@@ -181,10 +182,10 @@ The synced CI gates expect a specific environment. Here's what you need locally 
 
 | Surface | CI | Local (your machine) |
 |---|---|---|
-| Personal identity | `secrets.DEVAUDIT_USER_TOKEN` (operator's) | `~/.config/devaudit/auth.json` (yours) — `devaudit auth login` |
+| Personal identity | `secrets.DEVAUDIT_USER_TOKEN` (operator's, portal-only) | `~/.config/devaudit/auth.json` (yours) — `devaudit auth login` |
 | Project API key | `secrets.DEVAUDIT_API_KEY` | Usually unset locally — only needed if you're testing `devaudit push` against the live portal; ask the operator if you need to debug it |
 | Portal URL | `vars.DEVAUDIT_BASE_URL` | `~/.config/devaudit/auth.json` (set by `auth login`) or `$DEVAUDIT_BASE_URL` env |
-| GitHub auth | `${{ github.token }}` (auto) | `gh auth login` |
+| GitHub auth | `${{ github.token }}` (auto, repo mutations) | `gh auth login` |
 | Node | matrix-pinned to project's `node_version` | nvm / volta / whatever — `devaudit doctor` checks ≥ 22 |
 | `jq` / `curl` | always present on GH runners | install via package manager — `devaudit doctor` flags absence |
 

--- a/scripts/prepare-release-pr.sh
+++ b/scripts/prepare-release-pr.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# prepare-release-pr.sh — ensure there is one truthful release PR.
+#
+# Usage:
+#   ./scripts/prepare-release-pr.sh [--apply] [--mode=update|recreate]
+#
+# Default mode is dry-run + update. Dry-run prints the action it would take.
+# With --apply:
+#   - no existing PR: creates one
+#   - current PR: updates title/body only when needed
+#   - stale PR + mode=update: rewrites title/body and comments
+#   - stale PR + mode=recreate: closes old PR and opens a fresh one
+
+set -euo pipefail
+
+APPLY=false
+MODE="update"
+for arg in "$@"; do
+  case "$arg" in
+    --apply) APPLY=true ;;
+    --mode=update) MODE="update" ;;
+    --mode=recreate) MODE="recreate" ;;
+    *) echo "Unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
+
+INTEGRATION_BRANCH=$(jq -r '.integration_branch // "develop"' sdlc-config.json 2>/dev/null || echo "develop")
+RELEASE_BRANCH=$(jq -r '.release_branch // "main"' sdlc-config.json 2>/dev/null || echo "main")
+
+if [ ! -x scripts/derive-release-version.sh ]; then
+  chmod +x scripts/derive-release-version.sh 2>/dev/null || true
+fi
+CURRENT_RELEASE=$(./scripts/derive-release-version.sh)
+if [ -z "$CURRENT_RELEASE" ]; then
+  echo "No active release version derived; close-out reconciliation appears in progress." >&2
+  exit 1
+fi
+
+TITLE="Release: ${CURRENT_RELEASE}"
+BODY=$(cat <<EOF
+## Release
+
+- Release: ${CURRENT_RELEASE}
+- Base: ${RELEASE_BRANCH}
+- Head: ${INTEGRATION_BRANCH}
+
+## DevAudit
+
+- Release context is derived from the current ${INTEGRATION_BRANCH} head.
+- If this PR replaced an older release PR, the older PR was superseded because it no longer matched the governing release context.
+EOF
+)
+
+OPEN_PRS=$(gh pr list --base "$RELEASE_BRANCH" --head "$INTEGRATION_BRANCH" --state open --json number,title,body,url --limit 10)
+COUNT=$(echo "$OPEN_PRS" | jq 'length')
+
+if [ "$COUNT" -eq 0 ]; then
+  echo "No open ${INTEGRATION_BRANCH}->${RELEASE_BRANCH} PR found."
+  if [ "$APPLY" = "true" ]; then
+    gh pr create --base "$RELEASE_BRANCH" --head "$INTEGRATION_BRANCH" --title "$TITLE" --body "$BODY"
+  else
+    echo "Dry run: would create release PR titled '$TITLE'."
+  fi
+  exit 0
+fi
+
+if [ "$COUNT" -gt 1 ]; then
+  echo "ERROR: ${COUNT} open ${INTEGRATION_BRANCH}->${RELEASE_BRANCH} PRs found. Resolve duplicates manually." >&2
+  echo "$OPEN_PRS" | jq -r '.[] | "  #\(.number) \(.title) \(.url)"' >&2
+  exit 1
+fi
+
+PR_NUMBER=$(echo "$OPEN_PRS" | jq -r '.[0].number')
+PR_TITLE=$(echo "$OPEN_PRS" | jq -r '.[0].title // ""')
+PR_BODY=$(echo "$OPEN_PRS" | jq -r '.[0].body // ""')
+PR_URL=$(echo "$OPEN_PRS" | jq -r '.[0].url')
+
+if printf '%s\n%s\n' "$PR_TITLE" "$PR_BODY" | grep -q "$CURRENT_RELEASE"; then
+  echo "Open release PR #${PR_NUMBER} already matches ${CURRENT_RELEASE}: ${PR_URL}"
+  exit 0
+fi
+
+echo "Open release PR #${PR_NUMBER} is stale for current release ${CURRENT_RELEASE}: ${PR_URL}"
+echo "Current title: ${PR_TITLE}"
+
+if [ "$APPLY" != "true" ]; then
+  echo "Dry run: would ${MODE} stale PR #${PR_NUMBER} for ${CURRENT_RELEASE}."
+  exit 0
+fi
+
+if [ "$MODE" = "recreate" ]; then
+  gh pr comment "$PR_NUMBER" --body "Superseded: current ${INTEGRATION_BRANCH} head now derives ${CURRENT_RELEASE}; this PR no longer matches the governing release context."
+  gh pr close "$PR_NUMBER" --comment "Closed as superseded by ${CURRENT_RELEASE} release context."
+  gh pr create --base "$RELEASE_BRANCH" --head "$INTEGRATION_BRANCH" --title "$TITLE" --body "$BODY"
+else
+  gh pr edit "$PR_NUMBER" --title "$TITLE" --body "$BODY"
+  gh pr comment "$PR_NUMBER" --body "Release PR context refreshed: current ${INTEGRATION_BRANCH} head derives ${CURRENT_RELEASE}."
+  echo "Updated PR #${PR_NUMBER} to ${CURRENT_RELEASE}: ${PR_URL}"
+fi

--- a/scripts/validate-commits.sh
+++ b/scripts/validate-commits.sh
@@ -37,6 +37,23 @@ fi
 TOTAL=0
 FAILED=0
 
+ACTIVE_RELEASE_REQS=""
+if [ -d compliance/pending-releases ]; then
+  ACTIVE_RELEASE_REQS=$(find compliance/pending-releases -maxdepth 1 -type f \
+    -name 'RELEASE-TICKET-REQ-*.md' -print 2>/dev/null \
+    | sed -E 's|.*/RELEASE-TICKET-(REQ-[0-9]+)\.md$|\1|' | sort -u || true)
+fi
+if [ -z "$ACTIVE_RELEASE_REQS" ] && [ -f compliance/RTM.md ]; then
+  ACTIVE_RELEASE_REQS=$(sed 's/\\|/  /g' compliance/RTM.md 2>/dev/null \
+    | grep -E '\|[[:space:]]+IN PROGRESS|\|[[:space:]]+TESTED - PENDING SIGN-OFF' \
+    | grep -oE '^\|[[:space:]]*REQ-[0-9]+' \
+    | grep -oE 'REQ-[0-9]+' | sort -u || true)
+fi
+ACTIVE_RELEASE_REQ_COUNT=0
+if [ -n "$ACTIVE_RELEASE_REQS" ]; then
+  ACTIVE_RELEASE_REQ_COUNT=$(printf '%s\n' "$ACTIVE_RELEASE_REQS" | grep -c . || true)
+fi
+
 while IFS= read -r sha; do
   TOTAL=$((TOTAL + 1))
   SUBJECT=$(git log -1 --format='%s' "$sha")
@@ -66,13 +83,21 @@ while IFS= read -r sha; do
     feat|fix|refactor|perf)
       if ! echo "$SUBJECT" | grep -qP '\[REQ-\d{3,}\]' \
         && ! echo "$BODY" | grep -qiP 'Ref:\s*REQ-\d{3,}'; then
-        echo "ERROR [$SHORT]: '$TYPE' is an implementation commit but cites no requirement."
-        echo "       Add [REQ-XXX] to the subject or a 'Ref: REQ-XXX' trailer. Start work"
-        echo "       from a requirement via the sdlc-implementer skill (it assigns the REQ"
-        echo "       from the originating issue in Phase 1)."
-        FAILED=$((FAILED + 1))
-        EXIT_CODE=1
-        continue
+        if [ "$ACTIVE_RELEASE_REQ_COUNT" -eq 1 ]; then
+          ACTIVE_REQ=$(printf '%s\n' "$ACTIVE_RELEASE_REQS" | head -1)
+          echo "WARNING [$SHORT]: '$TYPE' cites no requirement, but the branch has one active tracked release (${ACTIVE_REQ})."
+          echo "       Treating the release ticket / RTM context as authoritative for this already-merged history."
+          echo "       Add a follow-up compliance note if this was not an intentional recovery path."
+          WARN_COUNT=$((WARN_COUNT + 1))
+        else
+          echo "ERROR [$SHORT]: '$TYPE' is an implementation commit but cites no requirement."
+          echo "       Add [REQ-XXX] to the subject or a 'Ref: REQ-XXX' trailer. Start work"
+          echo "       from a requirement via the sdlc-implementer skill (it assigns the REQ"
+          echo "       from the originating issue in Phase 1)."
+          FAILED=$((FAILED + 1))
+          EXIT_CODE=1
+          continue
+        fi
       fi
 
       # RTM provenance check (devaudit-installer#226): verify the REQ-XXX


### PR DESCRIPTION
## Summary

Sync the latest DevAudit SDLC installer templates (v0.3.11) into this repository. This is a housekeeping/framework update with no application code changes.

## What changed

- `SDLC/bin/devaudit-sdlc.js` + `SDLC/blueprints/*.raw.md` refreshed
- `.github/workflows/*.yml` updated:
  - `ci-status-fallback.yml`
  - `ci.yml`
  - `compliance-evidence.yml`
  - `incident-export.yml`
  - `label-retention.yml`
  - `periodic-review.yml`
  - `post-deploy-prod.yml`
  - `quality-gates-provenance.yml`
- `.husky/pre-push` hook refreshed
- `scripts/validate-commits.sh` updated
- `scripts/prepare-release-pr.sh` added
- `.claude/skills/sdlc-implementer/SKILL.md` updated
- `SDLC/joining-an-existing-project.md` updated
- `.gitignore` sentinel entries updated

## Verification

- `npx @metasession.co/devaudit-cli update --dry-run .` reviewed
- `npx @metasession.co/devaudit-cli update .` applied successfully
- `node SDLC/bin/devaudit-sdlc.js --phase=issue --view` works
- `npm run lint` — 0 errors (963 pre-existing warnings)
- `npx tsc --noEmit` — 0 errors
- `npx vitest run` could not be executed locally because the local environment has blocked install scripts and is missing the `@rolldown/binding-linux-x64-gnu` native optional dependency. CI will run the full test pack on the PR.

## Post-merge

After merging to `develop`, CI may auto-open a housekeeping release stub PR. Please review and sign it off.

Closes #476
