### PR TITLE
chore: sync DevAudit SDLC templates to 0.3.35

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,3 +9,6 @@ contact_links:
   - name: 🛠️ Implementing an SDLC issue
     url: https://github.com/metasession-dev/devaudit/blob/main/docs/implementing-an-sdlc-issue.md
     about: End-to-end walkthrough — GitHub issue → merged. Required reading before opening a Requirement.
+  - name: 🚀 Full onboarding guide
+    url: https://devaudit.ai/onboarding/guide
+    about: Every document, token, and access step required to fully onboard a project — including when and how to use SRS Bootstrap below.

--- a/.github/ISSUE_TEMPLATE/srs-bootstrap.yml
+++ b/.github/ISSUE_TEMPLATE/srs-bootstrap.yml
@@ -1,0 +1,77 @@
+name: SRS Bootstrap
+description: Author this project's first Software Requirements Specification (docs/SRS.md). One-time — use Requirement for everything after.
+title: '[SRS] Bootstrap the Software Requirements Specification'
+labels: ['srs-bootstrap', 'documentation']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template **once per project**, to create `docs/SRS.md` for the first time. `requirements-aligner` deliberately refuses to author an SRS from scratch — it only maintains one that already exists — so this bootstrap is a human (or AI-agent-assisted) step, not an automated one.
+
+        Once `docs/SRS.md` exists and is committed, this template has done its job. From your next requirement onward, use [Requirement](./requirement.yml) instead — `requirements-aligner` will propose new `REQ-AREA-NNN` stubs against the SRS you create here automatically at Stage 1 and Stage 3.
+
+        Start from `SRS_TEMPLATE.md` (synced to `SDLC/` alongside the stage docs) — it has the MoSCoW conventions, the `REQ-AREA-NNN` ID scheme, and two worked examples to copy the format from.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: What is this project, and who is it for?
+      description: A few sentences — enough for whoever works this issue to understand the system's purpose and users without reading the whole codebase first.
+      placeholder: |
+        [PROJECT NAME] is a [one-line description]. Primary users are [who]. It's currently at [stage — pre-launch / live with N users / internal tool / etc.].
+    validations:
+      required: true
+
+  - type: textarea
+    id: must
+    attributes:
+      label: Must — the system is broken or unshippable without these
+      description: The requirements that belong in the smoke/critical test suite. Start with the riskiest surfaces — auth, payments, data handling, anything an auditor would ask about first.
+      placeholder: |
+        - A registered user can sign in
+        - [core domain action] completes successfully for a valid input
+        - ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: should
+    attributes:
+      label: Should — important, expected functionality
+      description: Not launch-blocking on their own, but real gaps if missing. Goes in the regression suite.
+      placeholder: |
+        - A user can reset a forgotten password
+        - ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: could
+    attributes:
+      label: Could — nice-to-have, edge-case, or polish
+      description: Lowest test priority. "None yet" is a valid answer for a first pass.
+      validations:
+        required: false
+
+  - type: textarea
+    id: wont
+    attributes:
+      label: Won't (this cycle) — explicitly out of scope for now
+      description: Recorded so it doesn't get silently re-litigated later. Not the same as "never."
+      validations:
+        required: false
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Pre-flight
+      options:
+        - label: I've checked — `docs/SRS.md` does not already exist in this repository. (If it does, this is drift maintenance, not a bootstrap — file a [Requirement](./requirement.yml) instead, or ask `requirements-aligner` to audit the existing document.)
+          required: true
+        - label: I've read `SDLC/SRS_TEMPLATE.md` (or `sdlc/files/_common/SRS_TEMPLATE.md` in the DevAudit-Installer repo) and will use its format.
+          required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        **Definition of done:** `docs/SRS.md` exists in this repository, seeded from `SRS_TEMPLATE.md`, with the Must/Should/Could/Won't items above expanded into `REQ-AREA-NNN` entries in Given/When/Then format, committed to `develop`. Close this issue once it's merged.

