### PR TITLE
fix: [REQ-094] align bundle manifest schema

### DIFF
--- a/scripts/generate-bundled-changes.sh
+++ b/scripts/generate-bundled-changes.sh
@@ -300,7 +300,7 @@ MANIFEST_BASE="$(
     --arg repository "$REPOSITORY_SLUG" \
     --arg generatedAt "$GENERATED_AT" \
     '{
-      schemaVersion: 2,
+      schemaVersion: 1,
       approvalRelease: { version: $version },
       coreRelease: { version: $version },
       members: ($members | fromjson),

--- a/scripts/tests/generate-bundled-changes.test.sh
+++ b/scripts/tests/generate-bundled-changes.test.sh
@@ -30,7 +30,7 @@ git -C "$WORKDIR" commit --allow-empty -qm 'docs: [REQ-198] tracked documentatio
 git -C "$WORKDIR" commit --allow-empty -qm 'test: generic housekeeping verification'
 
 (cd "$WORKDIR" && bash scripts/generate-bundled-changes.sh "$BASE" REQ-200 --json-out manifest.json >/dev/null)
-jq -e '[.members[].version] == ["v2026.07.14"]' "$WORKDIR/manifest.json" >/dev/null
+jq -e '.schemaVersion == 1 and [.members[].version] == ["v2026.07.14"]' "$WORKDIR/manifest.json" >/dev/null
 jq -e '[.nonReleaseWorkItems[].title] == ["test: generic housekeeping verification"]' "$WORKDIR/manifest.json" >/dev/null
 
 echo 'generate-bundled-changes regression test passed'


### PR DESCRIPTION
## Summary
- emits the live portal-supported bundle manifest schema version
- retains explicit predecessor ownership and REQ-work exclusion
- extends the bundle-generator regression test with the contract assertion

## Verification
- `bash scripts/tests/generate-bundled-changes.test.sh`

Fixes #520
Ref: #439