### PR TITLE
[REQ-094] fix: scope E2E evidence to executed tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -719,18 +719,17 @@ jobs:
               --environment uat --sdlc-stage 2
           fi
 
-          # devaudit-installer#200 Fix 4 — Per-REQ gate evidence fan-out.
+          # Per-REQ gate evidence fan-out.
           # The gate evidence above was uploaded to the single commit-derived
           # release (FLAGS carries --release <derived>). When multiple REQs
           # have pending release tickets, only that one REQ gets gate evidence
           # on the portal — other in-scope REQs show "no gate evidence" and
           # "no tests tagged with this REQ" even though the gates ran and
-          # passed. Fan out gate-outcomes.json + e2e-results.json to each
-          # in-scope REQ's release so the portal's per-REQ test parser can
-          # extract REQ-tagged tests from the e2e-results.json associated with
-          # that REQ's release. Heavy run-context artefacts (SAST, dep-audit,
-          # playwright zip, coverage) remain on the commit-derived release
-          # only — they are run-level, not per-REQ.
+          # passed. Gate outcomes can be attached to every active REQ, but an
+          # E2E JSON result is REQ-scoped proof only when it actually contains
+          # an executed test tagged for that REQ. A smoke run must never
+          # overwrite or obscure a prior targeted feature execution merely
+          # because a pending ticket exists (WGB #530).
           COMMIT_REQ="${{ needs.register-release.outputs.version }}"
           FANOUT_REQS=()
           if [ -d compliance/pending-releases ]; then
@@ -761,10 +760,12 @@ jobs:
                   wgb "${REQ_ID}" gate_outcome ci-evidence/gate-outcomes.json \
                   --category ci_pipeline ${FANOUT_FLAGS}
               fi
-              if [ -f ci-evidence/e2e-results.json ]; then
+              if [ -f ci-evidence/e2e-results.json ] && python3 scripts/has-req-tagged-e2e-result.py "$REQ_ID" ci-evidence/e2e-results.json; then
                 upload "e2e-results.json -> ${REQ_ID}" \
                   wgb "${REQ_ID}" e2e_result ci-evidence/e2e-results.json \
                   --category e2e_result ${FANOUT_FLAGS}
+              elif [ -f ci-evidence/e2e-results.json ]; then
+                echo "::notice::Not attaching generic E2E JSON to ${REQ_ID}: this CI tier executed no tagged ${REQ_ID} test. Run-level evidence remains on _compliance-docs."
               fi
             done
           fi