--- a/.github/workflows/close-out-release.yml
+++ b/.github/workflows/close-out-release.yml
@@ -193,6 +193,21 @@ jobs:
         # the consumer repo" text while it's open. Never fails the job:
         # older portal deployments that don't yet accept status=pr_opened
         # (devaudit#740) should not break close-out.
+        #
+        # devaudit-installer#601 — a jq failure while building the POST
+        # payload previously crashed this script silently. The failure lived
+        # inside a `$(...)` substitution feeding `curl --data`; under
+        # `set -e`, a failing assignment substitution (`VAR=$(...)`) aborts
+        # the script immediately, but the intended `|| echo "::warning::..."`
+        # safety net was attached to the outer `curl` command, which never
+        # even started — only the step's own `continue-on-error: true`
+        # caught the resulting non-zero exit, with no warning annotation
+        # ever posted and no diagnosis possible after the fact (the exact
+        # runtime value that tripped it wasn't recoverable from the log).
+        # Every jq/curl call that feeds a later step is now individually
+        # guarded (`|| true` inside the substitution, so `set -e` can't
+        # abort on it) and logged, so a future failure is diagnosable and
+        # never silent, regardless of which specific call trips it.
         if: steps.closeout.outputs.changed == 'true' || steps.merge.outputs.merged == 'true'
         continue-on-error: true
         run: |
@@ -207,20 +222,116 @@ jobs:
           BRANCH="${CLOSEOUT_BRANCH_PREFIX}${REQ}"
           [ -z "$BRANCH" ] && BRANCH="chore/close-out-${REQ}"
           PR_JSON="$(gh pr view "$BRANCH" --repo "$GITHUB_REPOSITORY" --json number,url 2>/dev/null || true)"
-          NUMBER="$(jq -r '.number // empty' <<<"${PR_JSON:-{}}")"
-          URL="$(jq -r '.url // empty' <<<"${PR_JSON:-{}}")"
+          NUMBER="$(jq -r '.number // empty' <<<"${PR_JSON:-{}}" 2>/dev/null || true)"
+          URL="$(jq -r '.url // empty' <<<"${PR_JSON:-{}}" 2>/dev/null || true)"
+          echo "Resolved close-out PR for ${BRANCH}: number='${NUMBER}' url='${URL}'"
           if [ -z "$NUMBER" ] || [ -z "$URL" ]; then
             echo "::warning::Could not resolve the close-out PR for ${BRANCH}; skipping pr_opened report."
             exit 0
           fi
-          RELEASE="$(curl --fail-with-body -sS -G "${BASE_URL%/}/api/ci/releases/resolve" -H "Authorization: Bearer ${DEVAUDIT_API_KEY}" --data-urlencode "projectSlug=wgb" --data-urlencode "versionPrefix=${REQ}")"
-          RELEASE_ID="$(jq -r '.latest.id // empty' <<<"$RELEASE")"
-          RELEASE_VERSION="$(jq -r '.latest.version // empty' <<<"$RELEASE")"
+          if ! printf '%s' "$NUMBER" | grep -qE '^[0-9]+$'; then
+            echo "::warning::Resolved PR number '${NUMBER}' is not a bare integer; skipping pr_opened report."
+            exit 0
+          fi
+          RELEASE="$(curl --fail-with-body -sS -G "${BASE_URL%/}/api/ci/releases/resolve" -H "Authorization: Bearer ${DEVAUDIT_API_KEY}" --data-urlencode "projectSlug=wgb" --data-urlencode "versionPrefix=${REQ}" || true)"
+          RELEASE_ID="$(jq -r '.latest.id // empty' <<<"${RELEASE:-{}}" 2>/dev/null || true)"
+          RELEASE_VERSION="$(jq -r '.latest.version // empty' <<<"${RELEASE:-{}}" 2>/dev/null || true)"
+          echo "Resolved portal release for ${REQ}: id='${RELEASE_ID}' version='${RELEASE_VERSION}'"
           if [ "$RELEASE_VERSION" != "$REQ" ] || [ -z "$RELEASE_ID" ]; then
             echo "::warning::Unable to resolve ${REQ} on the portal; skipping pr_opened report."
             exit 0
           fi
