### PR TITLE
ci: stop scheduled E2E evidence uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,10 @@
 # Single consolidated job — on a self-hosted runner, parallel jobs run
 # sequentially anyway. One checkout + one cached npm ci = fast.
 #
-# PRs to develop run Quality Gates before integration. PRs to main are verified
-# by quality-gates-provenance.yml (same-SHA provenance check, not heavy CI rerun).
+# PRs to develop run Quality Gates before integration. Normal PRs to main are
+# verified by quality-gates-provenance.yml (same-SHA provenance check, not heavy
+# CI rerun). A hotfix/* PR to main is the exception: it receives fresh Quality
+# Gates on its own head SHA because it must not first travel through develop.
 # Compliance validation runs separately on PRs (compliance-validation.yml).
 
 name: CI Pipeline
@@ -15,7 +17,7 @@ name: CI Pipeline
 on:
   workflow_dispatch:
   pull_request:
-    branches: [develop]
+    branches: [develop, main]
   push:
     branches: [develop]
     paths-ignore:
@@ -40,8 +42,11 @@ jobs:
   # ──────────────────────────────────────────────
   quality-gates:
     name: Quality Gates
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.base_ref == 'develop' ||
+      startsWith(github.head_ref, 'hotfix/')
     runs-on: ubuntu-latest
-
     services:
       mongodb:
         image: mongo:7

--- a/.github/workflows/compliance-evidence.yml
+++ b/.github/workflows/compliance-evidence.yml
@@ -648,7 +648,12 @@ jobs:
   # against each in-scope REQ.
   upload-e2e-regression-evidence:
     name: Upload E2E Regression Evidence
-    if: github.event_name == 'workflow_run'
+    # Only accepted release-path executions can create portal evidence.
+    # Defence in depth: a future cron must not pollute a historical release
+    # record even if somebody re-adds schedule to E2E Regression.
+    if: >-
+      github.event_name == 'workflow_run' &&
+      contains(fromJSON('["pull_request", "push", "workflow_dispatch"]'), github.event.workflow_run.event)
     runs-on: ubuntu-latest
     # actions: read is required so `actions/download-artifact@v8` with
     # `run-id` can read another workflow's artifacts. Without it the
@@ -726,7 +731,8 @@ jobs:
 
           # Tier metadata for the portal (the operator filters/groups by
           # this on the release detail). pull_request → critical;
-          # push to main → regression; otherwise dispatch/schedule.
+          # push to main → regression; workflow_dispatch is explicitly
+          # operator-invoked. Scheduled origins are rejected at job level.
           PRIOR_EVENT="${{ github.event.workflow_run.event }}"
           PRIOR_BRANCH="${{ github.event.workflow_run.head_branch }}"
           case "$PRIOR_EVENT" in

--- a/.github/workflows/e2e-regression.yml
+++ b/.github/workflows/e2e-regression.yml
@@ -10,7 +10,7 @@
 #   - smoke      — runs on develop push via ci.yml (no change here, ~3-5 min)
 #   - critical   — Playwright project selecting e2e/smoke/ + e2e/critical/
 #                  (this workflow on PR-to-main, ~10-15 min target)
-#   - regression — all e2e/**/*.spec.ts (this workflow nightly + push-to-main +
+#   - regression — all e2e/**/*.spec.ts (this workflow on push-to-main +
 #                  dispatch, ~35 min with auto-issue on post-merge failure)
 #
 # The PR-to-main path runs the critical tier so velocity isn't blocked on
@@ -33,14 +33,12 @@ on:
         type: string
         default: ''
   # PR-to-main runs the critical tier (smoke + e2e/critical/), targeting
-  # ~10-15 min wall-clock per the 3-tier model. Push-to-main + schedule
-  # run the full regression project for the post-merge safety net.
+  # ~10-15 min wall-clock per the 3-tier model. Push-to-main runs the
+  # full regression project for the post-merge safety net.
   pull_request:
     branches: [main]
   push:
     branches: [main]
-  schedule:
-    - cron: '0 2 * * *' # nightly 02:00 UTC
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/quality-gates-provenance.yml
+++ b/.github/workflows/quality-gates-provenance.yml
@@ -9,7 +9,7 @@
 #   Quality Gates result. When that happens, neither existing workflow fires on
 #   the PR to main, so the release PR sits with missing/ambiguous protection.
 #
-#   This workflow fires on PRs to main, queries the GitHub API for prior
+#   This workflow fires on normal PRs to main, queries the GitHub API for prior
 #   successful `Quality Gates` check runs on the PR head SHA, and fails closed
 #   if none are found. It does NOT rerun heavy CI — it is a same-SHA provenance
 #   check only.
@@ -27,6 +27,10 @@ on:
 jobs:
   quality-gates:
     name: Quality Gates
+    # A hotfix is verified by the full CI Pipeline on its own head SHA. It
+    # cannot have prior develop-side provenance without violating the hotfix
+    # route; see DevAudit-Installer#431.
+    if: ${{ !startsWith(github.head_ref, 'hotfix/') }}
     runs-on: ubuntu-latest
     steps:
       - name: Verify prior Quality Gates success on head SHA


### PR DESCRIPTION
Closes #472

## Scope
- remove the nightly `schedule` trigger from project-owned E2E Regression
- accept portal E2E evidence uploads only from pull_request, push, or explicit workflow_dispatch origins
- run full Quality Gates on legitimate `hotfix/* -> main` PRs while retaining same-SHA develop provenance for normal `develop -> main` promotions
- skip the incompatible provenance check only for hotfix PRs

## Upstream template correction
- DevAudit-Installer#431 tracks the generated-template fix so `devaudit update` preserves this behavior.

## Release path
Operational release-capability hotfix from `main`. After terminal-green CI and merge, immediately open a mandatory `main` -> `develop` back-merge PR. This PR does not promote REQ-094.