### PR TITLE
compliance: refresh standalone housekeeping declaration

### DIFF
--- a/compliance/standalone-housekeeping/STANDALONE-HOUSEKEEPING-v2026.07.22.json
+++ b/compliance/standalone-housekeeping/STANDALONE-HOUSEKEEPING-v2026.07.22.json
@@ -1,6 +1,0 @@
-{
-  "schemaVersion": 1,
-  "version": "v2026.07.22",
-  "releaseMode": "standalone_housekeeping",
-  "reason": "Promote the DevAudit v0.3.20 evidence-upload workflow corrections now so future production deployments can upload deployment-origin E2E evidence correctly instead of waiting for the next tracked requirement release."
-}

--- a/compliance/standalone-housekeeping/STANDALONE-HOUSEKEEPING-v2026.07.24.json
+++ b/compliance/standalone-housekeeping/STANDALONE-HOUSEKEEPING-v2026.07.24.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "version": "v2026.07.24",
+  "releaseMode": "standalone_housekeeping",
+  "reason": "Promote the reviewed DevAudit v0.3.20 through v0.3.25 framework updates, governed dependency-risk evaluator, evidence-upload corrections, and REQ-094 close-out recovery path now. These release-control and audit-evidence repairs must reach production before the next tracked requirement release."
+}


### PR DESCRIPTION
Replaces the stale v2026.07.22 standalone declaration with the current v2026.07.24 identity derived by the integration head.

The existing develop → main promotion PR #572 remained open while reviewed housekeeping work continued to merge to develop. This correction restores exact declaration/version alignment so the standalone approval bypass applies without bypassing normal review or technical checks.

Refs metasession-dev/DevAudit-Installer#491.