+          PAYLOAD="$(jq -nc --arg workflowRunId '${{ github.run_id }}' --arg workflowUrl '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}' --arg pullRequestUrl "$URL" --argjson pullRequestNumber "$NUMBER" '{status:"pr_opened",workflowRunId:$workflowRunId,workflowUrl:$workflowUrl,pullRequestNumber:$pullRequestNumber,pullRequestUrl:$pullRequestUrl}')" || {
+            echo "::warning::Failed to build the pr_opened payload for ${BRANCH} (jq error); skipping report."
+            exit 0
+          }
           curl --fail-with-body -sS -X POST "${BASE_URL%/}/api/ci/releases/${RELEASE_ID}/close-out" \
             -H "Authorization: Bearer ${DEVAUDIT_API_KEY}" -H 'Content-Type: application/json' \
-            --data "$(jq -nc --arg workflowRunId '${{ github.run_id }}' --arg workflowUrl '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}' --arg pullRequestUrl "$URL" --argjson pullRequestNumber "$NUMBER" '{status:"pr_opened",workflowRunId:$workflowRunId,workflowUrl:$workflowUrl,pullRequestNumber:$pullRequestNumber,pullRequestUrl:$pullRequestUrl}')" \
+            --data "$PAYLOAD" \
             || echo "::warning::Failed to report close-out PR-opened status (portal may not support pr_opened yet)."
