### PR TITLE
ci: scope standalone declaration evidence correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,8 +424,10 @@ jobs:
           fi
           chmod +x scripts/standalone-housekeeping-release.sh scripts/upload-evidence.sh 2>/dev/null || true
           bash scripts/standalone-housekeeping-release.sh validate "$VERSION" "$DECLARATION"
+          # Bare-date versions identify releases, not requirements. The portal
+          # stores release-scoped evidence through its synthetic common scope.
           bash scripts/upload-evidence.sh \
-            wgb "$VERSION" release_ticket "$DECLARATION" \
+            wgb "_compliance-docs" release_ticket "$DECLARATION" \
             --release "$VERSION" --create-release-if-missing \
             --environment uat --category release_artifact --sdlc-stage 2 \
             --git-sha ${{ github.sha }} --branch ${{ github.ref_name }}


### PR DESCRIPTION
Temporary consumer repair for [Installer #540](https://github.com/metasession-dev/DevAudit-Installer/issues/540).

Standalone declaration registration incorrectly used the bare-date release version as the portal requirement ID, causing a 400. This uses `_compliance-docs` for evidence scope while preserving `--release "$VERSION"` for release ownership.

The authoritative installer template must be fixed under #540; this PR allows the current standalone v2026.07.24 promotion to register correctly after the normal feature-to-develop merge.