### PR TITLE
fix(ci): add verified Railway deployment reconciliation

### DIFF
--- a/.github/workflows/reconcile-deployment.yml
+++ b/.github/workflows/reconcile-deployment.yml
@@ -1,0 +1,69 @@
+name: Reconcile Verified Railway Deployment
+
+# Manual recovery only. This workflow never deploys an application and will
+# refuse to mark a GitHub deployment successful unless Railway provenance and
+# the production health probe agree with the requested main SHA.
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: 'REQ-XXX release receiving recovery evidence'
+        required: true
+      expected_sha:
+        description: 'Exact main SHA verified at Railway'
+        required: true
+      github_deployment_id:
+        description: 'Existing GitHub deployment ID to reconcile'
+        required: true
+      railway_deployment_id:
+        description: 'Terminal-successful Railway deployment ID'
+        required: true
+      railway_project:
+        description: 'Railway project ID'
+        required: true
+      railway_service:
+        description: 'Railway service ID or name'
+        required: true
+      health_url:
+        description: 'Configured production health URL'
+        required: true
+
+jobs:
+  reconcile:
+    name: Verify and reconcile deployment
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    env:
+      DEVAUDIT_API_KEY: ${{ secrets.DEVAUDIT_API_KEY }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.expected_sha }}
+
+      - name: Resolve DevAudit base URL
+        run: |
+          BASE=$(jq -r '.devaudit.base_url // empty' sdlc-config.json)
+          [ -n "$BASE" ] || { echo '::error::sdlc-config.json devaudit.base_url is required.'; exit 1; }
+          echo "DEVAUDIT_BASE_URL=${BASE%/}" >> "$GITHUB_ENV"
+
+      - name: Verify provider deployment before reconciliation
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          chmod +x scripts/reconcile-railway-deployment.sh
+          bash scripts/reconcile-railway-deployment.sh \
+            --repo="${{ github.repository }}" --sha="${{ inputs.expected_sha }}" \
+            --github-deployment-id="${{ inputs.github_deployment_id }}" \
+            --railway-deployment-id="${{ inputs.railway_deployment_id }}" \
+            --railway-project="${{ inputs.railway_project }}" --railway-service="${{ inputs.railway_service }}" \
+            --health-url="${{ inputs.health_url }}"
+
+      - name: Upload manual reconciliation evidence
+        run: |
+          bash scripts/upload-evidence.sh wgb "${{ inputs.release }}" test_report deployment-reconciliation.json \
+            --category release_artifact --release "${{ inputs.release }}" --environment production \
+            --git-sha "${{ inputs.expected_sha }}" --branch main --sdlc-stage 5 \
+            --meta-key 'provenance=manual_reconciliation' --meta-key 'provider=railway'

--- a/scripts/reconcile-railway-deployment.sh
+++ b/scripts/reconcile-railway-deployment.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Reconcile a verified Railway recovery deployment to its GitHub deployment.
+set -euo pipefail
+
+REPO=""; SHA=""; GITHUB_DEPLOYMENT_ID=""; RAILWAY_DEPLOYMENT_ID=""
+RAILWAY_PROJECT=""; RAILWAY_ENVIRONMENT="production"; RAILWAY_SERVICE=""; HEALTH_URL=""
+for arg in "$@"; do
+  case "$arg" in
+    --repo=*) REPO="${arg#*=}" ;; --sha=*) SHA="${arg#*=}" ;;
+    --github-deployment-id=*) GITHUB_DEPLOYMENT_ID="${arg#*=}" ;;
+    --railway-deployment-id=*) RAILWAY_DEPLOYMENT_ID="${arg#*=}" ;;
+    --railway-project=*) RAILWAY_PROJECT="${arg#*=}" ;;
+    --railway-environment=*) RAILWAY_ENVIRONMENT="${arg#*=}" ;;
+    --railway-service=*) RAILWAY_SERVICE="${arg#*=}" ;;
+    --health-url=*) HEALTH_URL="${arg#*=}" ;;
+    *) echo "Unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
+[ -n "$REPO" ] && [ -n "$SHA" ] && [ -n "$GITHUB_DEPLOYMENT_ID" ] && [ -n "$RAILWAY_DEPLOYMENT_ID" ] && [ -n "$RAILWAY_PROJECT" ] && [ -n "$RAILWAY_SERVICE" ] && [ -n "$HEALTH_URL" ] || { echo "Missing required reconciliation arguments" >&2; exit 2; }
+
+DEPLOYMENTS=$(railway deployment list --json --project "$RAILWAY_PROJECT" --environment "$RAILWAY_ENVIRONMENT" --service "$RAILWAY_SERVICE" --limit 100)
+MATCH=$(jq -cer --arg id "$RAILWAY_DEPLOYMENT_ID" '.[] | select(.id == $id)' <<<"$DEPLOYMENTS") || { echo "::error::Railway deployment ${RAILWAY_DEPLOYMENT_ID} was not found."; exit 1; }
+STATUS=$(jq -r '.status // empty' <<<"$MATCH")
+PROVIDER_SHA=$(jq -r '.meta.commitHash // empty' <<<"$MATCH")
+BRANCH=$(jq -r '.meta.branch // empty' <<<"$MATCH")
+PROVIDER_REPO=$(jq -r '.meta.repo // empty' <<<"$MATCH")
+[ "$STATUS" = "SUCCESS" ] || { echo "::error::Railway deployment is not terminal-successful: ${STATUS:-missing}"; exit 1; }
+[ "$PROVIDER_SHA" = "$SHA" ] && [ "$BRANCH" = "main" ] && [ "$PROVIDER_REPO" = "$REPO" ] || { echo "::error::Railway provenance mismatch: repo=$PROVIDER_REPO branch=$BRANCH sha=$PROVIDER_SHA"; exit 1; }
+HTTP=$(curl -sS -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 15 "$HEALTH_URL" || echo 000)
+[[ "$HTTP" =~ ^[23][0-9][0-9]$ ]] || { echo "::error::Health probe failed for ${HEALTH_URL}: HTTP ${HTTP}"; exit 1; }
+DESCRIPTION="manual_reconciliation; railway_deployment=${RAILWAY_DEPLOYMENT_ID}; sha=${SHA}; health_http=${HTTP}; verified_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+EXISTING=$(gh api "/repos/${REPO}/deployments/${GITHUB_DEPLOYMENT_ID}/statuses?per_page=20" --jq '[.[] | select(.state == "success" and (.description // "" | contains("railway_deployment='"$RAILWAY_DEPLOYMENT_ID"'")))] | length')
+if [ "$EXISTING" = "0" ]; then
+  gh api --method POST "/repos/${REPO}/deployments/${GITHUB_DEPLOYMENT_ID}/statuses" -f state=success -f environment=production -f description="$DESCRIPTION" -f environment_url="$HEALTH_URL" >/dev/null
+fi
+jq -n --arg provenance manual_reconciliation --arg provider railway --arg providerDeploymentId "$RAILWAY_DEPLOYMENT_ID" --arg sha "$SHA" --arg healthUrl "$HEALTH_URL" --arg healthHttp "$HTTP" --arg actor "${GITHUB_ACTOR:-operator}" --arg verifiedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '{provenance:$provenance,provider:$provider,providerDeploymentId:$providerDeploymentId,sha:$sha,healthUrl:$healthUrl,healthHttp:($healthHttp|tonumber),actor:$actor,verifiedAt:$verifiedAt}' > deployment-reconciliation.json
+echo "Verified Railway deployment ${RAILWAY_DEPLOYMENT_ID}; GitHub deployment ${GITHUB_DEPLOYMENT_ID} reconciled."