+
+      - name: Wait for close-out PR merge and report completion
+        # devaudit-installer#602 — a close-out PR merged via GitHub's native
+        # auto-merge (armed above using GITHUB_TOKEN) does not reliably
+        # trigger close-out-completion.yml's `pull_request: closed` event:
+        # GitHub suppresses new workflow runs for events whose actor is the
+        # same GITHUB_TOKEN identity that caused them, and the async merge
+        # performed by auto-merge is attributed to that identity. That
+        # workflow keeps working normally for a genuinely human-authored
+        # merge, so it is left in place — but this run cannot depend on it
+        # alone. Instead this step polls the close-out PR it just
+        # opened/armed and reports completion itself the moment it observes
+        # the merge, so the portal's closeout_status reaches "completed"
+        # even when the pull_request:closed event never arrives. A duplicate
+        # report from close-out-completion.yml firing too (e.g. a human
+        # merge observed by both) is harmless — it POSTs the same
+        # already-true status.
+        #
+        # Best-effort and bounded: if the close-out PR's checks take longer
+        # than the poll window, this step logs a warning and gives up
+        # without failing the job. Re-run this workflow via
+        # `workflow_dispatch` (release=${REQ}, release_pr=<PR>) once it
+        # merges — see "Report verified manual close-out catch-up" above,
+        # which already handles exactly that case.
+        if: steps.closeout.outputs.changed == 'true' || steps.merge.outputs.merged == 'true'
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          REQ="${{ steps.in.outputs.req }}"
+          BASE_URL="${DEVAUDIT_BASE_URL:-}"
+          if [ -z "$BASE_URL" ] || [ -z "$DEVAUDIT_API_KEY" ]; then
+            echo "::warning::DevAudit base URL and project API key are required to report close-out completion; skipping."
+            exit 0
+          fi
+          source scripts/close-out-contract.sh 2>/dev/null || true
+          BRANCH="${CLOSEOUT_BRANCH_PREFIX}${REQ}"
+          [ -z "$BRANCH" ] && BRANCH="chore/close-out-${REQ}"
+          MAX_ATTEMPTS=40
+          SLEEP_SECONDS=30
+          STATE=""
+          PR_JSON=""
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            PR_JSON="$(gh pr view "$BRANCH" --repo "$GITHUB_REPOSITORY" --json state,mergedAt,mergeCommit,number,url 2>/dev/null || true)"
+            STATE="$(jq -r '.state // empty' <<<"${PR_JSON:-{}}" 2>/dev/null || true)"
+            echo "Poll ${attempt}/${MAX_ATTEMPTS}: ${BRANCH} state='${STATE}'"
+            if [ "$STATE" = "MERGED" ]; then
+              break
+            fi
+            if [ "$STATE" = "CLOSED" ]; then
+              echo "::warning::${BRANCH} was closed without merging; not reporting completion."
+              exit 0
+            fi
+            sleep "$SLEEP_SECONDS"
+          done
+          if [ "$STATE" != "MERGED" ]; then
+            echo "::warning::${BRANCH} did not merge within $((MAX_ATTEMPTS * SLEEP_SECONDS / 60)) minutes of polling; not reporting completion here. Re-run this workflow via workflow_dispatch (release=${REQ}, release_pr=<PR>) once it merges."
+            exit 0
+          fi
+          NUMBER="$(jq -r '.number // empty' <<<"$PR_JSON" 2>/dev/null || true)"
+          URL="$(jq -r '.url // empty' <<<"$PR_JSON" 2>/dev/null || true)"
+          SHA="$(jq -r '.mergeCommit.oid // empty' <<<"$PR_JSON" 2>/dev/null || true)"
+          echo "Resolved merged ${BRANCH}: number='${NUMBER}' url='${URL}' mergeSha='${SHA}'"
+          if [ -z "$NUMBER" ] || [ -z "$URL" ] || [ -z "$SHA" ]; then
+            echo "::warning::Merged ${BRANCH} but could not resolve number/url/mergeSha; skipping completion report."
+            exit 0
+          fi
+          if ! printf '%s' "$NUMBER" | grep -qE '^[0-9]+$'; then
+            echo "::warning::Resolved PR number '${NUMBER}' is not a bare integer; skipping completion report."
+            exit 0
+          fi
+          RELEASE="$(curl --fail-with-body -sS -G "${BASE_URL%/}/api/ci/releases/resolve" -H "Authorization: Bearer ${DEVAUDIT_API_KEY}" --data-urlencode "projectSlug=wgb" --data-urlencode "versionPrefix=${REQ}" || true)"
+          RELEASE_ID="$(jq -r '.latest.id // empty' <<<"${RELEASE:-{}}" 2>/dev/null || true)"
+          RELEASE_VERSION="$(jq -r '.latest.version // empty' <<<"${RELEASE:-{}}" 2>/dev/null || true)"
+          echo "Resolved portal release for ${REQ}: id='${RELEASE_ID}' version='${RELEASE_VERSION}'"
+          if [ "$RELEASE_VERSION" != "$REQ" ] || [ -z "$RELEASE_ID" ]; then
+            echo "::warning::Unable to resolve ${REQ} on the portal; skipping completion report."
+            exit 0
+          fi
+          PAYLOAD="$(jq -nc --arg workflowRunId '${{ github.run_id }}' --arg workflowUrl '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}' --arg pullRequestUrl "$URL" --arg mergeSha "$SHA" --argjson pullRequestNumber "$NUMBER" '{status:"completed",workflowRunId:$workflowRunId,workflowUrl:$workflowUrl,pullRequestNumber:$pullRequestNumber,pullRequestUrl:$pullRequestUrl,mergeSha:$mergeSha}')" || {
+            echo "::warning::Failed to build the completion payload for ${BRANCH} (jq error); skipping report."
+            exit 0
+          }
+          curl --fail-with-body -sS -X POST "${BASE_URL%/}/api/ci/releases/${RELEASE_ID}/close-out" \
+            -H "Authorization: Bearer ${DEVAUDIT_API_KEY}" -H 'Content-Type: application/json' \
+            --data "$PAYLOAD" \
+            || echo "::warning::Failed to report close-out completion status."

--- a/SDLC/0-project-setup.md
+++ b/SDLC/0-project-setup.md
@@ -367,6 +367,24 @@ git push origin develop
 
 ---
 
