### PR TITLE
compliance: [REQ-091] add test-execution-summary to satisfy Test Reports gate

### DIFF
--- a/compliance/evidence/REQ-091/test-execution-summary.md
+++ b/compliance/evidence/REQ-091/test-execution-summary.md
@@ -1,0 +1,31 @@
+# Test Execution Summary — REQ-091
+
+## Requirement
+
+REQ-091: Stabilize REQ-084 AC12 E2E smoke test against nondeterministic menu seed data.
+
+## Scope
+
+Test-only change. No application code, API, schema, auth, payment, or PII changes.
+
+## Acceptance Criteria Coverage
+
+| AC | Description | Test | Result |
+|----|-------------|------|--------|
+| AC1 | AC12 targets a seeded, deterministic in-stock menu item via `data-testid` | `req-084-checkout-separation.spec.ts` — AC12 | Pass |
+| AC2 | Seeded item includes `kind: 'menu-item'` and `mainCategory: 'food'` to match customer-menu query filters | `seedMenuItem()` helper in spec | Pass |
+| AC3 | Seeded item is cleaned up after the test via `finally` block | `cleanupMenuItem()` in spec | Pass |
+| AC4 | CI Quality Gates (E2E Tests step) pass on PR #479 | GitHub Actions run 29235251080 | Pass |
+
+## Execution Details
+
+- **Test suite:** `e2e/smoke/req-084-checkout-separation.spec.ts`
+- **Test tier:** Smoke (E2E)
+- **CI run:** [29235251080](https://github.com/metasession-dev/wawagardenbar-app/actions/runs/29235251080)
+- **Branch:** `fix/REQ-091-checkout-separation-ac12-seed`
+- **PR:** [#479](https://github.com/metasession-dev/wawagardenbar-app/pull/479)
+- **Result:** All gates passed — E2E Tests ✓, TypeScript ✓, SAST ✓, Dependency Audit ✓, Build ✓
+
+## Unit Tests
+
+Not applicable — this requirement modifies only E2E test infrastructure. No application production code was changed.


### PR DESCRIPTION
## Why

The portal flags **Missing compliance gates: Test Reports** for REQ-091.

The CI uploads `compliance/evidence/REQ-XXX/test-execution-summary.md` as `evidence_type=test_report` (compliance-evidence.yml line 576). REQ-091's evidence folder was missing this file.

## What

Added `compliance/evidence/REQ-091/test-execution-summary.md` documenting the 4 ACs, the E2E test that covers them, and the CI run (29235251080, PR #479) that passed.

## Scope

Compliance doc only — no code changes.