### PR TITLE
chore: adopt DevAudit v0.3.21

### DIFF
--- a/.github/workflows/check-release-approval.yml
+++ b/.github/workflows/check-release-approval.yml
@@ -58,6 +58,32 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || 'develop' }}
           fetch-depth: 0
 
+      - name: Detect declared standalone housekeeping promotion
+        id: standalone
+        if: github.event_name == 'pull_request'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          echo "standalone=false" >> "$GITHUB_OUTPUT"
+          chmod +x scripts/derive-release-version.sh scripts/standalone-housekeeping-release.sh 2>/dev/null || true
+          VERSION=$(bash scripts/derive-release-version.sh)
+          if ! [[ "$VERSION" =~ ^v[0-9]{4}\.[0-9]{2}\.[0-9]{2}([.][0-9]+)?$ ]]; then
+            exit 0
+          fi
+          DECLARATION="compliance/standalone-housekeeping/STANDALONE-HOUSEKEEPING-${VERSION}.json"
+          if [ ! -f "$DECLARATION" ]; then
+            exit 0
+          fi
+          if ! printf '%s\n%s\n' "$PR_TITLE" "$PR_BODY" | grep -Fq 'Standalone housekeeping promotion'; then
+            echo "::error::Standalone declaration exists, but this PR is missing the literal 'Standalone housekeeping promotion' marker."
+            exit 1
+          fi
+          bash scripts/standalone-housekeeping-release.sh validate "$VERSION" "$DECLARATION"
+          echo "standalone=true" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Declared standalone housekeeping promotion ${VERSION}; normal GitHub review and technical checks remain required, but tracked portal approval does not apply."
+
       - name: Resolve DevAudit base URL
         run: |
           # Prefer sdlc-config.json (visible in PR review) over repo Variable.
@@ -159,7 +185,7 @@ jobs:
 
       - name: Resolve current release
         id: release
-        if: env.BOOTSTRAP_MODE != 'true'
+        if: env.BOOTSTRAP_MODE != 'true' && steps.standalone.outputs.standalone != 'true'
         run: |
           # devaudit#283 — repository_dispatch('release-approved') events
           # carry the release version in client_payload. Use it directly
@@ -218,7 +244,7 @@ jobs:
           esac
 
       - name: Link PR to release
-        if: env.BOOTSTRAP_MODE != 'true' && github.event_name == 'pull_request'
+        if: env.BOOTSTRAP_MODE != 'true' && steps.standalone.outputs.standalone != 'true' && github.event_name == 'pull_request'
         run: |
           RELEASE_ID="${{ steps.release.outputs.release_id }}"
           PR_URL="${{ github.event.pull_request.html_url }}"
@@ -231,7 +257,7 @@ jobs:
           echo "Linked PR #${PR_NUMBER} to release ${RELEASE_ID}"
 
       - name: Post release link on PR
-        if: env.BOOTSTRAP_MODE != 'true' && github.event_name == 'pull_request'
+        if: env.BOOTSTRAP_MODE != 'true' && steps.standalone.outputs.standalone != 'true' && github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -247,7 +273,7 @@ jobs:
           fi
 
       - name: SHA comparison
-        if: env.BOOTSTRAP_MODE != 'true' && github.event_name == 'pull_request'
+        if: env.BOOTSTRAP_MODE != 'true' && steps.standalone.outputs.standalone != 'true' && github.event_name == 'pull_request'
         run: |
           PR_HEAD_SHA="${{ github.event.pull_request.head.sha }}"
           APPROVED_SHA="${{ steps.release.outputs.approved_sha }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,8 @@ jobs:
           fi
           [ -n "$BASE" ] || BASE="$DEVAUDIT_BASE_URL_VAR"
           [ -n "$BASE" ] || { echo "::warning::No DevAudit URL; test execution lifecycle disabled"; exit 0; }
-          echo "DEVAUDIT_BASE_URL=${BASE%/}" >> "$GITHUB_ENV"
+          export DEVAUDIT_BASE_URL="${BASE%/}"
+          echo "DEVAUDIT_BASE_URL=${DEVAUDIT_BASE_URL}" >> "$GITHUB_ENV"
           chmod +x scripts/report-test-execution.sh scripts/report-release-check.sh 2>/dev/null || true
           bash scripts/report-test-execution.sh start \
             --project-slug wgb \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -544,11 +544,11 @@ jobs:
     name: Upload Evidence
     runs-on: ubuntu-latest
     needs: [quality-gates, register-release]
