### PR TITLE
fix: [REQ-094] reconcile bundle lineage

### DIFF
--- a/compliance/pending-releases/RELEASE-TICKET-REQ-094.md
+++ b/compliance/pending-releases/RELEASE-TICKET-REQ-094.md
@@ -20,11 +20,11 @@ REQ-094 makes financial report attribution consistent with the WAT business-date
 ## Bundled Changes
 
 - **Core tracked release:** REQ-094 reporting attribution and reconciliation correctness.
-- **Absorbed predecessor releases:** v2026.07.14.
+- **Absorbed predecessor releases:** None. `v2026.07.14` was already superseded by released REQ-093 and remains distinct historical lineage.
 - **Absorbed non-release work:** None.
-- **Why bundled here:** The pending bare-date housekeeping row is historical integration evidence and is carried into this tracked approval envelope rather than presented as an abandoned standalone release.
-- **Evidence impact:** REQ-094 retains its own implementation, test, and security evidence; eligible v2026.07.14 lineage and cycles are retained as distinct inherited housekeeping context.
-- **Reviewer impact:** Approval covers REQ-094 plus the explicitly named predecessor context. It does not relabel the predecessor work as REQ-094 implementation.
+- **Why bundled here:** No predecessor release is bundled. The repository's stale v2026.07.14 pending ticket is reconciled to its existing REQ-093 supersession separately.
+- **Evidence impact:** REQ-094 retains only its own implementation, test, and security evidence. REQ-093 retains v2026.07.14 lineage and cycles.
+- **Reviewer impact:** Approval covers REQ-094 only; it does not relabel or reassign prior released work.
 - **Security / risk impact:** No additional application-security impact beyond the REQ-094 HIGH-risk reporting and migration controls.
 
 ## Security and migration posture

--- a/compliance/superseded-releases/RELEASE-TICKET-v2026.07.14.md
+++ b/compliance/superseded-releases/RELEASE-TICKET-v2026.07.14.md
@@ -9,6 +9,8 @@ generated_by: "generate-housekeeping-release-ticket.sh (DevAudit-Installer#116)"
 
 # Release Ticket: v2026.07.14 (housekeeping)
 
+> **Superseded:** This release was absorbed by [REQ-093](../approved-releases/RELEASE-TICKET-REQ-093.md) and is marked `superseded` in DevAudit. It is retained here as historical lineage, not as a pending approval item.
+
 **Status:** TESTED - PENDING SIGN-OFF
 **Date:** 2026-07-14
 **Release Shape:** Housekeeping (bare-date, no REQ tag)

--- a/scripts/generate-bundled-changes.sh
+++ b/scripts/generate-bundled-changes.sh
@@ -250,7 +250,17 @@ for version in "${EXPLICIT_PREDECESSORS[@]}"; do
   PREDECESSOR_LINES+=("- \`${version}\` (${role}/${relationship}) — ${title:-Untitled release ticket}")
 done
 
-COMMITS="$(git log "$SINCE_REF"..HEAD --format='%h%x09%s' 2>/dev/null || true)"
+# A tagged REQ must never absorb arbitrary history just because this repository
+# has no recent git tag. Start the non-release scan at the first commit that
+# belongs to this REQ, then retain only genuinely REQ-free intervening work.
+SCAN_FROM="$SINCE_REF"
+if [[ "$VERSION" =~ ^REQ-[0-9]+$ ]]; then
+  FIRST_REQ_SHA="$(git log --reverse --format='%H' --grep="\\[${VERSION}\\]\\|Ref: ${VERSION}" 2>/dev/null | head -1 || true)"
+  if [ -n "$FIRST_REQ_SHA" ] && git rev-parse --verify "${FIRST_REQ_SHA}^" >/dev/null 2>&1; then
+    SCAN_FROM="${FIRST_REQ_SHA}^"
+  fi
+fi
+COMMITS="$(git log "$SCAN_FROM"..HEAD --format='%h%x09%s' 2>/dev/null || true)"
 # Conventional-commit type is not release ownership. A `test:` or `docs:`
 # commit can still belong to a tracked REQ (including the Ref trailer form),
 # and must never be recast as generic housekeeping in a later bundle.
