### PR TITLE
fix: [REQ-094] upload tagged feature E2E results

### DIFF
--- a/.github/workflows/feature-e2e.yml
+++ b/.github/workflows/feature-e2e.yml
@@ -221,14 +221,31 @@ jobs:
             exit 0
           fi
           export DEVAUDIT_BASE_URL="${BASE%/}"
+          LINEAGE_FLAGS=(--test-cycle "${{ github.run_id }}")
+          if [ "${{ steps.cycle.outputs.cycle_supported }}" = "true" ] && [ -n "${{ steps.cycle.outputs.cycle_record_id }}" ]; then
+            LINEAGE_FLAGS+=(--evidence-scope cycle --test-cycle-record-id "${{ steps.cycle.outputs.cycle_record_id }}")
+          fi
+
+          # The portal parses REQ/AC annotations from the JSON reporter
+          # output, not from the HTML report ZIP. This is the canonical
+          # machine-readable proof for the targeted feature E2E cycle.
+          if [ ! -f e2e-results.json ]; then
+            echo "::error::Feature E2E produced no e2e-results.json for ${REQ_ID}."
+            exit 1
+          fi
+          bash scripts/upload-evidence.sh \
+            wgb "$REQ_ID" e2e_result e2e-results.json \
+            --category e2e_result --release "$REQ_ID" --create-release-if-missing \
+            --environment uat --sdlc-stage 2 \
+            --git-sha "${{ github.event.pull_request.head.sha }}" \
+            --ci-run-id "${{ github.run_id }}" --branch "${{ github.head_ref }}" \
+            "${LINEAGE_FLAGS[@]}" \
+            --meta-key "origin=feature"
+
           if [ -d playwright-report ]; then
             zip -qr playwright-report.zip playwright-report/ 2>/dev/null || true
           fi
           if [ -f playwright-report.zip ]; then
-            LINEAGE_FLAGS=(--test-cycle "${{ github.run_id }}")
-            if [ "${{ steps.cycle.outputs.cycle_supported }}" = "true" ] && [ -n "${{ steps.cycle.outputs.cycle_record_id }}" ]; then
-              LINEAGE_FLAGS+=(--evidence-scope cycle --test-cycle-record-id "${{ steps.cycle.outputs.cycle_record_id }}")
-            fi
             bash scripts/upload-evidence.sh \
               wgb "$REQ_ID" feature_e2e_report playwright-report.zip \
               --category e2e_report --release "$REQ_ID" --create-release-if-missing \
@@ -251,10 +268,6 @@ jobs:
             exit 1
           fi
 
-          LINEAGE_FLAGS=(--test-cycle "${{ github.run_id }}")
-          if [ "${{ steps.cycle.outputs.cycle_supported }}" = "true" ] && [ -n "${{ steps.cycle.outputs.cycle_record_id }}" ]; then
-            LINEAGE_FLAGS+=(--evidence-scope cycle --test-cycle-record-id "${{ steps.cycle.outputs.cycle_record_id }}")
-          fi
           for PNG in "${SHOTS[@]}"; do
             ORIGIN_FLAGS=(--meta-key "origin=feature")
             if [ -f "${PNG}.meta.json" ]; then

--- a/__tests__/workflows/feature-e2e-evidence-contract.test.ts
+++ b/__tests__/workflows/feature-e2e-evidence-contract.test.ts
@@ -1,0 +1,25 @@
+/** @requirement REQ-094 — feature E2E must publish parseable AC evidence. */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const workflow = readFileSync(
+  resolve(process.cwd(), '.github/workflows/feature-e2e.yml'),
+  'utf8'
+);
+
+describe('feature E2E evidence publication contract', () => {
+  it('requires and uploads the annotated JSON reporter result as e2e_result', () => {
+    expect(workflow).toContain('Feature E2E produced no e2e-results.json');
+    expect(workflow).toMatch(/wgb "\$REQ_ID" e2e_result e2e-results\.json/);
+    expect(workflow).toMatch(/--category e2e_result --release "\$REQ_ID"/);
+    expect(workflow).toMatch(/--meta-key "origin=feature"/);
+  });
+
+  it('keeps per-AC screenshots as required first-class evidence', () => {
+    expect(workflow).toContain(
+      'No evidenceShot screenshots were captured for ${REQ_ID}.'
+    );
+    expect(workflow).toMatch(/wgb "\$REQ_ID" screenshot "\$PNG"/);
+  });
+});


### PR DESCRIPTION
## Summary
- publish `e2e-results.json` from Feature In-Scope E2E as canonical `e2e_result` evidence
- preserve UAT cycle and feature-origin provenance
- fail the workflow when the JSON reporter result is missing or cannot upload
- add a workflow contract test for JSON and screenshot publication

## Verification
- `npx vitest run __tests__/workflows/feature-e2e-evidence-contract.test.ts`

Closes #530