--- a/scripts/tests/reconcile-deployment-workflow.test.sh
+++ b/scripts/tests/reconcile-deployment-workflow.test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+WORKFLOW="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/.github/workflows/reconcile-deployment.yml"
+for text in 'workflow_dispatch:' 'deployments: write' 'RAILWAY_TOKEN' 'reconcile-railway-deployment.sh' 'manual_reconciliation' 'sdlc-config.json devaudit.base_url'; do
+  rg -q --fixed-strings "$text" "$WORKFLOW"
+done
+echo 'reconcile deployment workflow contract passed'

--- a/scripts/tests/reconcile-railway-deployment.test.sh
+++ b/scripts/tests/reconcile-railway-deployment.test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Contract tests for wawagardenbar-app#552.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HELPER="$ROOT/scripts/reconcile-railway-deployment.sh"
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/bin"
+cat > "$WORK/bin/railway" <<'EOF'
+#!/usr/bin/env bash
+printf '%s' "$MOCK_RAILWAY_JSON"
+EOF
+cat > "$WORK/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+printf '%s' "${MOCK_HTTP:-200}"
+EOF
+cat > "$WORK/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == *"--jq"* ]]; then printf '%s' "${MOCK_EXISTING:-[]}"; else echo "$*" >> "$MOCK_GH_LOG"; fi
+EOF
+chmod +x "$WORK/bin/"*
+run() { (cd "$WORK" && PATH="$WORK/bin:$PATH" MOCK_GH_LOG="$WORK/gh.log" "$@" bash "$HELPER" --repo=metasession-dev/wawagardenbar-app --sha=abc --github-deployment-id=42 --railway-deployment-id=r1 --railway-project=p --railway-service=s --health-url=https://health.test); }
+GOOD='[{"id":"r1","status":"SUCCESS","meta":{"repo":"metasession-dev/wawagardenbar-app","branch":"main","commitHash":"abc"}}]'
+run env MOCK_RAILWAY_JSON="$GOOD"
+rg -q '"provenance": "manual_reconciliation"' "$WORK/deployment-reconciliation.json"
+if run env MOCK_RAILWAY_JSON='[{"id":"r1","status":"SUCCESS","meta":{"repo":"metasession-dev/wawagardenbar-app","branch":"main","commitHash":"wrong"}}]'; then exit 1; fi
+if run env MOCK_RAILWAY_JSON="$GOOD" MOCK_HTTP=500; then exit 1; fi
+rm -f "$WORK/gh.log"
+run env MOCK_RAILWAY_JSON="$GOOD" MOCK_EXISTING='[{"state":"success","description":"railway_deployment=r1"}]'
+[ ! -f "$WORK/gh.log" ]
+echo 'reconcile-railway-deployment contract passed'


### PR DESCRIPTION
## Summary
- add manual-only guarded Railway to GitHub deployment reconciliation
- verify provider repository, main branch, exact SHA, terminal success, and health before mutation
- upload manual-recovery provenance as production release evidence

## Verification
- workflow YAML parsing
- Railway reconciliation helper contract test
- workflow contract test

Closes #552