### PR TITLE
ci: Standalone housekeeping promotion v2026.07.26

### DIFF
--- a/.github/workflows/post-deploy-prod.yml
+++ b/.github/workflows/post-deploy-prod.yml
@@ -445,6 +445,10 @@ jobs:
             VERSION=$(echo "$RESP" | jq -r '.latest.version // empty')
             [ -z "$VERSION" ] && VERSION="${PREFIX}"
             RELEASE_ID=$(echo "$RESP" | jq -r '.latest.id // empty')
+            EVIDENCE_SCOPE="${VERSION}"
+            if [ -n "${STANDALONE_DECLARATION:-}" ] && [ "$VERSION" = "${REQS}" ]; then
+              EVIDENCE_SCOPE="_compliance-docs"
+            fi
             REQ_FAILURES=0
             LINEAGE_FLAGS=(--test-execution "${CI_RUN}")
             EXECUTION_OUT="$(mktemp)"
@@ -472,7 +476,7 @@ jobs:
             # Production smoke evidence (whole-app health) attached to this release.
             if [ -f prod-smoke-results.json ]; then
               bash scripts/upload-evidence.sh \
-                "${PROJECT_SLUG}" "${VERSION}" smoke_test prod-smoke-results.json \
+                "${PROJECT_SLUG}" "${EVIDENCE_SCOPE}" smoke_test prod-smoke-results.json \
                 --release "${VERSION}" --create-release-if-missing --environment production \
                 --category smoke_test --sdlc-stage 5 --git-sha "${GIT_SHA}" --ci-run-id "${CI_RUN}" --branch main \
                 "${LINEAGE_FLAGS[@]}" \
@@ -491,7 +495,7 @@ jobs:
             done
             if [ -n "$TICKET" ]; then
               bash scripts/upload-evidence.sh \
-                "${PROJECT_SLUG}" "${VERSION}" release_ticket "$TICKET" \
+                "${PROJECT_SLUG}" "${EVIDENCE_SCOPE}" release_ticket "$TICKET" \
                 --release "${VERSION}" --create-release-if-missing --environment production \
                 --category release_artifact --sdlc-stage 5 --git-sha "${GIT_SHA}" --ci-run-id "${CI_RUN}" --branch main \
                 || { echo "Warning: ticket upload failed for ${VERSION}"; REQ_FAILURES=$((REQ_FAILURES + 1)); }


### PR DESCRIPTION
Release: v2026.07.26

Standalone housekeeping promotion

## Scope
Fix-forward the already deployed standalone housekeeping release after production run 30197546898 passed host deployment, health, and smoke but failed portal evidence attribution.

- adopts released DevAudit Installer v0.3.30 production evidence routing
- standalone smoke and declaration evidence use `_compliance-docs` requirement scope
- exact `v2026.07.26` release ownership is retained
- tracked REQ release behavior is unchanged

## Release behavior
This is the same declared standalone housekeeping release, not a tracked REQ and not a new approval record. After Railway deploys the merge SHA, production evidence must upload successfully and the portal must mark `v2026.07.26` as `standalone_housekeeping` and `released`.

Source correction: #588
Upstream: metasession-dev/DevAudit-Installer#571
Supersedes: #590 (metadata event payload only)