### PR TITLE
[REQ-094] fix(ci): accept qualified production statuses

### DIFF
--- a/.github/workflows/e2e-regression.yml
+++ b/.github/workflows/e2e-regression.yml
@@ -55,7 +55,9 @@ jobs:
     if: >-
       github.event_name != 'deployment_status' ||
       (github.event.deployment_status.state == 'success' &&
-       (github.event.deployment.environment == 'production' || github.event.deployment.environment == 'prod'))
+       (github.event.deployment.environment == 'production' ||
+        github.event.deployment.environment == 'prod' ||
+        endsWith(github.event.deployment.environment, '/ production')))
     runs-on: ubuntu-latest
     # Keep the job budget above the Playwright budget so timeout metadata and
     # partial evidence can be retained before GitHub terminates the runner.

--- a/.github/workflows/post-deploy-prod.yml
+++ b/.github/workflows/post-deploy-prod.yml
@@ -38,7 +38,9 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.deployment_status.state == 'success' &&
-       (github.event.deployment.environment == 'production' || github.event.deployment.environment == 'prod'))
+       (github.event.deployment.environment == 'production' ||
+        github.event.deployment.environment == 'prod' ||
+        endsWith(github.event.deployment.environment, '/ production')))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/scripts/tests/production-deployment-environment.test.sh
+++ b/scripts/tests/production-deployment-environment.test.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+WORKFLOWS=(
+  "$ROOT/.github/workflows/post-deploy-prod.yml"
+  "$ROOT/.github/workflows/e2e-regression.yml"
+)
+
+for workflow in "${WORKFLOWS[@]}"; do
+  rg -q --fixed-strings "github.event.deployment_status.state == 'success'" "$workflow"
+  rg -q --fixed-strings "github.event.deployment.environment == 'production'" "$workflow"
+  rg -q --fixed-strings "github.event.deployment.environment == 'prod'" "$workflow"
+  rg -q --fixed-strings "endsWith(github.event.deployment.environment, '/ production')" "$workflow"
+done
+
+is_production_environment() {
+  case "${1,,}" in
+    production|prod|*/\ production) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_production_environment production
+is_production_environment prod
+is_production_environment 'Wawa Garden Bar / production'
+is_production_environment 'Provider / Production'
+
+for environment in uat staging preview 'Wawa Garden Bar / uat' 'production-preview'; do
+  if is_production_environment "$environment"; then
+    echo "Unexpected production match: $environment" >&2
+    exit 1
+  fi
+done
+
+echo 'qualified production environment workflow contract passed'


### PR DESCRIPTION
Fixes #563.

Railway reports production deployment status with the qualified environment `Wawa Garden Bar / production`. The post-deploy evidence and regression guards now accept that bounded provider form alongside canonical `production` and `prod`, while retaining successful-status-only gating.

Validation:
- `bash scripts/tests/production-deployment-environment.test.sh`
- `bash scripts/tests/reconcile-deployment-workflow.test.sh`
- `git diff --check`

Canonical template follow-up: DevAudit-Installer #465.