### PR TITLE
ci: bound E2E readiness waits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,9 @@ jobs:
         run: npm run dev &
 
       - name: Wait for dev server
-        run: npx wait-on http://localhost:3000 --timeout 120000
+        # The inner wait-on timeout is not a reliable process boundary on
+        # hosted runners. Keep a hard outer deadline below the job timeout.
+        run: timeout --signal=TERM --kill-after=15s 150s npx wait-on http://localhost:3000 --timeout 120000
 
       # Compute the set of e2e spec files added on this branch (relative
       # to the merge base). The evidenceShot helper in the consumer's

--- a/.github/workflows/e2e-regression.yml
+++ b/.github/workflows/e2e-regression.yml
@@ -132,7 +132,10 @@ jobs:
           echo "Started E2E server pid $(cat .e2e-server.pid)"
 
       - name: Wait for dev server
-        run: npx wait-on http://localhost:3000 --timeout 120000
+        # `wait-on` owns its internal readiness budget, but a process-level
+        # deadline is needed so a hung child cannot leave the required check
+        # in progress until the job-level 55-minute timeout.
+        run: timeout --signal=TERM --kill-after=15s 150s npx wait-on http://localhost:3000 --timeout 120000
 
       # Decide which Playwright project to run based on the trigger.
       # PR-to-main runs `critical` (~10-15 min); push-to-main runs

--- a/.github/workflows/feature-e2e.yml
+++ b/.github/workflows/feature-e2e.yml
@@ -123,7 +123,9 @@ jobs:
         run: npm run dev &
 
       - name: Wait for dev server
-        run: npx wait-on http://localhost:3000 --timeout 120000
+        # Keep an outer deadline so a hung readiness child cannot hold the
+        # feature-E2E check until the job-level timeout.
+        run: timeout --signal=TERM --kill-after=15s 150s npx wait-on http://localhost:3000 --timeout 120000
 
       # Compute the set of e2e spec files added on this branch (relative
       # to the merge base). The evidenceShot helper reads E2E_NEW_SPECS

--- a/scripts/tests/e2e-regression-readiness.test.sh
+++ b/scripts/tests/e2e-regression-readiness.test.sh
@@ -3,20 +3,32 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-WORKFLOW="$ROOT/.github/workflows/e2e-regression.yml"
+WORKFLOWS=(
+  "$ROOT/.github/workflows/ci.yml"
+  "$ROOT/.github/workflows/e2e-regression.yml"
+  "$ROOT/.github/workflows/feature-e2e.yml"
+)
 
 require() {
   local pattern="$1"
   local description="$2"
-  if ! rg -q --fixed-strings "$pattern" "$WORKFLOW"; then
-    echo "FAIL: missing ${description}" >&2
-    exit 1
-  fi
+  local workflow
+  for workflow in "${WORKFLOWS[@]}"; do
+    if ! rg -q --fixed-strings "$pattern" "$workflow"; then
+      echo "FAIL: missing ${description} in ${workflow#$ROOT/}" >&2
+      exit 1
+    fi
+  done
 }
 
 require 'timeout --signal=TERM --kill-after=15s 150s npx wait-on http://localhost:3000 --timeout 120000' 'outer readiness deadline'
-require '.e2e-server.pid' 'captured development-server PID'
-require 'name: Stop dev server' 'always-run development-server teardown'
-require 'e2e-server.log' 'server log artifact upload'
+
+REGRESSION_WORKFLOW="$ROOT/.github/workflows/e2e-regression.yml"
+for pattern in '.e2e-server.pid' 'name: Stop dev server' 'e2e-server.log'; do
+  if ! rg -q --fixed-strings "$pattern" "$REGRESSION_WORKFLOW"; then
+    echo "FAIL: regression workflow lost ${pattern}" >&2
+    exit 1
+  fi
+done
 
 echo 'E2E regression readiness contract passed'

--- a/scripts/tests/e2e-regression-readiness.test.sh
+++ b/scripts/tests/e2e-regression-readiness.test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Contract coverage for wawagardenbar-app#580.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW="$ROOT/.github/workflows/e2e-regression.yml"
+
+require() {
+  local pattern="$1"
+  local description="$2"
+  if ! rg -q --fixed-strings "$pattern" "$WORKFLOW"; then
+    echo "FAIL: missing ${description}" >&2
+    exit 1
+  fi
+}
+
+require 'timeout --signal=TERM --kill-after=15s 150s npx wait-on http://localhost:3000 --timeout 120000' 'outer readiness deadline'
+require '.e2e-server.pid' 'captured development-server PID'
+require 'name: Stop dev server' 'always-run development-server teardown'
+require 'e2e-server.log' 'server log artifact upload'
+
+echo 'E2E regression readiness contract passed'


### PR DESCRIPTION
## Summary
- enforce a process-level 150-second bound around E2E server readiness
- preserve existing always-run server teardown and log artifact upload
- add a workflow contract test

## Verification
- `bash scripts/tests/e2e-regression-readiness.test.sh`
- Node YAML parse of `.github/workflows/e2e-regression.yml`

Closes #580