### PR TITLE
[REQ-094] fix(ci): preserve tracked scope on promotion

### DIFF
--- a/scripts/check-release-pr-scope.sh
+++ b/scripts/check-release-pr-scope.sh
@@ -51,7 +51,15 @@ fi
 if [ ! -x scripts/derive-release-version.sh ]; then
   chmod +x scripts/derive-release-version.sh 2>/dev/null || true
 fi
-CURRENT_RELEASE=$(bash scripts/derive-release-version.sh)
+# An ordinary CI run must not inherit a pending ticket merely because one
+# happens to exist. A reviewed develop -> main promotion is different: it is
+# the explicit selection point for the single pending tracked release.
+if [ "$HEAD_REF" = "develop" ]; then
+  CURRENT_RELEASE=$(DEVAUDIT_ALLOW_PENDING_TICKET_FALLBACK=1 \
+    bash scripts/derive-release-version.sh)
+else
+  CURRENT_RELEASE=$(bash scripts/derive-release-version.sh)
+fi
 if [ -z "$CURRENT_RELEASE" ]; then
   echo "::error::Could not derive the effective release scope from the current branch head."
   exit 1

--- a/scripts/tests/check-release-pr-scope.test.sh
+++ b/scripts/tests/check-release-pr-scope.test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+mkdir -p "$WORKDIR/scripts" "$WORKDIR/compliance/pending-releases"
+cp "$ROOT/scripts/check-release-pr-scope.sh" \
+  "$ROOT/scripts/derive-release-version.sh" \
+  "$ROOT/scripts/extract-release-metadata.sh" \
+  "$WORKDIR/scripts/"
+chmod +x "$WORKDIR/scripts/"*.sh
+cat > "$WORKDIR/compliance/pending-releases/RELEASE-TICKET-REQ-094.md" <<'EOF'
+# Release Ticket -- REQ-094: Scope test
+
+## Summary
+
+Tracked release fixture.
+EOF
+
+git -C "$WORKDIR" init -q --initial-branch=develop
+git -C "$WORKDIR" config user.email test@example.com
+git -C "$WORKDIR" config user.name test
+printf 'integration head\n' > "$WORKDIR/file.txt"
+git -C "$WORKDIR" add .
+git -C "$WORKDIR" commit -q -m 'ci: untagged integration head'
+
+run_scope_check() {
+  (
+    cd "$WORKDIR"
+    PR_TITLE='[REQ-094] release: promote tracked release' \
+      PR_BODY='' \
+      HEAD_REF="$1" \
+      bash scripts/check-release-pr-scope.sh
+  )
+}
+
+run_scope_check develop
+
+if run_scope_check 'feature/no-pending-ticket-inheritance'; then
+  echo 'Feature CI must not inherit a pending tracked release.' >&2
+  exit 1
+fi
+
+echo 'check-release-pr-scope regression test passed'


### PR DESCRIPTION
Fixes #561.

A reviewed `develop -> main` release promotion is the explicit selection point for exactly one pending tracked ticket. The release-scope checker now enables the pending-ticket fallback only in that context; feature and housekeeping branch CI retain the default no-fallback behavior.

Validation:
- `bash scripts/tests/check-release-pr-scope.test.sh`
- `bash scripts/tests/derive-release-version.test.sh`
- `git diff --check`

Canonical template follow-up: DevAudit-Installer #464.