### PR TITLE
fix(test): stabilize menu-category-cascade search regression on main

### DIFF
--- a/e2e/menu-category-cascade.spec.ts
+++ b/e2e/menu-category-cascade.spec.ts
@@ -17,11 +17,23 @@ async function expectVisibleRowsToMatch(
   rowLocator: Locator,
   expectedText: string
 ) {
-  const rows = await rowLocator.allTextContents();
-  expect(rows.length).toBeGreaterThan(0);
-  for (const row of rows) {
-    expect(row.toLowerCase()).toContain(expectedText.toLowerCase());
-  }
+  await expect
+    .poll(
+      async () => {
+        const rows = (await rowLocator.allTextContents()).map((row) =>
+          row.toLowerCase()
+        );
+        return (
+          rows.length > 0 &&
+          rows.every((row) => row.includes(expectedText.toLowerCase()))
+        );
+      },
+      {
+        message: `Expected all visible rows to contain "${expectedText}"`,
+        timeout: 10_000,
+      }
+    )
+    .toBe(true);
 }
 
 async function findMainCategoryWithContent(


### PR DESCRIPTION
## Summary
- wait for the debounced async express-order search results before asserting row contents in `e2e/menu-category-cascade.spec.ts`
- keep the assertion strict: every visible row must still contain the searched item once the result set settles

## Why
The post-merge `main` regression run failed on the `menu-category-cascade` express-order search assertion:
- expected substring: `budweiser`
- received row text: `desperadosbeer-imported₦1,500`

The page debounces search input and updates rows via an async server action. The prior spec asserted row contents immediately after `fill()`, which can observe the pre-search DOM. This change polls until the visible rows actually settle to the filtered result set.

## Tracking
- local bug: #492
- auto-filed post-merge issue: #501

## Verification
- local Playwright execution attempt reached browser launch but this shell is missing the required Playwright browser binary in `/home/william/.cache/ms-playwright/...`, so GitHub Actions is the authoritative rerun for this hotfix
