### PR TITLE
ci: remove scheduled nightly E2E regression

### DIFF
--- a/.github/workflows/e2e-regression.yml
+++ b/.github/workflows/e2e-regression.yml
@@ -10,8 +10,8 @@
 #   - smoke      — runs on develop push via ci.yml (no change here, ~3-5 min)
 #   - critical   — Playwright project selecting e2e/smoke/ + e2e/critical/
 #                  (this workflow on PR-to-main, ~10-15 min target)
-#   - regression — all e2e/**/*.spec.ts (this workflow nightly + push-to-main +
-#                  dispatch, ~35 min with auto-issue on post-merge failure)
+#   - regression — all e2e/**/*.spec.ts (this workflow on push-to-main +
+#                  manual dispatch, ~35 min with auto-issue on post-merge failure)
 #
 # The PR-to-main path runs the critical tier so velocity isn't blocked on
 # the full regression suite. The post-merge path runs full regression
@@ -33,14 +33,13 @@ on:
         type: string
         default: ''
   # PR-to-main runs the critical tier (smoke + e2e/critical/), targeting
-  # ~10-15 min wall-clock per the 3-tier model. Push-to-main + schedule
-  # run the full regression project for the post-merge safety net.
+  # ~10-15 min wall-clock per the 3-tier model. Push-to-main runs the
+  # full regression project for the post-merge safety net; manual dispatch
+  # supports intentional operator-triggered full or scoped regression runs.
   pull_request:
     branches: [main]
   push:
     branches: [main]
-  schedule:
-    - cron: '0 2 * * *' # nightly 02:00 UTC
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -122,8 +121,8 @@ jobs:
         run: npx wait-on http://localhost:3000 --timeout 120000
 
       # Decide which Playwright project to run based on the trigger.
-      # PR-to-main runs `critical` (~10-15 min); push-to-main + schedule
-      # run `regression` (~35 min full pack); workflow_dispatch runs
+      # PR-to-main runs `critical` (~10-15 min); push-to-main runs
+      # `regression` (~35 min full pack); workflow_dispatch runs
       # regression with optional spec filter for scoped iteration.
       #
       # Fallback: if the `critical` project isn't defined in
@@ -146,7 +145,7 @@ jobs:
               fi
               echo "specs=" >> "$GITHUB_OUTPUT"
               ;;
-            push|schedule)
+            push)
               echo "project=regression" >> "$GITHUB_OUTPUT"
               echo "specs=" >> "$GITHUB_OUTPUT"
               echo "Running full regression project"


### PR DESCRIPTION
Closes #472

Classification: lightweight application-specific CI change, coordinated by #514. No tracked release or portal approval artefacts are created by this PR.

Removes only the scheduled nightly full-regression trigger. PR-to-main critical coverage, push-to-main full regression, and manual dispatch remain enabled. Workflow comments and trigger selection are aligned with the remaining paths.

Validation:
- `actionlint .github/workflows/e2e-regression.yml`
- `git diff --check`
