### PR TITLE
test: harden tab creation E2E selectors

### DIFF
--- a/e2e/critical/daily-report-payments.spec.ts
+++ b/e2e/critical/daily-report-payments.spec.ts
@@ -105,9 +105,10 @@ test.describe
     await page.goto('/dashboard/orders');
     await page.waitForLoadState('networkidle');
 
-    // The "Open a New Tab" card triggers the CreateTabDialog
-    await page.locator('text=Open a New Tab').click();
-    const createDialog = page.getByRole('dialog');
+    // Scope both controls by their accessible names. The broad text locator
+    // could resolve before the intended card/dialog was ready.
+    await page.getByRole('button', { name: /Open a New Tab/ }).click();
+    const createDialog = page.getByRole('dialog', { name: 'Create New Tab' });
     await expect(createDialog).toBeVisible();
     await createDialog.getByLabel('Table Number').fill(TEST_TABLE);
     await createDialog.getByRole('button', { name: 'Create Tab' }).click();
@@ -338,8 +339,8 @@ test.describe
     await page.goto('/dashboard/orders');
     await page.waitForLoadState('networkidle');
 
-    await page.locator('text=Open a New Tab').click();
-    const createDialog = page.getByRole('dialog');
+    await page.getByRole('button', { name: /Open a New Tab/ }).click();
+    const createDialog = page.getByRole('dialog', { name: 'Create New Tab' });
     await expect(createDialog).toBeVisible();
     await createDialog.getByLabel('Table Number').fill(TEST_TABLE_OPEN);
     await createDialog.getByRole('button', { name: 'Create Tab' }).click();


### PR DESCRIPTION
## Summary
- replace broad tab-create text locators with the trigger button's accessible name
- scope the assertion and form interaction to the `Create New Tab` dialog
- retain the existing URL assertion; no timeout-only change

## Verification
- `npx eslint e2e/critical/daily-report-payments.spec.ts`
- focused Playwright flow executed locally after restoring Chromium; a later repeat was authentication-skipped because local MongoDB was unavailable, so the PR CI run is the authoritative clean-environment repeat

Closes #498
Coordinated by #514. This is lightweight test reliability work and does not create a tracked release by itself.