@@ -338,7 +348,7 @@ echo "- **Why bundled here:** Explicit predecessor release tickets and non-relea
 echo "- **Evidence impact:** Evidence ownership remains on the source releases; the bundle manifest provides lineage and inherited visibility only."
 echo "- **Reviewer impact:** Approval scope includes the core tracked release plus the explicit predecessor releases and non-release work listed below."
 echo "- **Security / risk impact:** No additional security/risk impact identified automatically; reviewer must confirm in the canonical release artifacts."
-echo "- **Reference:** commit range \`${SINCE_REF}..HEAD\`"
+echo "- **Reference:** commit range \`${SCAN_FROM}..HEAD\`"
 echo ""
 
 echo "### Explicit Constituent Releases"

--- a/scripts/tests/generate-bundled-changes.test.sh
+++ b/scripts/tests/generate-bundled-changes.test.sh
@@ -9,8 +9,8 @@ trap 'rm -rf "$WORKDIR"' EXIT
 mkdir -p "$WORKDIR/scripts" "$WORKDIR/compliance/pending-releases" "$WORKDIR/cli"
 cp "$ROOT/scripts/generate-bundled-changes.sh" "$WORKDIR/scripts/"
 printf '{"version":"test"}\n' > "$WORKDIR/cli/package.json"
-cat > "$WORKDIR/compliance/pending-releases/RELEASE-TICKET-REQ-200.md" <<'EOF'
-# Release Ticket — REQ-200
+cat > "$WORKDIR/compliance/pending-releases/RELEASE-TICKET-REQ-199.md" <<'EOF'
+# Release Ticket — REQ-199
 - **Absorbed predecessor releases:** v2026.07.14
 EOF
 cat > "$WORKDIR/compliance/pending-releases/RELEASE-TICKET-v2026.07.14.md" <<'EOF'
@@ -25,11 +25,12 @@ git -C "$WORKDIR" config user.name test
 git -C "$WORKDIR" add .
 git -C "$WORKDIR" commit -qm 'chore: seed bundle fixture'
 BASE="$(git -C "$WORKDIR" rev-parse HEAD)"
+git -C "$WORKDIR" commit --allow-empty -qm 'docs: unrelated historical housekeeping'
 git -C "$WORKDIR" commit --allow-empty -qm 'test: [REQ-199] tracked verification'
 git -C "$WORKDIR" commit --allow-empty -qm 'docs: [REQ-198] tracked documentation'
 git -C "$WORKDIR" commit --allow-empty -qm 'test: generic housekeeping verification'
 
-(cd "$WORKDIR" && bash scripts/generate-bundled-changes.sh "$BASE" REQ-200 --json-out manifest.json >/dev/null)
+(cd "$WORKDIR" && bash scripts/generate-bundled-changes.sh "$BASE" REQ-199 --json-out manifest.json >/dev/null)
 jq -e '.schemaVersion == 1 and [.members[].version] == ["v2026.07.14"]' "$WORKDIR/manifest.json" >/dev/null
 jq -e '[.nonReleaseWorkItems[].title] == ["test: generic housekeeping verification"]' "$WORKDIR/manifest.json" >/dev/null
 


### PR DESCRIPTION
## Summary
- moves v2026.07.14 from stale pending state to its existing REQ-093 supersession record
- removes duplicate predecessor assignment from REQ-094
- bounds non-release bundle context to the current REQ start

## Verification
- `bash scripts/tests/generate-bundled-changes.test.sh`
- REQ-094 manifest: schema v1, zero predecessor members, no pre-REQ-094 historical work

Fixes #522
Fixes #523
Ref: #439