### PR TITLE
chore(security): fix stale vulnerableRange in brace-expansion risk acceptance

### DIFF
--- a/compliance/security/accepted-vulnerabilities.json
+++ b/compliance/security/accepted-vulnerabilities.json
@@ -4,7 +4,7 @@
     {
       "advisoryId": "GHSA-mh99-v99m-4gvg",
       "package": "brace-expansion",
-      "vulnerableRange": "<=5.0.7",
+      "vulnerableRange": "<1.1.17",
       "vulnerableVersion": "1.1.16",
       "dependencyPath": "node_modules/@eslint/eslintrc/node_modules/brace-expansion",
       "introducedBy": "@eslint/eslintrc@2.1.4",
@@ -18,7 +18,7 @@
     {
       "advisoryId": "GHSA-mh99-v99m-4gvg",
       "package": "brace-expansion",
-      "vulnerableRange": "<=5.0.7",
+      "vulnerableRange": "<1.1.17",
       "vulnerableVersion": "1.1.16",
       "dependencyPath": "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion",
       "introducedBy": "@humanwhocodes/config-array@0.13.0",
@@ -32,7 +32,7 @@
     {
       "advisoryId": "GHSA-mh99-v99m-4gvg",
       "package": "brace-expansion",
-      "vulnerableRange": "<=5.0.7",
+      "vulnerableRange": "<1.1.17",
       "vulnerableVersion": "1.1.16",
       "dependencyPath": "node_modules/eslint-plugin-import/node_modules/brace-expansion",
       "introducedBy": "eslint-plugin-import@2.32.0",
@@ -46,7 +46,7 @@
     {
       "advisoryId": "GHSA-mh99-v99m-4gvg",
       "package": "brace-expansion",
-      "vulnerableRange": "<=5.0.7",
+      "vulnerableRange": "<1.1.17",
       "vulnerableVersion": "1.1.16",
       "dependencyPath": "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion",
       "introducedBy": "eslint-plugin-jsx-a11y@6.10.2",
@@ -60,7 +60,7 @@
     {
       "advisoryId": "GHSA-mh99-v99m-4gvg",
       "package": "brace-expansion",
-      "vulnerableRange": "<=5.0.7",
+      "vulnerableRange": "<1.1.17",
       "vulnerableVersion": "1.1.16",
       "dependencyPath": "node_modules/eslint-plugin-react/node_modules/brace-expansion",
       "introducedBy": "eslint-plugin-react@7.37.5",
@@ -74,7 +74,7 @@
     {
       "advisoryId": "GHSA-mh99-v99m-4gvg",
       "package": "brace-expansion",
-      "vulnerableRange": "<=5.0.7",
+      "vulnerableRange": "<1.1.17",
       "vulnerableVersion": "1.1.16",
       "dependencyPath": "node_modules/eslint/node_modules/brace-expansion",
       "introducedBy": "eslint@8.57.1",
@@ -88,7 +88,7 @@
     {
       "advisoryId": "GHSA-mh99-v99m-4gvg",
       "package": "brace-expansion",
-      "vulnerableRange": "<=5.0.7",
+      "vulnerableRange": "<1.1.17",
       "vulnerableVersion": "1.1.16",
       "dependencyPath": "node_modules/glob/node_modules/brace-expansion",
       "introducedBy": "glob@7.2.3",
@@ -102,7 +102,7 @@
     {
       "advisoryId": "GHSA-mh99-v99m-4gvg",
       "package": "brace-expansion",
-      "vulnerableRange": "<=5.0.7",
+      "vulnerableRange": "<1.1.17",
       "vulnerableVersion": "2.1.2",
       "dependencyPath": "node_modules/minimatch/node_modules/brace-expansion",
       "introducedBy": "minimatch@9.0.9",


### PR DESCRIPTION
## Summary
- The `GHSA-mh99-v99m-4gvg` exceptions in `compliance/security/accepted-vulnerabilities.json` recorded `vulnerableRange: "<=5.0.7"`, which no longer matches what `npm audit`'s live advisory data reports for the installed nodes (the evaluator resolves `"<1.1.17"` per node, including the `minimatch@9.0.9` one — npm nests the two advisory ranges under one shared `nodes` list, and the evaluator's node→range attribution takes the first match).
- The mismatch means the risk acceptance silently stopped matching, so the **Dependency Audit gate now hard-fails on every PR to `develop`**, independent of what that PR changes — confirmed by diffing this file and `package-lock.json` against `develop` (byte-identical) and reproducing the failure locally with `scripts/evaluate-npm-audit.sh`.
- Fix: correct the 8 `vulnerableRange` values to `"<1.1.17"` (matching what the evaluator actually resolves for every node in this finding). No change to `approvedBy`, `expiresAt`, `reason`, or `remediationIssue` — the underlying accepted risk and its owner are unchanged, only the stale range field.
- The actual remediation (migrate off `eslint@8.x`/`minimatch@3.x` so a patched `brace-expansion` can be adopted) remains tracked in #584 — investigated as part of this fix; not in scope here, since it requires an ESLint 8→9 migration across configs/plugins.

## Test plan
- [x] `bash scripts/evaluate-npm-audit.sh` locally — `8 accepted, 0 unresolved` (was `7 accepted, 1 unresolved` before the fix)
- [x] `npm run lint` — 0 errors
- [x] `npx tsc --noEmit` — clean
- [ ] CI Quality Gates green on this PR (Dependency Audit specifically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)