### PR TITLE
fix: [REQ-094] export quality-cycle portal URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,8 @@ jobs:
           fi
           [ -n "$BASE" ] || BASE="$DEVAUDIT_BASE_URL_VAR"
           [ -n "$BASE" ] || { echo "::warning::No DevAudit URL; cycle lifecycle disabled"; exit 0; }
-          echo "DEVAUDIT_BASE_URL=${BASE%/}" >> "$GITHUB_ENV"
+          export DEVAUDIT_BASE_URL="${BASE%/}"
+          echo "DEVAUDIT_BASE_URL=${DEVAUDIT_BASE_URL}" >> "$GITHUB_ENV"
           chmod +x scripts/report-test-cycle.sh scripts/report-release-check.sh 2>/dev/null || true
           bash scripts/report-test-cycle.sh start \
             --project-slug wgb \


### PR DESCRIPTION
## Summary
- exports `DEVAUDIT_BASE_URL` in the current Quality Gates shell
- retains the `$GITHUB_ENV` handoff for subsequent steps
- restores first-class develop quality-cycle reporting

## Verification
- workflow review: report-test-cycle.sh now executes with an exported URL

Fixes #525
Ref: #439