+## Step 6a: Bootstrap the Software Requirements Specification
+
+`docs/SRS.md` is the project's living spec — what `e2e-test-engineer` derives tests from, and what `requirements-aligner` checks every future requirement against. Nothing in the framework authors this for you: `requirements-aligner` explicitly refuses to write an SRS from scratch (it only maintains one that already exists), so this is the one manual bootstrap step in an otherwise-automated pipeline.
+
+1. File an **SRS Bootstrap** issue (synced to `.github/ISSUE_TEMPLATE/srs-bootstrap.yml`) — it walks through identifying your project's Must/Should/Could/Won't requirements using MoSCoW prioritisation.
+2. Work the issue from `SDLC/SRS_TEMPLATE.md` (synced alongside the stage docs) — it has the `REQ-AREA-NNN` ID scheme, the MoSCoW conventions, and two worked Given/When/Then examples to copy the format from.
+3. Commit the result as `docs/SRS.md`:
+
+```bash
+git add docs/SRS.md
+git commit -m "docs: bootstrap the Software Requirements Specification"
+git push origin develop
+```
+
+From your next requirement onward, use the **Requirement** issue template, not SRS Bootstrap again — `requirements-aligner` takes over incremental maintenance automatically (advisory at Stage 1, blocking at Stage 3).
+
+---
+
 ## Step 7: Verify Everything Works
 
 Run through the complete pipeline once with a small test change:
@@ -412,6 +430,7 @@ If any step fails, fix the configuration before starting real work.
 | AI assistant SDLC rules configured (AGENTS.md / CLAUDE.md / GEMINI.md / .windsurfrules / .cursorrules) | [ ] |
 | DevAudit evidence upload configured in CI | [ ] |
 | Project Test Plan created | [ ] |
+| SRS bootstrapped (`docs/SRS.md` exists) | [ ] |
 | End-to-end pipeline verified with test change | [ ] |
 
 ---

