### PR TITLE
fix: bound post-merge E2E timeout evidence

### DIFF
--- a/.github/workflows/compliance-evidence.yml
+++ b/.github/workflows/compliance-evidence.yml
@@ -829,6 +829,17 @@ jobs:
           if [ "${#REQS[@]}" -eq 0 ]; then
             REQS=(_compliance-docs)
           fi
+          # A bounded Playwright process exits the workflow with `failure`
+          # even when its machine-readable execution result is specifically
+          # `timed_out`. Preserve that distinction for the portal lifecycle.
+          EXECUTION_OUTCOME=""
+          if [ -f e2e-artifacts/e2e-regression-metadata.json ]; then
+            EXECUTION_OUTCOME="$(jq -r '.outcome // empty' e2e-artifacts/e2e-regression-metadata.json 2>/dev/null || true)"
+            case "$EXECUTION_OUTCOME" in
+              passed|failed|timed_out) ;;
+              *) EXECUTION_OUTCOME="" ;;
+            esac
+          fi
           echo "Uploading E2E ${TIER}-tier evidence to: ${REQS[*]} (release: ${DERIVED_RELEASE})"
 
           UPLOAD_FAILURES=0
@@ -874,7 +885,24 @@ jobs:
                 REQ_FAILURES=$((REQ_FAILURES + 1))
               fi
             fi
-            # 2. Playwright HTML report zip → e2e_report. Operator-
+            # 2. The bounded execution metadata makes a timeout distinct
+            # from an ordinary failed workflow on the portal.
+            if [ -f e2e-artifacts/e2e-regression-metadata.json ]; then
+              if bash scripts/upload-evidence.sh \
+                wgb "$REQ" test_report \
+                e2e-artifacts/e2e-regression-metadata.json \
+                --category test_report ${FLAGS} --release "${DERIVED_RELEASE}" \
+                "${LINEAGE_FLAGS[@]}" \
+                --meta-key "tier=${TIER}" --meta-key "execution_outcome=${EXECUTION_OUTCOME:-unknown}"
+              then
+                :
+              else
+                echo "::warning::E2E execution metadata upload failed for ${REQ}"
+                UPLOAD_FAILURES=$((UPLOAD_FAILURES + 1))
+                REQ_FAILURES=$((REQ_FAILURES + 1))
+              fi
+            fi
+            # 3. Playwright HTML report zip → e2e_report. Operator-
             # facing artefact (the formatted run summary). Skipped if
             # the report directory is missing (e.g. an upstream
             # infrastructure failure aborted before reporting).
@@ -914,6 +942,12 @@ jobs:
               action_required) REQ_OUTCOME=action_required ;;
               *)               REQ_OUTCOME=unknown ;;
             esac
+            if [ "$EXECUTION_OUTCOME" = "timed_out" ]; then
+              REQ_OUTCOME=timed_out
+              OUTCOME_REASON="bounded Playwright execution timed out (metadata); workflow_run conclusion: ${{ github.event.workflow_run.conclusion }}"
+            else
+              OUTCOME_REASON="authoritative workflow_run conclusion: ${{ github.event.workflow_run.conclusion }}"
+            fi
             bash scripts/report-test-cycle.sh complete \
               --project-slug wgb \
               --release "${DERIVED_RELEASE}" \
@@ -930,7 +964,7 @@ jobs:
               --workflow-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}" \
               --started-at "${{ github.event.workflow_run.run_started_at }}" \
               --completed-at "${{ github.event.workflow_run.updated_at }}" \
-              --outcome-reason "authoritative workflow_run conclusion: ${{ github.event.workflow_run.conclusion }}" \
+              --outcome-reason "$OUTCOME_REASON" \
               --outcome "${REQ_OUTCOME}"
             case "$REQ_OUTCOME" in
               passed) CHECK_STATUS=successful ;;
@@ -938,8 +972,9 @@ jobs:
             esac
             CHECK_DETAILS=$(jq -cn \
               --arg conclusion "${{ github.event.workflow_run.conclusion }}" \
+              --arg executionOutcome "${EXECUTION_OUTCOME:-unknown}" \
               --argjson artifactUploadFailures "$REQ_FAILURES" \
-              '{executionSource:"workflow_run.conclusion",conclusion:$conclusion,artifactUploadFailures:$artifactUploadFailures}')
+              '{executionSource:"workflow_run.conclusion",conclusion:$conclusion,executionOutcome:$executionOutcome,artifactUploadFailures:$artifactUploadFailures}')
             bash scripts/report-release-check.sh \
               --project-slug wgb --release "${DERIVED_RELEASE}" \
               --check-key "e2e-regression:${{ github.event.workflow_run.id }}:${{ github.event.workflow_run.run_attempt }}:${REQ}" \

--- a/.github/workflows/e2e-regression.yml
+++ b/.github/workflows/e2e-regression.yml
@@ -53,6 +53,9 @@ jobs:
   e2e-regression:
     name: E2E Regression Suite
     runs-on: ubuntu-latest
