### PR TITLE
test: gate REQ-088 without reordering regression (#596)

### DIFF
--- a/e2e/invariants/inventory-deduction-checkout.spec.ts
+++ b/e2e/invariants/inventory-deduction-checkout.spec.ts
@@ -26,7 +26,7 @@ import {
   uniqueIdempotencyKey,
   deleteMany,
   findOrCreateMenuItem,
-} from '../invariants/helpers';
+} from './helpers';
 import { tagTest } from '../helpers/test-tags';
 import { evidenceShot } from '../helpers/evidence';
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -84,6 +84,7 @@ export default defineConfig({
       testMatch: [
         /e2e\/smoke\/.*\.spec\.ts$/,
         /e2e\/critical\/.*\.spec\.ts$/,
+        /e2e\/invariants\/inventory-deduction-checkout\.spec\.ts$/,
         /requirements-verification\.spec\.ts$/,
       ],
       retries: 0,


### PR DESCRIPTION
## Summary

- restore the REQ-088 invariant spec to its original full-regression path/order
- explicitly include that exact spec in the critical PR gate
- retain the deterministic positive-stock fixture from #593

## Verification

- `npx tsc --noEmit`
- `npx playwright test --project=critical --list`
- confirmed `invariants/inventory-deduction-checkout.spec.ts` is selected by the critical project
- `git diff --check`

Closes #596
