### PR TITLE
chore: declare standalone housekeeping v2026.07.26

### DIFF
--- a/compliance/standalone-housekeeping/STANDALONE-HOUSEKEEPING-v2026.07.26.json
+++ b/compliance/standalone-housekeeping/STANDALONE-HOUSEKEEPING-v2026.07.26.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "version": "v2026.07.26",
+  "releaseMode": "standalone_housekeeping",
+  "reason": "Promote the reviewed DevAudit v0.3.29 standalone-routing, evidence, close-out, and dependency-risk contract updates together with the WGB dependency remediation. These release-control and security-evidence repairs must reach production before the next tracked requirement release."
+}


### PR DESCRIPTION
Part of #573.

Adds the exact standalone declaration derived from the current integration head. This repairs the stale v2026.07.24 metadata exposed by promotion PR #586 without bypassing Release Scope Integrity or the approval gate.