-    # `always()` instead of `!failure()` so failed gates still upload their
-    # evidence — `status=failed` is itself the audit trail. `!cancelled()`
-    # still guards against partial state on operator-cancel.
-    # DevAudit-Installer#96.
-    if: ${{ always() && github.ref_name == 'develop' && needs.register-release.result == 'success' }}
+    # `!cancelled()` preserves failed-gate evidence on eligible integration
+    # pushes, while a pull request remains an intentionally inapplicable,
+    # cleanly skipped job. `always()` caused GitHub to mark this job cancelled
+    # when Register Release was correctly skipped on a no-REQ PR (#500).
+    if: ${{ !cancelled() && github.event_name != 'pull_request' && github.ref_name == 'develop' && needs.register-release.result == 'success' }}
     env:
       DEVAUDIT_BASE_URL_VAR: ${{ vars.DEVAUDIT_BASE_URL }}
       DEVAUDIT_API_KEY: ${{ secrets.DEVAUDIT_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,7 @@ jobs:
                         if finding.get('severity') in ('high', 'critical') and not accepted(name, finding)]
           print(len(unresolved))
           PY
+          )
           echo "Unaccepted high/critical: $UNACCEPTED"
           if [ "$UNACCEPTED" != "0" ] && [ "$UNACCEPTED" != "unknown" ]; then
             echo "::error::$UNACCEPTED unaccepted high/critical vulnerability(ies)."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,18 +172,38 @@ jobs:
         run: |
           # stderr → /dev/null so warnings can't corrupt the JSON (DevAudit #48)
           npm audit --json > dependency-audit.json 2>/dev/null || true
