### PR TITLE
[REQ-094] release: recognise qualified production deployment status

### DIFF
--- a/.github/workflows/e2e-regression.yml
+++ b/.github/workflows/e2e-regression.yml
@@ -55,7 +55,9 @@ jobs:
     if: >-
       github.event_name != 'deployment_status' ||
       (github.event.deployment_status.state == 'success' &&
-       (github.event.deployment.environment == 'production' || github.event.deployment.environment == 'prod'))
+       (github.event.deployment.environment == 'production' ||
+        github.event.deployment.environment == 'prod' ||
+        endsWith(github.event.deployment.environment, '/ production')))
     runs-on: ubuntu-latest
     # Keep the job budget above the Playwright budget so timeout metadata and
     # partial evidence can be retained before GitHub terminates the runner.

--- a/.github/workflows/post-deploy-prod.yml
+++ b/.github/workflows/post-deploy-prod.yml
@@ -38,7 +38,9 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.deployment_status.state == 'success' &&
-       (github.event.deployment.environment == 'production' || github.event.deployment.environment == 'prod'))
+       (github.event.deployment.environment == 'production' ||
+        github.event.deployment.environment == 'prod' ||
+        endsWith(github.event.deployment.environment, '/ production')))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/scripts/tests/production-deployment-environment.test.sh
+++ b/scripts/tests/production-deployment-environment.test.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+WORKFLOWS=(
+  "$ROOT/.github/workflows/post-deploy-prod.yml"
+  "$ROOT/.github/workflows/e2e-regression.yml"
+)
+
+for workflow in "${WORKFLOWS[@]}"; do
+  rg -q --fixed-strings "github.event.deployment_status.state == 'success'" "$workflow"
+  rg -q --fixed-strings "github.event.deployment.environment == 'production'" "$workflow"
+  rg -q --fixed-strings "github.event.deployment.environment == 'prod'" "$workflow"
+  rg -q --fixed-strings "endsWith(github.event.deployment.environment, '/ production')" "$workflow"
+done
+
+is_production_environment() {
+  case "${1,,}" in
+    production|prod|*/\ production) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_production_environment production
+is_production_environment prod
+is_production_environment 'Wawa Garden Bar / production'
+is_production_environment 'Provider / Production'
+
+for environment in uat staging preview 'Wawa Garden Bar / uat' 'production-preview'; do
+  if is_production_environment "$environment"; then
+    echo "Unexpected production match: $environment" >&2
+    exit 1
+  fi
+done
+
+echo 'qualified production environment workflow contract passed'


### PR DESCRIPTION
## Release scope

Promotes the REQ-094 production-event repair from `develop` to `main`.

Railway emits a successful production deployment environment as `Wawa Garden Bar / production`. The generated post-deploy evidence and regression workflows previously accepted only exact `production` or `prod`, so they skipped despite a verified Railway and GitHub deployment success.

Included:
- WGB #563: bounded qualified-production predicate in post-deploy evidence and full-regression workflows.
- Contract coverage accepting canonical/qualified production labels and rejecting UAT, staging, preview, and production-preview.

## Required post-merge proof

1. Merge only after this PR's required checks are terminal-success.
2. Railway must deploy the resulting `main` SHA successfully.
3. GitHub deployment status must be successful with the provider-qualified production environment.
4. `Post-Deploy Production Evidence` and `E2E Regression` must run automatically, complete terminally, and identify that deployed SHA.
5. Review the REQ-094 portal record before production approval/release.

Related: WGB #563, Installer #465, Installer umbrella #430 Track A.