### PR TITLE
fix: include vendored xlsx tarball in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ WORKDIR /app
 # Install dependencies for native modules
 RUN apk add --no-cache libc6-compat
 
-# Copy package files
+# Copy package files and vendored tarballs needed by file: dependencies
 COPY package.json package-lock.json* ./
+COPY vendor ./vendor
 
 # Install ALL dependencies (needed for build)
 RUN npm ci
@@ -35,8 +36,9 @@ WORKDIR /app
 # Install dependencies for native modules
 RUN apk add --no-cache libc6-compat
 
-# Copy package files
+# Copy package files and vendored tarballs needed by file: dependencies
 COPY package.json package-lock.json* ./
+COPY vendor ./vendor
 
 # Install ONLY production dependencies
 RUN npm ci --omit=dev --ignore-scripts
@@ -96,4 +98,3 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
 # Start application with dumb-init for proper signal handling
 ENTRYPOINT ["dumb-init", "--"]
 CMD ["node_modules/.bin/tsx", "server.ts"]
-


### PR DESCRIPTION
Fix-forward for the failed, not-yet-released `REQ-093` production attempt.

## Root cause

`package.json` now references `xlsx` as `file:vendor/xlsx-0.20.3.tgz`, but the Railway Docker build only copied `package.json` and `package-lock.json` into the `deps` and `prod-deps` stages before `npm ci`.

That means the Docker/Railway build could not resolve the vendored tarball during install.

## Fix

Copy `vendor/` into both dependency install stages before `npm ci`.

## Why this is the right fix-forward

- production remained healthy
- PR `#504` merged to `main` but the deploy failed before this release could be marked `released`
- per the SDLC low-risk playbook, fix-forward on `develop` is preferred in this state

Ref: REQ-093