-          ACCEPTED=""
-          UNACCEPTED=$(python3 -c "
-          import json
+          # Optional, repository-owned exceptions must be advisory- and
+          # range-specific, approved, and unexpired. Missing means none.
+          UNACCEPTED=$(python3 - <<'PY' 2>/dev/null || echo "unknown"
+          import json, os
+          from datetime import date
           with open('dependency-audit.json') as f:
-            data = json.load(f)
-          accepted = set('${ACCEPTED}'.split()) if '${ACCEPTED}' else set()
-          vulns = data.get('vulnerabilities', {})
-          issues = [name for name, v in vulns.items()
-                    if v.get('severity') in ('high', 'critical')
-                    and name not in accepted]
-          print(len(issues))
-          " 2>/dev/null || echo "unknown")
+              audit = json.load(f)
+          path = 'compliance/security/accepted-vulnerabilities.json'
+          exceptions = []
+          if os.path.exists(path):
+              with open(path) as f:
+                  exceptions = json.load(f).get('exceptions', [])
+          def accepted(package, finding):
+              advisory_ids = {
+                  item.get('url', '').rsplit('/', 1)[-1]
+                  for item in finding.get('via', []) if isinstance(item, dict)
+              }
+              for item in exceptions:
+                  required = ('advisoryId', 'package', 'vulnerableRange', 'expiresAt', 'approvedBy', 'reason', 'remediationIssue')
+                  if not all(item.get(key) for key in required):
+                      continue
+                  if item['expiresAt'] < date.today().isoformat():
+                      continue
+                  if item['package'] == package and item['vulnerableRange'] == finding.get('range') and item['advisoryId'] in advisory_ids:
+                      print(f"Accepted temporary risk: {item['advisoryId']} ({package}) until {item['expiresAt']}")
+                      return True
+              return False
+          findings = audit.get('vulnerabilities', {})
+          unresolved = [name for name, finding in findings.items()
+                        if finding.get('severity') in ('high', 'critical') and not accepted(name, finding)]
+          print(len(unresolved))
+          PY
           echo "Unaccepted high/critical: $UNACCEPTED"
           if [ "$UNACCEPTED" != "0" ] && [ "$UNACCEPTED" != "unknown" ]; then
             echo "::error::$UNACCEPTED unaccepted high/critical vulnerability(ies)."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,44 +172,12 @@ jobs:
         run: |
           # stderr → /dev/null so warnings can't corrupt the JSON (DevAudit #48)
           npm audit --json > dependency-audit.json 2>/dev/null || true
-          # Optional, repository-owned exceptions must be advisory- and
-          # range-specific, approved, and unexpired. Missing means none.
-          UNACCEPTED=$(python3 - <<'PY' 2>/dev/null || echo "unknown"
-          import json, os
-          from datetime import date
-          with open('dependency-audit.json') as f:
-              audit = json.load(f)
-          path = 'compliance/security/accepted-vulnerabilities.json'
-          exceptions = []
-          if os.path.exists(path):
-              with open(path) as f:
-                  exceptions = json.load(f).get('exceptions', [])
-          def accepted(package, finding):
-              advisory_ids = {
-                  item.get('url', '').rsplit('/', 1)[-1]
-                  for item in finding.get('via', []) if isinstance(item, dict)
-              }
-              for item in exceptions:
-                  required = ('advisoryId', 'package', 'vulnerableRange', 'expiresAt', 'approvedBy', 'reason', 'remediationIssue')
-                  if not all(item.get(key) for key in required):
-                      continue
-                  if item['expiresAt'] < date.today().isoformat():
-                      continue
-                  if item['package'] == package and item['vulnerableRange'] == finding.get('range') and item['advisoryId'] in advisory_ids:
-                      print(f"Accepted temporary risk: {item['advisoryId']} ({package}) until {item['expiresAt']}")
-                      return True
-              return False
-          findings = audit.get('vulnerabilities', {})
-          unresolved = [name for name, finding in findings.items()
-                        if finding.get('severity') in ('high', 'critical') and not accepted(name, finding)]
-          print(len(unresolved))
-          PY
-          )
-          echo "Unaccepted high/critical: $UNACCEPTED"
-          if [ "$UNACCEPTED" != "0" ] && [ "$UNACCEPTED" != "unknown" ]; then
-            echo "::error::$UNACCEPTED unaccepted high/critical vulnerability(ies)."
-            exit 1
-          fi
+          # The helper evaluates each high/critical advisory independently
+          # against the installed package-lock path and writes an auditable
+          # decision record. It is intentionally fail-closed: malformed audit
+          # output or a malformed/expired exception fails this gate.
+          chmod +x scripts/evaluate-npm-audit.sh 2>/dev/null || true
+          bash scripts/evaluate-npm-audit.sh
 
       # ── Gate 4: E2E Tests (Playwright) ──
 
@@ -353,6 +321,7 @@ jobs:
           path: |
             sast-results.json
             dependency-audit.json
+            dependency-risk-evaluation.json
             e2e-results.json
             e2e-auth-results.json
             playwright-report/
@@ -702,6 +671,15 @@ jobs:
           if [ -f ci-evidence/dependency-audit.json ]; then
             upload dependency-audit.json \
               wgb _compliance-docs dependency_audit ci-evidence/dependency-audit.json \
+              --category security_scan --gate-status "$STATUS_DEPAUDIT" ${FLAGS} "${PRIMARY_LINEAGE_FLAGS[@]}"
+          fi
+
+          # The decision record explains each accepted temporary risk with its
+          # exact advisory, installed provenance, expiry, owner, and tracked
+          # remediation. It is separate from the raw npm audit artifact.
+          if [ -f ci-evidence/dependency-risk-evaluation.json ]; then
+            upload dependency-risk-evaluation.json \
+              wgb _compliance-docs dependency_audit ci-evidence/dependency-risk-evaluation.json \
               --category security_scan --gate-status "$STATUS_DEPAUDIT" ${FLAGS} "${PRIMARY_LINEAGE_FLAGS[@]}"
           fi
 

--- a/.github/workflows/close-out-completion.yml
+++ b/.github/workflows/close-out-completion.yml
@@ -1,0 +1,56 @@
+name: Report Release Close-out Completion
+
+on:
+  pull_request:
+    branches: [develop]
+    types: [closed]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  report-completion:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'chore/close-out-')
+    runs-on: ubuntu-latest
+    env:
+      DEVAUDIT_API_KEY: ${{ secrets.DEVAUDIT_API_KEY }}
+      PROJECT_SLUG: wgb
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Report tracked close-out completion
+        run: |
+          set -euo pipefail
+          REQ="$(printf '%s' '${{ github.event.pull_request.head.ref }}' | sed -n 's#^chore/close-out-\(REQ-[0-9][0-9][0-9]*\)$#\1#p')"
+          if [ -z "$REQ" ]; then
+            echo "Standalone and integration housekeeping have no tracked close-out callback."
+            exit 0
+          fi
+          BASE="$(jq -r '.devaudit.base_url // empty' sdlc-config.json)"
+          if [ -z "$BASE" ] || [ -z "$DEVAUDIT_API_KEY" ]; then
+            echo "::error::DevAudit base URL and project API key are required for tracked close-out completion."
+            exit 1
+          fi
+          RELEASE="$(curl --fail-with-body -sS -G "${BASE%/}/api/ci/releases/resolve" \
+            -H "Authorization: Bearer ${DEVAUDIT_API_KEY}" \
+            --data-urlencode "projectSlug=${PROJECT_SLUG}" \
+            --data-urlencode "versionPrefix=${REQ}")"
+          RELEASE_ID="$(jq -r '.latest.id // empty' <<<"$RELEASE")"
+          RELEASE_VERSION="$(jq -r '.latest.version // empty' <<<"$RELEASE")"
+          if [ -z "$RELEASE_ID" ] || [ "$RELEASE_VERSION" != "$REQ" ]; then
+            echo "::error::Unable to resolve the tracked release ${REQ}; refusing callback."
+            exit 1
+          fi
+          curl --fail-with-body -sS -X POST "${BASE%/}/api/ci/releases/${RELEASE_ID}/close-out" \
+            -H "Authorization: Bearer ${DEVAUDIT_API_KEY}" \
+            -H 'Content-Type: application/json' \
+            --data "$(jq -nc \
+              --arg workflowRunId '${{ github.run_id }}' \
+              --arg workflowUrl '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}' \
+              --arg pullRequestUrl '${{ github.event.pull_request.html_url }}' \
+              --arg mergeSha '${{ github.event.pull_request.merge_commit_sha }}' \
+              --argjson pullRequestNumber '${{ github.event.pull_request.number }}' \
+              '{status:"completed",workflowRunId:$workflowRunId,workflowUrl:$workflowUrl,pullRequestNumber:$pullRequestNumber,pullRequestUrl:$pullRequestUrl,mergeSha:$mergeSha}')"

--- a/.github/workflows/close-out-release.yml
+++ b/.github/workflows/close-out-release.yml
@@ -96,6 +96,29 @@ jobs:
             echo "Nothing to close out (idempotent no-op) — no PR opened."
           fi
 
+      - name: Report verified manual close-out catch-up
+        if: github.event_name == 'workflow_dispatch' && steps.closeout.outputs.changed != 'true' && steps.merge.outputs.merged != 'true'
+        run: |
+          set -euo pipefail
+          REQ="${{ steps.in.outputs.req }}"
+          PR_REF="${{ steps.in.outputs.pr }}"
+          [ -n "$REQ" ] && [ -n "$PR_REF" ] || { echo "::error::Manual no-op reporting requires release and release_pr."; exit 1; }
+          PR_JSON="$(gh pr view "$PR_REF" --repo "$GITHUB_REPOSITORY" --json mergedAt,baseRefName,headRefName,mergeCommit,number,url)"
+          HEAD="$(jq -r '.headRefName // empty' <<<"$PR_JSON")"
+          BASE="$(jq -r '.baseRefName // empty' <<<"$PR_JSON")"
+          MERGED="$(jq -r '.mergedAt // empty' <<<"$PR_JSON")"
+          SHA="$(jq -r '.mergeCommit.oid // empty' <<<"$PR_JSON")"
+          NUMBER="$(jq -r '.number' <<<"$PR_JSON")"
+          URL="$(jq -r '.url' <<<"$PR_JSON")"
+          [ -n "$MERGED" ] && [ "$BASE" = develop ] && [ "$HEAD" = "chore/close-out-$REQ" ] && [ -n "$SHA" ] || { echo "::error::release_pr must be a merged develop close-out PR for $REQ."; exit 1; }
+          BASE_URL="${DEVAUDIT_BASE_URL:-}"
+          [ -n "$BASE_URL" ] && [ -n "$DEVAUDIT_API_KEY" ] || { echo "::error::DevAudit base URL and project API key are required."; exit 1; }
+          RELEASE="$(curl --fail-with-body -sS -G "${BASE_URL%/}/api/ci/releases/resolve" -H "Authorization: Bearer ${DEVAUDIT_API_KEY}" --data-urlencode "projectSlug=wgb" --data-urlencode "versionPrefix=${REQ}")"
+          RELEASE_ID="$(jq -r '.latest.id // empty' <<<"$RELEASE")"
+          RELEASE_VERSION="$(jq -r '.latest.version // empty' <<<"$RELEASE")"
+          [ "$RELEASE_VERSION" = "$REQ" ] && [ -n "$RELEASE_ID" ] || { echo "::error::Unable to resolve $REQ."; exit 1; }
+          curl --fail-with-body -sS -X POST "${BASE_URL%/}/api/ci/releases/${RELEASE_ID}/close-out" -H "Authorization: Bearer ${DEVAUDIT_API_KEY}" -H 'Content-Type: application/json' --data "$(jq -nc --arg workflowRunId '${{ github.run_id }}' --arg workflowUrl '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}' --arg pullRequestUrl "$URL" --arg mergeSha "$SHA" --argjson pullRequestNumber "$NUMBER" '{status:"completed",workflowRunId:$workflowRunId,workflowUrl:$workflowUrl,pullRequestNumber:$pullRequestNumber,pullRequestUrl:$pullRequestUrl,mergeSha:$mergeSha}')"
+
       - name: Close existing sync PRs for same REQ
         if: steps.closeout.outputs.changed == 'true' || steps.merge.outputs.merged == 'true'
         run: |

--- a/.github/workflows/close-out-release.yml
+++ b/.github/workflows/close-out-release.yml
@@ -54,8 +54,8 @@ jobs:
           REQ="${{ github.event.inputs.release }}${{ github.event.client_payload.release }}"
           PR="${{ github.event.inputs.release_pr }}${{ github.event.client_payload.release_pr }}"
           if ! printf '%s' "$REQ" | grep -qE '^REQ-[0-9]{3,}$'; then
-            echo "::error::No valid REQ-XXX supplied (inputs.release / client_payload.release)."
-            exit 1
+            echo "Standalone and integration housekeeping have no ticket/RTM close-out. No-op."
+            exit 0
           fi
           echo "req=${REQ}" >> "$GITHUB_OUTPUT"
           echo "pr=${PR}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/compliance-evidence.yml
+++ b/.github/workflows/compliance-evidence.yml
@@ -910,6 +910,10 @@ jobs:
           fi
 
           if [ "${#REQS[@]}" -eq 0 ]; then
+            if echo "$DERIVED_RELEASE" | grep -qE '^v[0-9]{4}\.[0-9]{2}\.[0-9]{2}([.][0-9]+)?$'; then
+              echo "No tracked REQ was executed for standalone/integration housekeeping ${DERIVED_RELEASE}; preserving this as GitHub historical CI without portal approval evidence."
+              exit 0
+            fi
             REQS=(_compliance-docs)
           fi
           # A bounded Playwright process exits the workflow with `failure`

--- a/compliance/security/accepted-vulnerabilities.json
+++ b/compliance/security/accepted-vulnerabilities.json
@@ -1,9 +1,14 @@
 {
+  "schemaVersion": 1,
   "exceptions": [
     {
       "advisoryId": "GHSA-6g55-p6wh-862q",
       "package": "postcss",
       "vulnerableRange": "<=8.5.11",
+      "vulnerableVersion": "8.4.31",
+      "dependencyPath": "node_modules/next/node_modules/postcss",
+      "introducedBy": "next@16.2.11",
+      "approvedAt": "2026-07-24",
       "expiresAt": "2026-08-24",
       "approvedBy": "william@ostendo.io",
       "reason": "next@16.2.11 is the latest available compatible release and exact-pins postcss@8.4.31. npm cannot safely replace that nested exact dependency.",

--- a/compliance/security/accepted-vulnerabilities.json
+++ b/compliance/security/accepted-vulnerabilities.json
@@ -1,0 +1,14 @@
+{
+  "exceptions": [
+    {
+      "advisoryId": "GHSA-6g55-p6wh-862q",
+      "package": "postcss",
+      "vulnerableRange": "<=8.5.11",
+      "expiresAt": "2026-08-24",
+      "approvedBy": "william@ostendo.io",
+      "reason": "next@16.2.11 is the latest available compatible release and exact-pins postcss@8.4.31. npm cannot safely replace that nested exact dependency.",
+      "remediationIssue": "https://github.com/metasession-dev/wawagardenbar-app/issues/575",
+      "compensatingControls": "Automated npm audit remains enabled; remove this exception immediately when a compatible Next release updates the nested dependency."
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "jspdf-autotable": "^5.0.2",
         "lucide-react": "^0.451.0",
         "mongoose": "^8.23.1",
-        "next": "^16.1.6",
+        "next": "^16.2.11",
         "nodemailer": "^9.0.1",
         "nuqs": "^2.2.0",
         "papaparse": "^5.5.3",
@@ -2709,9 +2709,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.9.tgz",
-      "integrity": "sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.11.tgz",
+      "integrity": "sha512-0do5A3BJ2gxWr0ZCMcD6BhW+e595jyxdTl3rXTS6lOtD8ektMiW6CO+EPwt1Eca1DBnm90r/7GdiKWBKxH++DA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2725,9 +2725,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.9.tgz",
-      "integrity": "sha512-HkfxNYUCmcct0Xsqib5KxqMSHV4AHJq857BNRchyBDs4YS19aHzVfn1kDuBYKqLLQBjXgnkIsjV2Kd4d2wzYhw==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.11.tgz",
+      "integrity": "sha512-wryL4pjKmDwGv2ox6+GZDFxvmtSRLqApBR8kL1j4+vhB7Z5vJC/zAnXpiR9Xkfzl0AS8WLMnsuGV/UKI67/rrw==",
       "cpu": [
         "arm64"
       ],
@@ -2741,9 +2741,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.9.tgz",
-      "integrity": "sha512-7IAtK4MeybpqRV9GRABWEhJ62mOS+rzWOzOTFie4cSEtm12xsoOMJRcECoZx3FHPzFAqN/IJtHqWAFOLfl152w==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.11.tgz",
+      "integrity": "sha512-aZl2j4f/fLyjQvOhv0Oe9UaMAQHolYpKhctsoYzplSumKJKPUmgjcf6545aBtysLTcu994TREd0+pSgNE4ohmg==",
       "cpu": [
         "x64"
       ],
@@ -2757,11 +2757,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.9.tgz",
-      "integrity": "sha512-hBD75iWpUtkL9SmQmcRhmLomn9jgkPzCEkbOcLgHymPEKzv+6ONy13RRiIEz/iEObjkS2Jlb5gYS2XGoS3X4rw==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.11.tgz",
+      "integrity": "sha512-5jEriyEnH/LWFy27L2ZG0XaLlyEJIjhsImEsiS9P563PKEVp2BVups/xfOucIrsvVntp11oNcZwjHvaDPYVB5g==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2773,11 +2776,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.9.tgz",
-      "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.11.tgz",
+      "integrity": "sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2789,11 +2795,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.9.tgz",
-      "integrity": "sha512-xm0HfRNX+UkH4R3c18ynswjj5o5uEj/7iI9p9omdtTSIsRCzQqkGMA+10nzJ4EHnYC3as65IMhbbl5fWRUWHYg==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.11.tgz",
+      "integrity": "sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2805,11 +2814,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.9.tgz",
-      "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.11.tgz",
+      "integrity": "sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2821,9 +2833,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.9.tgz",
-      "integrity": "sha512-hzQpKZvw8rAwI6A2uQh6SacCSvNAXaIkPNsWwzqqfRiIMiXMfH936skDhz1OO6KpvdKkJrgHHtqQOq5PIXOvdQ==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.11.tgz",
+      "integrity": "sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g==",
       "cpu": [
         "arm64"
       ],
@@ -2837,9 +2849,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.9.tgz",
-      "integrity": "sha512-qr2VL3Ce5QrwgO2yh1ujSBawrimjVKX8FGF/cOynmdYKJY0BdHpGVNIRK1tqONB10Vkm25Ub1BD2bkjWs4+96w==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.11.tgz",
+      "integrity": "sha512-md8CLNggS1Dx9pUgApzps5uAf+N8GN9xywzmNx9vHAWo94HtBwCCqkSnhIrdfQe83Dhz8Lfo/20Nb1Zxal092w==",
       "cpu": [
         "x64"
       ],
@@ -11334,12 +11346,12 @@
       }
     },
     "node_modules/next": {
-      "version": "16.2.9",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.9.tgz",
-      "integrity": "sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==",
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.11.tgz",
+      "integrity": "sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.9",
+        "@next/env": "16.2.11",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -11353,14 +11365,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.9",
-        "@next/swc-darwin-x64": "16.2.9",
-        "@next/swc-linux-arm64-gnu": "16.2.9",
-        "@next/swc-linux-arm64-musl": "16.2.9",
-        "@next/swc-linux-x64-gnu": "16.2.9",
-        "@next/swc-linux-x64-musl": "16.2.9",
-        "@next/swc-win32-arm64-msvc": "16.2.9",
-        "@next/swc-win32-x64-msvc": "16.2.9",
+        "@next/swc-darwin-arm64": "16.2.11",
+        "@next/swc-darwin-x64": "16.2.11",
+        "@next/swc-linux-arm64-gnu": "16.2.11",
+        "@next/swc-linux-arm64-musl": "16.2.11",
+        "@next/swc-linux-x64-gnu": "16.2.11",
+        "@next/swc-linux-x64-musl": "16.2.11",
+        "@next/swc-win32-arm64-msvc": "16.2.11",
+        "@next/swc-win32-x64-msvc": "16.2.11",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "jspdf-autotable": "^5.0.2",
     "lucide-react": "^0.451.0",
     "mongoose": "^8.23.1",
-    "next": "^16.1.6",
+    "next": "^16.2.11",
     "nodemailer": "^9.0.1",
     "nuqs": "^2.2.0",
     "papaparse": "^5.5.3",

--- a/scripts/evaluate-npm-audit.sh
+++ b/scripts/evaluate-npm-audit.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# evaluate-npm-audit.sh -- evaluate npm audit high/critical advisories against
+# narrowly governed, repository-owned temporary risk acceptances.
+#
+# The helper intentionally owns both decision logic and machine-readable output.
+# Workflow templates must not parse its human log output or convert evaluation
+# failures into successful "unknown" results.
+
+set -euo pipefail
+
+AUDIT_PATH="dependency-audit.json"
+LOCK_PATH="package-lock.json"
+EXCEPTIONS_PATH="compliance/security/accepted-vulnerabilities.json"
+OUTPUT_PATH="dependency-risk-evaluation.json"
+
+usage() {
+  echo "Usage: $0 [--audit <path>] [--lock <path>] [--exceptions <path>] [--output <path>]" >&2
+  exit 2
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --audit) AUDIT_PATH="${2:-}"; shift 2 ;;
+    --lock) LOCK_PATH="${2:-}"; shift 2 ;;
+    --exceptions) EXCEPTIONS_PATH="${2:-}"; shift 2 ;;
+    --output) OUTPUT_PATH="${2:-}"; shift 2 ;;
+    -h|--help) usage ;;
+    *) echo "Error: unknown argument: $1" >&2; usage ;;
+  esac
+done
+
+for required_path in "$AUDIT_PATH" "$LOCK_PATH"; do
+  [ -n "$required_path" ] && [ -f "$required_path" ] || {
+    echo "Error: required input is missing: ${required_path:-<empty>}" >&2
+    exit 2
+  }
+done
+
+python3 - "$AUDIT_PATH" "$LOCK_PATH" "$EXCEPTIONS_PATH" "$OUTPUT_PATH" <<'PY'
+import json
+import os
+import sys
+from datetime import date
+
+audit_path, lock_path, exceptions_path, output_path = sys.argv[1:]
+
+
+def fail(message):
+    print(f"Dependency-risk evaluation error: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def load_json(path, label):
+    try:
+        with open(path, encoding="utf-8") as handle:
+            return json.load(handle)
+    except (OSError, json.JSONDecodeError) as error:
+        fail(f"cannot read {label} {path}: {error}")
+
+
+def package_name_from_path(path):
+    marker = "node_modules/"
+    if marker not in path:
+        fail(f"package-lock node path is not a node_modules path: {path}")
+    tail = path.rsplit(marker, 1)[1]
+    parts = tail.split("/")
+    if not parts or not parts[0]:
+        fail(f"cannot derive package name from node path: {path}")
+    return "/".join(parts[:2]) if parts[0].startswith("@") else parts[0]
+
+
+def introducer_for(node_path, packages):
+    parent_marker = "/node_modules/"
+    if parent_marker not in node_path:
+        return "direct"
+    parent_path = node_path.rsplit(parent_marker, 1)[0]
+    parent = packages.get(parent_path)
+    if not isinstance(parent, dict) or not isinstance(parent.get("version"), str):
+        fail(f"cannot resolve introducing dependency for {node_path}")
+    return f"{package_name_from_path(parent_path)}@{parent['version']}"
+
+
+def advisory_id(advisory):
+    url = advisory.get("url")
+    if not isinstance(url, str) or "/" not in url:
+        fail("high/critical audit advisory is missing a URL")
+    value = url.rsplit("/", 1)[-1]
+    if not value:
+        fail("high/critical audit advisory has an empty advisory ID")
+    return value
+
+
+def valid_date(value, field, index):
+    if not isinstance(value, str):
+        fail(f"exception {index} has no valid {field}")
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        fail(f"exception {index} has invalid {field}: {value}")
+
+
+audit = load_json(audit_path, "npm audit JSON")
+lock = load_json(lock_path, "package-lock JSON")
+if not isinstance(audit, dict) or not isinstance(audit.get("vulnerabilities"), dict):
+    fail("npm audit JSON must contain a vulnerabilities object")
+if not isinstance(lock, dict) or not isinstance(lock.get("packages"), dict):
+    fail("package-lock JSON must contain a packages object")
+
+if os.path.exists(exceptions_path):
+    exception_document = load_json(exceptions_path, "risk acceptance JSON")
+    if not isinstance(exception_document, dict) or exception_document.get("schemaVersion") != 1:
+        fail("risk acceptance JSON must be an object with schemaVersion 1")
+    exceptions = exception_document.get("exceptions")
+    if not isinstance(exceptions, list):
+        fail("risk acceptance JSON must contain an exceptions array")
+else:
+    exceptions = []
+
+required_fields = (
+    "advisoryId",
+    "package",
+    "vulnerableRange",
+    "vulnerableVersion",
+    "dependencyPath",
+    "introducedBy",
+    "approvedAt",
+    "expiresAt",
+    "approvedBy",
+    "reason",
+    "remediationIssue",
+)
+today = date.today()
+validated_exceptions = []
+seen_exception_keys = set()
+for index, item in enumerate(exceptions, start=1):
+    if not isinstance(item, dict):
+        fail(f"exception {index} must be an object")
+    missing = [field for field in required_fields if not isinstance(item.get(field), str) or not item[field].strip()]
+    if missing:
+        fail(f"exception {index} is missing required field(s): {', '.join(missing)}")
+    approved_at = valid_date(item["approvedAt"], "approvedAt", index)
+    expires_at = valid_date(item["expiresAt"], "expiresAt", index)
+    if approved_at > today:
+        fail(f"exception {index} approvedAt cannot be in the future")
+    if expires_at <= today:
+        fail(f"exception {index} is expired on {item['expiresAt']}")
+    if not item["remediationIssue"].startswith("https://github.com/"):
+        fail(f"exception {index} remediationIssue must be a GitHub issue URL")
+    key = (item["advisoryId"], item["dependencyPath"])
+    if key in seen_exception_keys:
+        fail(f"duplicate exception for {item['advisoryId']} at {item['dependencyPath']}")
+    seen_exception_keys.add(key)
+    validated_exceptions.append(item)
+
+packages = lock["packages"]
+accepted = []
+unresolved = []
+seen_advisories = set()
+
+for finding_name, finding in audit["vulnerabilities"].items():
+    if not isinstance(finding, dict):
+        fail(f"audit vulnerability {finding_name} must be an object")
+    via = finding.get("via", [])
+    if not isinstance(via, list):
+        fail(f"audit vulnerability {finding_name} has invalid via data")
+    advisory_objects = [
+        item for item in via
+        if isinstance(item, dict) and item.get("severity") in ("high", "critical")
+    ]
+    if finding.get("severity") in ("high", "critical") and not advisory_objects:
+        fail(f"high/critical audit vulnerability {finding_name} has no resolvable advisory object")
+
+    nodes = finding.get("nodes", [])
+    if advisory_objects and (not isinstance(nodes, list) or not nodes):
+        fail(f"audit vulnerability {finding_name} has no installed package-lock node")
+
+    for advisory in advisory_objects:
+        package = advisory.get("dependency") or finding_name
+        advisory_range = advisory.get("range")
+        if not isinstance(package, str) or not package:
+            fail(f"advisory in {finding_name} has no package name")
+        if not isinstance(advisory_range, str) or not advisory_range:
+            fail(f"advisory {advisory_id(advisory)} has no vulnerable range")
+        identifier = advisory_id(advisory)
+        for node_path in nodes:
+            if not isinstance(node_path, str):
+                fail(f"advisory {identifier} has invalid package-lock node")
+            node = packages.get(node_path)
+            if not isinstance(node, dict) or not isinstance(node.get("version"), str):
+                fail(f"cannot resolve installed version for {node_path}")
+            if package_name_from_path(node_path) != package:
+                fail(f"audit package {package} does not match package-lock node {node_path}")
+            version = node["version"]
+            introduced_by = introducer_for(node_path, packages)
+            decision_key = (identifier, node_path)
+            if decision_key in seen_advisories:
+                continue
+            seen_advisories.add(decision_key)
+            context = {
+                "advisoryId": identifier,
+                "severity": advisory["severity"],
+                "package": package,
+                "vulnerableRange": advisory_range,
+                "vulnerableVersion": version,
+                "dependencyPath": node_path,
+                "introducedBy": introduced_by,
+            }
+            match = next((item for item in validated_exceptions if all(
+                item[field] == context[field]
+                for field in ("advisoryId", "package", "vulnerableRange", "vulnerableVersion", "dependencyPath", "introducedBy")
+            )), None)
+            if match is None:
+                unresolved.append(context)
+                print(
+                    f"Unaccepted {context['severity']} risk: {identifier} "
+                    f"({package}@{version} at {node_path})",
+                    file=sys.stderr,
+                )
+            else:
+                accepted.append({**context, "acceptance": {
+                    field: match[field]
+                    for field in ("approvedAt", "expiresAt", "approvedBy", "reason", "remediationIssue")
+                }})
+                print(
+                    f"Accepted temporary risk: {identifier} ({package}@{version}) "
+                    f"until {match['expiresAt']} by {match['approvedBy']}; "
+                    f"remediation {match['remediationIssue']}",
+                )
+
+result = {
+    "schemaVersion": 1,
+    "auditFile": audit_path,
+    "lockFile": lock_path,
+    "accepted": accepted,
+    "unresolved": unresolved,
+    "summary": {
+        "accepted": len(accepted),
+        "unresolved": len(unresolved),
+    },
+}
+with open(output_path, "w", encoding="utf-8") as handle:
+    json.dump(result, handle, indent=2)
+    handle.write("\n")
+
+print(f"Dependency risk evaluation: {len(accepted)} accepted, {len(unresolved)} unresolved.")
+raise SystemExit(1 if unresolved else 0)
+PY

--- a/scripts/generate-security-summary.sh
+++ b/scripts/generate-security-summary.sh
@@ -19,6 +19,7 @@
 # - `sast-results.json` (Semgrep) — high/critical findings count
 # - `dependency-audit.json` (npm audit / pip-audit) — high/critical
 #   vulnerability count
+# - `dependency-risk-evaluation.json` — governed temporary acceptances
 # - `gate-outcomes.json` (DevAudit-Installer v0.1.29) — per-gate
 #   pass/fail/skip status
 #
@@ -91,6 +92,25 @@ dep_audit_summary() {
   echo "$TOTAL total vulnerability/ies · $HIGH high · $CRITICAL critical"
 }
 
+risk_acceptance_summary() {
+  if [ ! -f dependency-risk-evaluation.json ]; then
+    echo "No dependency-risk decision artifact was present for this run."
+    return
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "REPLACE — \`jq\` not available; inspect \`dependency-risk-evaluation.json\` manually"
+    return
+  fi
+  jq -r '
+    if (.accepted | length) == 0 then
+      "No temporary high/critical dependency risks were accepted."
+    else
+      .accepted[] | "- Accepted \(.advisoryId) — \(.package)@\(.vulnerableVersion), introduced by \(.introducedBy), expires \(.acceptance.expiresAt), owner \(.acceptance.approvedBy), remediation \(.acceptance.remediationIssue)"
+    end
+  ' dependency-risk-evaluation.json 2>/dev/null \
+    || echo "REPLACE — could not parse \`dependency-risk-evaluation.json\`"
+}
+
 # Helper: gate-outcomes.json (DevAudit-Installer v0.1.29 onwards).
 gate_outcomes_summary() {
   if [ ! -f gate-outcomes.json ]; then
@@ -107,6 +127,7 @@ gate_outcomes_summary() {
 
 SAST_SUMMARY=$(sast_summary)
 DEP_SUMMARY=$(dep_audit_summary)
+RISK_ACCEPTANCE_SUMMARY=$(risk_acceptance_summary)
 GATES=$(gate_outcomes_summary)
 
 cat <<EOF
@@ -133,7 +154,7 @@ generated_by: "generate-security-summary.sh (DevAudit-Installer#116)"
 
 **Release shape:** $SHAPE
 **Generated:** $TODAY
-**Source data:** \`sast-results.json\` + \`dependency-audit.json\` + \`gate-outcomes.json\` (this CI run)
+**Source data:** \`sast-results.json\` + \`dependency-audit.json\` + \`dependency-risk-evaluation.json\` + \`gate-outcomes.json\` (this CI run)
 
 ## SAST findings (Semgrep)
 
@@ -145,7 +166,11 @@ $SAST_SUMMARY
 
 $DEP_SUMMARY
 
-> **Policy:** the dependency-audit gate fails the build at \`high\` or \`critical\` severity. If this release shipped, both are zero.
+> **Policy:** the dependency-audit gate fails at \`high\` or \`critical\` severity unless every affected advisory has an exact, unexpired, reviewer-attributed acceptance. The raw audit count may therefore be non-zero only when the governed decision record below identifies the accepted risk.
+
+## Governed temporary dependency risks
+
+$RISK_ACCEPTANCE_SUMMARY
 
 ## Gate outcomes (per CI run)
 


### PR DESCRIPTION
## Summary

Adopts the published DevAudit v0.3.21 generated contract for the WGB standalone-housekeeping release path.

- Adds the REQ-only close-out completion callback workflow.
- Exports the resolved portal URL in the Stage 2 shell before starting the test execution.
- Treats untagged bare-date E2E as historical CI rather than tracked approval evidence.
- Applies the standalone housekeeping admission semantics.

## Verification

- npm run lint (warnings only; no errors)
- npm test (1,298 passed; 4 skipped)
- npm run build

Part of metasession-dev/DevAudit-Installer#491.

Relates to #573, #532, #566, #525, and #520.