### PR TITLE
chore(release): promote REQ-088 regression-order fix

### DIFF
--- a/e2e/invariants/inventory-deduction-checkout.spec.ts
+++ b/e2e/invariants/inventory-deduction-checkout.spec.ts
@@ -26,7 +26,7 @@ import {
   uniqueIdempotencyKey,
   deleteMany,
   findOrCreateMenuItem,
-} from '../invariants/helpers';
+} from './helpers';
 import { tagTest } from '../helpers/test-tags';
 import { evidenceShot } from '../helpers/evidence';
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -84,6 +84,7 @@ export default defineConfig({
       testMatch: [
         /e2e\/smoke\/.*\.spec\.ts$/,
         /e2e\/critical\/.*\.spec\.ts$/,
+        /e2e\/invariants\/inventory-deduction-checkout\.spec\.ts$/,
         /requirements-verification\.spec\.ts$/,
       ],
       retries: 0,


### PR DESCRIPTION
## Standalone housekeeping promotion

Release: v2026.07.26

Promotes the terminal-green #596 fix from `develop` to `main`:

- retain the deterministic REQ-088 inventory fixture
- restore the established full-regression file order
- select REQ-088 explicitly in the critical pre-main gate

This is an exact standalone housekeeping release. It does not create or require a tracked REQ approval record.

## Verification

- feature PR #597 passed all checks before merge to `develop`
- `npx tsc --noEmit`
- critical project list includes REQ-088 AC1

Fixes #596