--- a/components/features/admin/profitability-charts.tsx
+++ b/components/features/admin/profitability-charts.tsx
@@ -35,7 +35,7 @@ export function ProfitabilityCharts({
     return null;
   }
 
-  const { trends, byOrderType } = report;
+  const { trends, byCategory, byOrderType } = report;
 
   // Calculate max values for scaling
   const maxRevenue = Math.max(...trends.daily.map((d) => d.revenue));
@@ -130,7 +130,7 @@ export function ProfitabilityCharts({
       </Card>
 
       {/* Order Type Profitability */}
-      <Card>
+      <Card aria-label="Profitability by order type">
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <BarChart3 className="h-5 w-5" />
@@ -189,6 +189,40 @@ export function ProfitabilityCharts({
               })
             )}
           </div>
+        </CardContent>
+      </Card>
+
+      <Card aria-label="Profitability by category">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <BarChart3 className="h-5 w-5" />
+            Profitability by Category
+          </CardTitle>
+          <CardDescription>
+            Category attribution for the selected report filters
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {byCategory.length === 0 ? (
+            <p className="text-sm text-muted-foreground text-center py-8">
+              No category data available for the selected period
+            </p>
+          ) : (
+            <div className="space-y-3">
+              {byCategory.map((entry) => (
+                <div key={entry.category} className="flex items-center justify-between border-b pb-2 last:border-0">
+                  <div>
+                    <p className="font-medium">{entry.category}</p>
+                    <p className="text-xs text-muted-foreground">{entry.orderCount} orders</p>
+                  </div>
+                  <div className="text-right">
+                    <p className="font-medium">₦{entry.totalRevenue.toLocaleString()}</p>
+                    <p className="text-xs text-green-600">{entry.profitMargin.toFixed(1)}% margin</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/e2e/reports/profitability-attribution.spec.ts
+++ b/e2e/reports/profitability-attribution.spec.ts
@@ -33,5 +33,13 @@ test('REQ-094 profitability reviewer can select a named category filter', async 
   await category.click();
   await page.getByRole('option', { name: 'Local Beer' }).click();
   await expect(category).toContainText('Local Beer');
+  await expect(category).toBeEnabled();
+  await expect(page.getByText('Total Revenue', { exact: true })).toBeVisible();
+  await expect(page.getByText('Revenue vs Cost vs Profit', { exact: true })).toBeVisible();
+  await expect(page.getByText('Profitability by Order Type', { exact: true })).toBeVisible();
+  const categoryBreakdown = page.getByLabel('Profitability by category');
+  await expect(categoryBreakdown).toBeVisible();
+  await expect(categoryBreakdown).not.toContainText('No category data available');
+  await expect(categoryBreakdown).toContainText('beer-local');
   await evidenceShot(page, 'REQ-094', 3, 'profitability-category-filter');
 });

--- a/scripts/has-req-tagged-e2e-result.py
+++ b/scripts/has-req-tagged-e2e-result.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Return success when a Playwright JSON result executed a tagged REQ test."""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+def values(value):
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, dict):
+        return [str(value.get("type", "")), str(value.get("description", ""))]
+    return []
+
+
+def tagged(node, ancestry, req_id):
+    text = [*ancestry, str(node.get("title", ""))]
+    for field in ("annotations", "tags"):
+        for value in node.get(field, []):
+            text.extend(values(value))
+    return any(req_id in value for value in text)
+
+
+def executed(test):
+    results = test.get("results", [])
+    return any(result.get("status") not in {"skipped", "interrupted"} for result in results)
+
+
+def contains_tagged_execution(node, ancestry, req_id):
+    title = str(node.get("title", ""))
+    path = [*ancestry, title] if title else ancestry
+    for spec in node.get("specs", []):
+        if tagged(spec, path, req_id) and any(executed(test) for test in spec.get("tests", [])):
+            return True
+    for test in node.get("tests", []):
+        if tagged(test, path, req_id) and executed(test):
+            return True
+    return any(contains_tagged_execution(suite, path, req_id) for suite in node.get("suites", []))
+
+
+def main():
+    if len(sys.argv) != 3 or not re.fullmatch(r"REQ-[A-Z0-9-]+", sys.argv[1]):
+        raise SystemExit("usage: has-req-tagged-e2e-result.py REQ-XXX e2e-results.json")
+
+    req_id, filename = sys.argv[1:]
+    with Path(filename).open(encoding="utf-8") as handle:
+        report = json.load(handle)
+    raise SystemExit(0 if contains_tagged_execution(report, [], req_id) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/has-req-tagged-e2e-result.test.sh
+++ b/scripts/tests/has-req-tagged-e2e-result.test.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+HELPER="$ROOT/scripts/has-req-tagged-e2e-result.py"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+cat > "$WORKDIR/tagged.json" <<'EOF'
+{
+  "suites": [{"title":"profitability", "specs":[{"title":"select category", "annotations":[{"type":"req","description":"REQ-094 AC3"}], "tests":[{"results":[{"status":"passed"}]}]}]}]
+}
+EOF
+python3 "$HELPER" REQ-094 "$WORKDIR/tagged.json"
+
+cat > "$WORKDIR/untagged.json" <<'EOF'
+{
+  "suites": [{"title":"smoke", "specs":[{"title":"dashboard loads", "tests":[{"results":[{"status":"passed"}]}]}]}]
+}
+EOF
+if python3 "$HELPER" REQ-094 "$WORKDIR/untagged.json"; then
+  echo 'untagged smoke result must not be attributed to REQ-094' >&2
+  exit 1
+fi
+
+cat > "$WORKDIR/skipped.json" <<'EOF'
+{
+  "suites": [{"specs":[{"title":"REQ-094 skipped", "tests":[{"results":[{"status":"skipped"}]}]}]}]
+}
+EOF
+if python3 "$HELPER" REQ-094 "$WORKDIR/skipped.json"; then
+  echo 'skipped result must not be treated as an execution' >&2
+  exit 1
+fi
+
+echo 'REQ-tagged E2E result guard regression test passed'


### PR DESCRIPTION
## Summary
- prevent generic smoke E2E JSON from being attributed to a pending REQ it did not execute
- retain generic results as run-level evidence while keeping targeted Feature E2E as REQ proof
- render and verify the profitability category breakdown required by REQ-094 AC3
- add a regression test for the JSON guard

## Verification
- `scripts/tests/has-req-tagged-e2e-result.test.sh`
- `npx eslint e2e/reports/profitability-attribution.spec.ts components/features/admin/profitability-charts.tsx`
- `npx tsc --noEmit`
- `npm run build`

Closes #530
Closes #538

Upstream template dependency: metasession-dev/DevAudit-Installer#435