### PR TITLE
Release: v2026.07.26

### DIFF
--- a/.github/workflows/compliance-evidence.yml
+++ b/.github/workflows/compliance-evidence.yml
@@ -388,9 +388,9 @@ jobs:
           [ -n "$STAGE" ] && FLAGS="${FLAGS} --sdlc-stage ${STAGE}"
 
           # In-scope REQs from pending release tickets at the triggering
-          # SHA. If the ticket was created after the triggering E2E run,
-          # recover REQs from the Playwright JSON artifact before falling
-          # back to `_compliance-docs` (DevAudit-Installer#311).
+          # SHA. Release-ticket scope is authoritative. A bare-date release
+          # with no ticket is historical/integration CI and must not infer
+          # scope from arbitrary Playwright report text.
           REQS=()
           if [ -d compliance/pending-releases ]; then
             for TICKET in compliance/pending-releases/RELEASE-TICKET-REQ-*.md; do
@@ -406,6 +406,14 @@ jobs:
             done
           fi
 
+          if [ "${#REQS[@]}" -eq 0 ] && echo "$DERIVED_RELEASE" | grep -qE '^v[0-9]{4}\.[0-9]{2}\.[0-9]{2}([.][0-9]+)?$'; then
+            echo "No tracked REQ was in scope for standalone/integration housekeeping ${DERIVED_RELEASE}; preserving this as GitHub historical CI without portal approval evidence."
+            exit 0
+          fi
+
+          # Compatibility fallback for a tracked release whose ticket was
+          # created after the triggering run. Only exact canonical IDs may
+          # be recovered; arbitrary report text must never become scope.
           if [ "${#REQS[@]}" -eq 0 ] && [ -f e2e-artifacts/e2e-regression-results.json ]; then
             {
               printf '%s\n' 'import json'
@@ -422,7 +430,7 @@ jobs:
               printf '%s\n' ''
               printf '%s\n' 'def walk(value):'
               printf '%s\n' '    if isinstance(value, str):'
-              printf '%s\n' "        for req in re.findall(r'REQ-[0-9]+', value):"
+              printf '%s\n' "        for req in re.findall(r'(?<![A-Z0-9])REQ-[0-9]{3}(?![0-9])', value):"
               printf '%s\n' '            seen.add(req)'
               printf '%s\n' '    elif isinstance(value, dict):'
               printf '%s\n' '        for item in value.values():'


### PR DESCRIPTION
Release: v2026.07.26

Standalone housekeeping promotion

## Scope

Promotes #600 from `develop` to `main`.

- bare-date housekeeping E2E runs remain GitHub historical CI
- release-ticket files remain authoritative for tracked scope
- arbitrary Playwright report text cannot create portal requirement IDs
- compatibility fallback accepts only exact `REQ-XXX` identifiers

The production run for the previous commit passed E2E but exposed this importer defect in run 30208066567.
