### PR TITLE
chore: back-merge hotfix bundle scope guard into develop

### DIFF
--- a/.github/workflows/check-release-approval.yml
+++ b/.github/workflows/check-release-approval.yml
@@ -1,6 +1,8 @@
 # Release Approval Gate — blocks PR merge until release is approved in DevAudit.
 #
-# Four-eyes release-approval gate (always required). When UAT-environment
+# Four-eyes release-approval gate for tracked releases. Independent hotfix PRs
+# are intentionally excluded: they carry no tracked REQ release and must not
+# be forced to create or approve a phantom bare-date release. When UAT-environment
 # verification is configured for the project (sdlc-config.json `uat.enabled`),
 # the human approver factors that into their review, but the gate itself is
 # about the approval click — not the UAT-env exercise. Renamed from
@@ -34,6 +36,13 @@ permissions:
 jobs:
   check-approval:
     name: DevAudit Release Approval
+    # A hotfix goes directly to main under the documented exception path. It
+    # remains subject to its full CI gates, but is not a tracked-release
+    # promotion and therefore has no DevAudit approval record to resolve.
+    if: >-
+      github.event_name != 'pull_request' ||
+      (!startsWith(github.event.pull_request.head.ref, 'hotfix/') &&
+       !startsWith(github.event.pull_request.head.ref, 'fix/hotfix-'))
     runs-on: ubuntu-latest
     env:
       DEVAUDIT_BASE_URL_VAR: ${{ vars.DEVAUDIT_BASE_URL }}

--- a/scripts/derive-release-version.sh
+++ b/scripts/derive-release-version.sh
@@ -24,13 +24,11 @@
 #                                                                    -> empty/skip
 #   5. Fallback:                      bare date                      -> v2026.05.17
 #
-# Step 4 (DevAudit-Installer#92) handles `chore:` / `docs:` / `ci:`
-# commits (e.g. a `devaudit update` sync) landing on the integration
-# branch between feature merge and release-PR open. Such a commit has
-# no REQ tag in its message → steps 1-3 fall through. The release
-# ticket on disk is a stronger explicit-operator-state signal than the
-# bare date — when exactly one ticket is open, attribute to it.
-# Multiple open tickets stays ambiguous → bare-date fallback.
+# A pending ticket or RTM row is not commit ownership. In particular, an
+# independent main hotfix must not become part of an active UAT REQ merely
+# because its mandatory back-merge lands while that REQ is the only pending
+# ticket. The optional fallback below is disabled by default and may be used
+# only for an explicitly reviewed integration exception.
 #
 # Note (DevAudit-Installer#220): `devaudit update` syncs now include
 # `[skip ci]` in their commit message, so they no longer trigger CI
@@ -91,7 +89,7 @@ fi
 # operator's explicit state says THIS is the in-flight release. Use it.
 # Zero or multiple → ambiguous, fall through to the bare date.
 # DevAudit-Installer#92.
-if [ -d compliance/pending-releases ]; then
+if [ "${DEVAUDIT_ALLOW_PENDING_TICKET_FALLBACK:-0}" = "1" ] && [ -d compliance/pending-releases ]; then
   # NUL-delimited count so filenames with spaces don't trip us up.
   TICKET_COUNT=$(find compliance/pending-releases -maxdepth 1 -type f \
     -name 'RELEASE-TICKET-REQ-*.md' -print0 2>/dev/null \
@@ -113,7 +111,7 @@ fi
 # multiple IN PROGRESS rows → ambiguous, fall through.
 # DevAudit-Installer#95.
 RTM_PATH="${RTM_PATH:-compliance/RTM.md}"
-if [ -f "$RTM_PATH" ]; then
+if [ "${DEVAUDIT_ALLOW_PENDING_TICKET_FALLBACK:-0}" = "1" ] && [ -f "$RTM_PATH" ]; then
   # Match REQ rows whose status column starts with `IN PROGRESS`.
   # `\|[[:space:]]+IN PROGRESS` requires a pipe followed by whitespace,
   # so legend rows (`| \`IN PROGRESS\``) and prose mentions don't match.

--- a/scripts/tests/derive-release-version.test.sh
+++ b/scripts/tests/derive-release-version.test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+HELPER="$ROOT/scripts/derive-release-version.sh"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+git -C "$WORKDIR" init -q --initial-branch=main
+git -C "$WORKDIR" config user.email test@example.com
+git -C "$WORKDIR" config user.name test
+printf 'initial\n' > "$WORKDIR/file.txt"
+git -C "$WORKDIR" add file.txt
+git -C "$WORKDIR" commit -q -m 'feat: initial tracked work [REQ-094]'
+mkdir -p "$WORKDIR/compliance/pending-releases"
+printf '# Release Ticket\n' > "$WORKDIR/compliance/pending-releases/RELEASE-TICKET-REQ-094.md"
+printf 'hotfix\n' >> "$WORKDIR/file.txt"
+git -C "$WORKDIR" add file.txt
+git -C "$WORKDIR" commit -q -m 'ci: independent hotfix back-merge'
+
+DEFAULT_VERSION="$(cd "$WORKDIR" && bash "$HELPER")"
+EXPECTED_DATE="v$(date -u +%Y.%m.%d)"
+if [ "$DEFAULT_VERSION" != "$EXPECTED_DATE" ]; then
+  echo "Expected independent back-merge to derive $EXPECTED_DATE, got $DEFAULT_VERSION" >&2
+  exit 1
+fi
+
+EXCEPTION_VERSION="$(cd "$WORKDIR" && DEVAUDIT_ALLOW_PENDING_TICKET_FALLBACK=1 bash "$HELPER")"
+if [ "$EXCEPTION_VERSION" != 'REQ-094' ]; then
+  echo "Expected explicit fallback to derive REQ-094, got $EXCEPTION_VERSION" >&2
+  exit 1
+fi
+
+printf 'req change\n' >> "$WORKDIR/file.txt"
+git -C "$WORKDIR" add file.txt
+git -C "$WORKDIR" commit -q -m '[REQ-095] fix: tracked release change'
+TAGGED_VERSION="$(cd "$WORKDIR" && bash "$HELPER")"
+if [ "$TAGGED_VERSION" != 'REQ-095' ]; then
+  echo "Expected tagged commit to derive REQ-095, got $TAGGED_VERSION" >&2
+  exit 1
+fi
+
+echo 'derive-release-version regression test passed'


### PR DESCRIPTION
## Summary

Mandatory GitFlow back-merge for hotfix PR #536.

- carries the hotfix-only bundle attribution guard into develop
- carries the hotfix-only DevAudit Release Approval Gate exclusion into develop
- contains no REQ-094 release-scope change and must not regenerate or modify REQ-094 evidence

## Verification

- PR #536 Quality Gates passed
- PR #536 E2E Regression Suite passed
- PR #536 Compliance Validation passed

Refs #535