### PR TITLE
chore: declare v2026.07.22 standalone housekeeping

### DIFF
--- a/compliance/standalone-housekeeping/STANDALONE-HOUSEKEEPING-v2026.07.22.json
+++ b/compliance/standalone-housekeeping/STANDALONE-HOUSEKEEPING-v2026.07.22.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "version": "v2026.07.22",
+  "releaseMode": "standalone_housekeeping",
+  "reason": "Promote the DevAudit v0.3.20 evidence-upload workflow corrections now so future production deployments can upload deployment-origin E2E evidence correctly instead of waiting for the next tracked requirement release."
+}


### PR DESCRIPTION
## Summary

Adds the explicit standalone-housekeeping declaration required to promote v2026.07.22 from develop to main.

This is needed because the promotion activates DevAudit v0.3.20 workflow/evidence-upload corrections for future production deployments and should not wait for the next tracked REQ.

## Validation

- bash scripts/standalone-housekeeping-release.sh validate v2026.07.22 compliance/standalone-housekeeping/STANDALONE-HOUSEKEEPING-v2026.07.22.json
- npm test -- --run __tests__/workflows/feature-e2e-evidence-contract.test.ts __tests__/services/order-service.completeOrder.test.ts

Refs #532
Refs #566
Refs metasession-dev/DevAudit-Installer#430