--- a/SDLC/SRS_TEMPLATE.md
+++ b/SDLC/SRS_TEMPLATE.md
@@ -1,0 +1,74 @@
+# Software Requirements Specification — [PROJECT NAME]
+
+**Document Type:** Software Requirements Specification (Project-Specific) | **Version:** 1.0 | **Effective Date:** [DATE]
+
+**Project:** [PROJECT NAME] | **Repository:** `[org/repo-name]`
+
+**Parent Documents:** Test Policy, Test Strategy (both Tier 1/2, in `devaudit/sdlc/files/`)
+
+---
+
+## Purpose
+
+This is [PROJECT NAME]'s Software Requirements Specification — the single source of truth for what the system does, phrased as testable, prioritised requirements. It is the document `e2e-test-engineer` derives tests from and `requirements-aligner` checks every new requirement against, once seeded.
+
+This file exists at `docs/SRS.md` in your repository (not under `compliance/` — it's a living engineering document, not a per-release artefact).
+
+**How this file gets created.** Nothing in the framework authors an SRS from scratch on your behalf — `requirements-aligner` explicitly refuses to ("Do NOT use for SRS authoring from scratch"), by design: requirements are a judgement call only a human can make correctly. This template is the starting skeleton. Fill in the sections below (delete the worked examples once you've replaced them with your own), commit the result as `docs/SRS.md`, and from your next requirement onward `requirements-aligner` takes over incremental maintenance — proposing new `REQ-AREA-NNN` stubs and flagging drift automatically at Stage 1 (advisory) and Stage 3 (blocking) of every requirement cycle. See `requirements-aligner/SKILL.md` for the full mechanism.
+
+---
+
+## Conventions
+
+- **Requirement IDs:** `REQ-<AREA>-NNN` (e.g. `REQ-AUTH-001`, `REQ-BILLING-014`). Pick short, stable area codes for this project's main domains up front — IDs are permanent once assigned; never renumber, only append.
+- **Acceptance criteria:** Given / When / Then, phrased against observable behaviour (what a user, an API caller, or a test sees — not internal implementation detail).
+- **Priority — MoSCoW:**
+  - **Must** — the system is broken or unshippable without this. Goes in the smoke/critical test suite.
+  - **Should** — important, expected functionality; not launch-blocking on its own. Goes in the regression suite.
+  - **Could** — nice-to-have, edge-case, or polish. Lowest test priority.
+  - **Won't** (this cycle) — explicitly out of scope for now, recorded so it doesn't get silently re-litigated later. Not the same as "never" — revisit next planning cycle.
+- **Source:** cite the file(s)/function(s) each requirement is implemented by. This is where to look when a test fails — not part of the contract itself, and it's fine for this to say "not yet implemented" for a requirement you're specifying ahead of the code.
+
+---
+
+## Worked examples (delete once you've written your own)
+
+#### REQ-AUTH-001 — A registered user can sign in with email + password
+
+- **Priority:** Must — no other feature is reachable without authentication.
+- **Source:** *(fill in once implemented, e.g. `app/api/auth/login/route.ts`)*
+- **Given** a user with a valid, verified account **When** they submit correct email + password to the sign-in form **Then** they receive a valid session and are redirected to the dashboard.
+- **Error paths:** Wrong password → generic "invalid credentials" (never reveal which field was wrong); unverified account → prompt to re-verify; unknown email → same generic message as wrong password (no user-enumeration).
+- **Fixtures/env:** A verified test user with a known password; an unverified test user.
+
+#### REQ-BILLING-001 — A workspace owner can upgrade from Free to a paid plan
+
+- **Priority:** Should — core to the product's business model but the app functions on the Free tier without it.
+- **Source:** *(fill in once implemented)*
+- **Given** a workspace on the Free plan **When** its owner completes the upgrade checkout flow **Then** the workspace's plan updates and previously-gated features unlock immediately.
+- **Error paths:** Payment declined → workspace stays on Free, user sees the decline reason; upgrade attempted by a non-owner → 403.
+- **Fixtures/env:** A test workspace on Free; a test payment method that reliably declines (per your payment provider's test-mode docs).
+
+---
+
+## Your requirements
+
+Group by area. Add a new `###` heading per area (e.g. `### Authentication`, `### Billing`, `### Core domain — [your main feature]`) and list each `REQ-AREA-NNN` underneath in the same format as the worked examples above. Start small — even 3–5 Must-priority requirements covering your riskiest surfaces is a real starting point; `requirements-aligner` will help it grow from here.
+
+*(start writing here)*
+
+---
+
+## Appendix A — Assumptions & Ambiguities
+
+Record anything you're specifying as intent rather than observed behaviour (this file may be written before the corresponding code exists), and any known-current-but-suspect behaviour you don't want silently smoothed over. Empty is fine for a brand-new project.
+
+---
+
+## Document Control
+
+| Version | Date | Author | Changes |
+| --- | --- | --- | --- |
+| 1.0 | [DATE] | [AUTHOR] | Initial SRS, bootstrapped from SRS_TEMPLATE.md |
+
+**Parent Documents:** Test Policy, Test Strategy (in `devaudit/sdlc/files/`)

--- a/SDLC/blueprints/1-plan-requirement.raw.md
+++ b/SDLC/blueprints/1-plan-requirement.raw.md
@@ -414,7 +414,7 @@ EOF
 
 ### Step 9: Update the Software Requirements Specification (If Applicable)
 
-If the requirement adds, changes, or removes **observable behaviour**, update the project's Software Requirements Specification (`docs/SRS.md`) — or `docs/REQUIREMENTS.md` if the project has not adopted the SRS — to reflect the intended change. The SRS is the MoSCoW-prioritised, Given/When/Then source that developers and the `e2e-test-engineer` skill derive tests from, so keeping it current is what carries the requirement through into test cases.
+If the requirement adds, changes, or removes **observable behaviour**, update the project's Software Requirements Specification (`docs/SRS.md`) — or `docs/REQUIREMENTS.md` if the project has not adopted the SRS — to reflect the intended change. The SRS is the MoSCoW-prioritised, Given/When/Then source that developers and the `e2e-test-engineer` skill derive tests from, so keeping it current is what carries the requirement through into test cases. This isn't a manual-only step: the `requirements-aligner` skill fuzzy-matches this plan's AC table against `docs/SRS.md` and proposes new `REQ-AREA-NNN` stubs or flags drift — the operator edits its proposals into final prose rather than authoring from a blank page.
 
 Only act if the document exists; do not introduce an SRS on a project that has not adopted one.
 

--- a/SDLC/blueprints/3-compile-evidence.raw.md
+++ b/SDLC/blueprints/3-compile-evidence.raw.md
@@ -123,6 +123,8 @@ All must pass. Evidence must reflect a green suite.
 
 After confirming all gates pass, generate the test execution summary. This documents what ran, the results, and maps back to the test plan.
 
+**This file will be authored before the integration PR exists, so it will necessarily say things like `"CI Run: local"` or reference gates as not-yet-run-in-CI at this point — that's expected here.** It is not expected to still say that once the release PR (develop→main) opens. Before that PR merges, come back and replace any `[run ID or "local"]` placeholder with the real CI workflow run link, and update the closing assessment so it reflects what actually happened — not the pre-PR draft state. `validate-test-summary.sh` enforces this at the release-PR gate and will fail the PR on placeholder language like `"not yet a CI run"`, `"CI run: not yet available"`, or `"Production promotion remains blocked"` surviving that far (devaudit-installer#607) — the file that ships as this REQ's ISO 29119-3 §3.5.6 Test Completion Report must reflect the release that actually happened.
+
 ```bash
 cat > compliance/evidence/REQ-XXX/test-execution-summary.md << 'EOF'
 # Test Execution Summary — REQ-XXX

--- a/scripts/generate-bundled-changes.sh
+++ b/scripts/generate-bundled-changes.sh
@@ -250,16 +250,18 @@ for version in "${EXPLICIT_PREDECESSORS[@]}"; do
   PREDECESSOR_LINES+=("- \`${version}\` (${role}/${relationship}) — ${title:-Untitled release ticket}")
 done
 
-# A tracked release only absorbs genuinely REQ-free housekeeping performed
-# during its own implementation window. Do not recast earlier history, or a
-# conventional commit explicitly owned by any REQ, as generic bundle work.
+# devaudit-installer#600 — scan the full SINCE_REF..HEAD window for
+# non-release housekeeping; do not re-narrow it to this REQ's own
+# implementation window. A predecessor housekeeping release (e.g. a
+# `devaudit update` sync) commonly lands on the integration branch shortly
+# *before* this REQ's own first commit — narrowing the scan floor to that
+# first commit's parent excluded exactly that predecessor from ever being
+# detected (confirmed live: a housekeeping commit one commit outside the
+# window was silently missed). The per-commit REQ-tag filter below already
+# excludes any commit explicitly owned by a REQ (this one or another), which
+# is what actually protects against recasting REQ-owned work as generic
+# bundle work — no additional window-narrowing is needed on top of it.
 SCAN_FROM="$SINCE_REF"
-if [[ "$VERSION" =~ ^REQ-[0-9]+$ ]]; then
-  FIRST_REQ_SHA="$(git log --reverse --format='%H' --grep="\\[${VERSION}\\]\\|Ref: ${VERSION}" 2>/dev/null | head -1 || true)"
-  if [ -n "$FIRST_REQ_SHA" ] && git rev-parse --verify "${FIRST_REQ_SHA}^" >/dev/null 2>&1; then
-    SCAN_FROM="${FIRST_REQ_SHA}^"
-  fi
-fi
 COMMITS="$(git log "$SCAN_FROM"..HEAD --format='%h%x09%s' 2>/dev/null || true)"
 BUNDLED=""
 while IFS=$'\t' read -r sha subject; do

--- a/scripts/validate-test-summary.sh
+++ b/scripts/validate-test-summary.sh
@@ -10,6 +10,13 @@
 # or SKIPPED (with operator-approved rationale). "Deferred to CI" is not
 # a valid SDLC state (devaudit-installer#240).
 #
+# Also rejects Stage-3 pre-PR draft placeholder language ("not yet a CI
+# run", "CI run: not yet available", "Production promotion remains
+# blocked") surviving into the release PR — this script only runs on PRs
+# to main, so by definition real CI has already run on develop by the
+# time it executes; that language means the evidence was never refreshed
+# after the fact (devaudit-installer#607).
+#
 # Designed to run as a CI job on PRs to main, alongside
 # validate-compliance-artifacts.sh.
 #
@@ -168,6 +175,37 @@ for REQ in $REQUIREMENTS; do
         fi
       fi
     fi
+  fi
+
+  # Check 8: Reject pre-PR draft placeholder language surviving into the
+  # release PR (devaudit-installer#607). test-execution-summary.md is
+  # authored once, locally, at Stage 3 — before the integration PR even
+  # opens — and this script only ever runs on PRs to main (the final
+  # release gate). By the time a release PR exists, real CI has already
+  # run on develop; any of this language still present means the evidence
+  # was never refreshed and is actively misleading for a release that's
+  # about to (or already did) ship.
+  if grep -qi 'not yet a ci run' "$SUMMARY"; then
+    echo "  ERROR: 'not yet a CI run' found in $SUMMARY — this evidence pack was never refreshed after the integration PR's real CI run completed (devaudit-installer#607)."
+    echo "         Replace with the actual CI workflow run link/ID before this release PR merges."
+    echo "         Offending lines:"
+    grep -in 'not yet a ci run' "$SUMMARY" | sed 's/^/           /'
+    EXIT_CODE=1
+  fi
+
+  if grep -qi 'ci run.*not yet available' "$SUMMARY"; then
+    echo "  ERROR: 'CI run: not yet available' found in $SUMMARY — a release PR to main means real CI already ran on develop; this evidence pack was never refreshed (devaudit-installer#607)."
+    echo "         Offending lines:"
+    grep -in 'ci run.*not yet available' "$SUMMARY" | sed 's/^/           /'
+    EXIT_CODE=1
+  fi
+
+  if grep -qi 'production promotion remains blocked' "$SUMMARY"; then
+    echo "  ERROR: 'Production promotion remains blocked' found in $SUMMARY — this is Stage-3 draft boilerplate; it cannot still be true once a release PR to main exists for this REQ (devaudit-installer#607)."
+    echo "         Update the Final assessment to reflect the actual, current state before this release PR merges."
+    echo "         Offending lines:"
+    grep -in 'production promotion remains blocked' "$SUMMARY" | sed 's/^/           /'
+    EXIT_CODE=1
   fi
 
   echo ""


### PR DESCRIPTION
## Summary
- Syncs the DevAudit SDLC framework (templates, hooks, scripts, CI workflows, `.claude/skills/`) from 0.3.33 → 0.3.35 via `npx @metasession.co/devaudit-cli update`.
- Fixes silent close-out completion reporting on GITHUB_TOKEN-authored PR merges, plus a jq failure that could crash close-out status posting (devaudit-installer#601, #602).
- `validate-test-summary.sh` now rejects stale pre-PR draft placeholder language (e.g. "not yet a CI run") surviving into the release PR (devaudit-installer#607).
- Fixes `generate-bundled-changes.sh` missing a predecessor housekeeping sync that landed just before a REQ's own commit window (devaudit-installer#600).
- Adds the one-time SRS Bootstrap issue template + `SDLC/SRS_TEMPLATE.md` — no-op for this repo since `docs/SRS.md` already exists.

No application code (`app/`, `lib/`, `components/`) touched — framework/tooling only.

Closes #627

## Test plan
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 1340 passed, 4 skipped, 0 failed
- [x] `npm audit --audit-level=high` — 1 pre-existing high (transitive `brace-expansion` in eslint tooling), unrelated to this change; package.json/lock untouched
- [x] Manually reviewed full diff for injected URLs/secrets — none found, all changes match upstream release notes for v0.3.35
- [ ] CI quality gates green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)