### PR TITLE
fix: [REQ-094] declare bundled release ownership

### DIFF
--- a/compliance/pending-releases/RELEASE-TICKET-REQ-094.md
+++ b/compliance/pending-releases/RELEASE-TICKET-REQ-094.md
@@ -17,6 +17,16 @@ REQ-094 makes financial report attribution consistent with the WAT business-date
 - Dry-run-first, idempotent legacy provenance migration.
 - Targeted unit/integration and tagged authenticated E2E coverage.
 
+## Bundled Changes
+
+- **Core tracked release:** REQ-094 reporting attribution and reconciliation correctness.
+- **Absorbed predecessor releases:** v2026.07.14.
+- **Absorbed non-release work:** None.
+- **Why bundled here:** The pending bare-date housekeeping row is historical integration evidence and is carried into this tracked approval envelope rather than presented as an abandoned standalone release.
+- **Evidence impact:** REQ-094 retains its own implementation, test, and security evidence; eligible v2026.07.14 lineage and cycles are retained as distinct inherited housekeeping context.
+- **Reviewer impact:** Approval covers REQ-094 plus the explicitly named predecessor context. It does not relabel the predecessor work as REQ-094 implementation.
+- **Security / risk impact:** No additional application-security impact beyond the REQ-094 HIGH-risk reporting and migration controls.
+
 ## Security and migration posture
 
 No dependency or secret changes. The production migration is additive, must be dry-run and independently reviewed before apply, and never overwrites populated sale-time data.

--- a/scripts/generate-bundled-changes.sh
+++ b/scripts/generate-bundled-changes.sh
@@ -251,7 +251,21 @@ for version in "${EXPLICIT_PREDECESSORS[@]}"; do
 done
 
 COMMITS="$(git log "$SINCE_REF"..HEAD --format='%h%x09%s' 2>/dev/null || true)"
-BUNDLED="$(printf '%s\n' "$COMMITS" | grep -E "$HOUSEKEEPING_TYPES" || true)"
+# Conventional-commit type is not release ownership. A `test:` or `docs:`
+# commit can still belong to a tracked REQ (including the Ref trailer form),
+# and must never be recast as generic housekeeping in a later bundle.
+BUNDLED=""
+while IFS=$'\t' read -r sha subject; do
+  [ -n "$sha" ] || continue
+  if ! printf '%s\t%s\n' "$sha" "$subject" | grep -Eq "$HOUSEKEEPING_TYPES"; then
+    continue
+  fi
+  if git log -1 --format='%s%n%b' "$sha" | grep -Eq '\[REQ-[0-9]+\]|Ref:[[:space:]]*REQ-[0-9]+'; then
+    continue
+  fi
+  BUNDLED+="${sha}"$'\t'"${subject}"$'\n'
+done <<<"$COMMITS"
+BUNDLED="${BUNDLED%$'\n'}"
 NON_RELEASE_ITEMS='[]'
 NON_RELEASE_LINES=()
 if [ -n "$BUNDLED" ]; then

--- a/scripts/tests/generate-bundled-changes.test.sh
+++ b/scripts/tests/generate-bundled-changes.test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Regression coverage for wawagardenbar-app#519.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+mkdir -p "$WORKDIR/scripts" "$WORKDIR/compliance/pending-releases" "$WORKDIR/cli"
+cp "$ROOT/scripts/generate-bundled-changes.sh" "$WORKDIR/scripts/"
+printf '{"version":"test"}\n' > "$WORKDIR/cli/package.json"
+cat > "$WORKDIR/compliance/pending-releases/RELEASE-TICKET-REQ-200.md" <<'EOF'
+# Release Ticket — REQ-200
+- **Absorbed predecessor releases:** v2026.07.14
+EOF
+cat > "$WORKDIR/compliance/pending-releases/RELEASE-TICKET-v2026.07.14.md" <<'EOF'
+# Release Ticket: v2026.07.14 (housekeeping)
+## Summary
+Historical housekeeping context.
+EOF
+
+git -C "$WORKDIR" init -q
+git -C "$WORKDIR" config user.email test@example.invalid
+git -C "$WORKDIR" config user.name test
+git -C "$WORKDIR" add .
+git -C "$WORKDIR" commit -qm 'chore: seed bundle fixture'
+BASE="$(git -C "$WORKDIR" rev-parse HEAD)"
+git -C "$WORKDIR" commit --allow-empty -qm 'test: [REQ-199] tracked verification'
+git -C "$WORKDIR" commit --allow-empty -qm 'docs: [REQ-198] tracked documentation'
+git -C "$WORKDIR" commit --allow-empty -qm 'test: generic housekeeping verification'
+
+(cd "$WORKDIR" && bash scripts/generate-bundled-changes.sh "$BASE" REQ-200 --json-out manifest.json >/dev/null)
+jq -e '[.members[].version] == ["v2026.07.14"]' "$WORKDIR/manifest.json" >/dev/null
+jq -e '[.nonReleaseWorkItems[].title] == ["test: generic housekeeping verification"]' "$WORKDIR/manifest.json" >/dev/null
+
+echo 'generate-bundled-changes regression test passed'


### PR DESCRIPTION
## Summary
- explicitly assigns pending housekeeping release `v2026.07.14` to REQ-094
- prevents REQ-tagged `test:` / `docs:` commits from being misclassified as generic bundled housekeeping
- adds a hermetic bundle-generator regression test
- unblocks guarded bundle-manifest generation on develop without rewriting prior tracked-release ownership

## Verification
- `bash scripts/tests/generate-bundled-changes.test.sh`
- manifest has only `v2026.07.14` as an explicit predecessor member
- manifest contains no REQ-tagged work item

Fixes #519
Ref: #439