+    # Keep the job budget above the Playwright budget so timeout metadata and
+    # partial evidence can be retained before GitHub terminates the runner.
+    timeout-minutes: 55
 
     services:
       mongodb:
@@ -115,7 +118,11 @@ jobs:
           npx tsx scripts/seed-e2e-fixtures.ts
 
       - name: Start dev server
-        run: npm run dev &
+        run: |
+          set -euo pipefail
+          npm run dev > e2e-server.log 2>&1 &
+          echo "$!" > .e2e-server.pid
+          echo "Started E2E server pid $(cat .e2e-server.pid)"
 
       - name: Wait for dev server
         run: npx wait-on http://localhost:3000 --timeout 120000
@@ -159,21 +166,62 @@ jobs:
               ;;
           esac
 
+      - name: Record E2E execution context
+        run: |
+          set -euo pipefail
+          SERVER_PID="$(cat .e2e-server.pid 2>/dev/null || true)"
+          jq -n \
+            --arg targetUrl "http://localhost:3000" \
+            --arg project "${{ steps.select.outputs.project }}" \
+            --arg specs "${{ steps.select.outputs.specs }}" \
+            --arg serverStart "npm run dev (pid ${SERVER_PID:-unknown})" \
+            --arg serverStop "kill ${SERVER_PID:-unknown}" \
+            --arg startedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --argjson timeoutMinutes 40 \
+            '{target_url: $targetUrl, project: $project, selected_specs: $specs, test_server_start: $serverStart, test_server_stop: $serverStop, timeout_minutes: $timeoutMinutes, started_at: $startedAt, outcome: "running"}' \
+            > e2e-regression-metadata.json
+
       - name: E2E Regression Tests
         env:
           PLAYWRIGHT_HTML_REPORTER_OPEN: never
           PLAYWRIGHT_JSON_OUTPUT_NAME: e2e-regression-results.json
         run: |
-          set -euo pipefail
+          set -uo pipefail
           PROJECT="${{ steps.select.outputs.project }}"
           SPECS="${{ steps.select.outputs.specs }}"
           if [ -n "$SPECS" ]; then
             echo "::notice::Running scoped regression — project=$PROJECT specs=$SPECS"
             # shellcheck disable=SC2086
-            npx playwright test --project="$PROJECT" --reporter=json,html $SPECS
+            timeout --signal=TERM --kill-after=60s 40m npx playwright test --project="$PROJECT" --reporter=json,html $SPECS
           else
             echo "::notice::Running project=$PROJECT"
-            npx playwright test --project="$PROJECT" --reporter=json,html
+            timeout --signal=TERM --kill-after=60s 40m npx playwright test --project="$PROJECT" --reporter=json,html
+          fi
+          STATUS=$?
+          if [ "$STATUS" -eq 124 ]; then
+            OUTCOME="timed_out"
+            echo "::error::E2E regression exceeded its 40-minute execution budget. Partial evidence will be uploaded."
+          elif [ "$STATUS" -eq 0 ]; then
+            OUTCOME="passed"
+          else
+            OUTCOME="failed"
+          fi
+          jq --arg outcome "$OUTCOME" --arg completedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --argjson exitCode "$STATUS" \
+            '. + {outcome: $outcome, completed_at: $completedAt, exit_code: $exitCode}' \
+            e2e-regression-metadata.json > e2e-regression-metadata.tmp
+          mv e2e-regression-metadata.tmp e2e-regression-metadata.json
+          exit "$STATUS"
+
+      - name: Stop dev server
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ -f .e2e-server.pid ]; then
+            PID="$(cat .e2e-server.pid)"
+            if kill -0 "$PID" 2>/dev/null; then
+              kill "$PID"
+              wait "$PID" 2>/dev/null || true
+            fi
           fi
 
       - uses: actions/upload-artifact@v4
@@ -183,6 +231,7 @@ jobs:
           name: e2e-regression-report
           path: |
             e2e-regression-results.json
+            e2e-regression-metadata.json
             playwright-report/
             # Playwright writes per-test traces, videos, screenshots and
             # error-context.md to test-results/<spec>-<title>[-retry<N>]/
@@ -193,6 +242,8 @@ jobs:
             # step. Storage cost is a duplicate of the data already in
             # playwright-report/data/, accepted for the debuggability win.
             test-results/
+            e2e-server.log
+          if-no-files-found: warn
           retention-days: 30
 
       # ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #547

## Summary
- bounds the project-owned post-merge regression at 40 minutes inside a 55-minute job
- starts/stops the test server explicitly and retains its log
- writes and uploads execution metadata with target, project, specs, budget, outcome, and exit code
- maps a controlled timeout to a terminal `timed_out` DevAudit cycle/check rather than generic workflow failure

## Verification
- parsed both modified GitHub workflow YAML files with `js-yaml`
- `git diff --check`

## Upstream
- adopts Installer #441 locally
- Installer #447 now tracks the generated uploader equivalent and is attached to umbrella #430