### PR TITLE
chore: sync DevAudit SDLC templates to 0.3.36

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,16 +438,25 @@ jobs:
             --environment uat --category release_artifact --sdlc-stage 2 \
             --git-sha ${{ github.sha }} --branch ${{ github.ref_name }}
 
-      - name: Generate and upload bundled changes (REQ releases only)
+      - name: Generate and upload bundled changes
         if: env.DEVAUDIT_BASE_URL != '' && steps.version.outputs.version != 'skip'
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          # Only generate bundled changes for REQ-tagged releases —
-          # housekeeping (bare-date) releases don't bundle other housekeeping.
-          if [[ "$VERSION" =~ ^v[0-9]{4}\.[0-9]{2}\.[0-9]{2}(\.[0-9]+)?$ ]]; then
-            echo "Version ${VERSION} is housekeeping — skipping bundled changes."
-            exit 0
-          fi
+          # devaudit-installer#622 — this used to skip every bare-date
+          # (housekeeping) version entirely, on the theory that
+          # "housekeeping releases don't bundle other housekeeping."
+          # That's still true (a bare-date release should not absorb an
+          # unrelated EARLIER release's explicit predecessor ticket), but
+          # it doesn't cover the much more common case: a bare-date
+          # release describing its OWN constituent commits (e.g. three
+          # housekeeping PRs merged the same day into one vYYYY.MM.DD
+          # release row). Skipping unconditionally left every such
+          # release with no description of what it actually shipped.
+          # generate-bundled-changes.sh now handles bare-date versions
+          # itself (skips the release-ticket/explicit-predecessor
+          # machinery, which doesn't apply — a bare-date release has no
+          # ticket — and falls through to the commit-range scan, which
+          # is what actually describes "what's in this release").
           chmod +x scripts/generate-bundled-changes.sh 2>/dev/null || true
           chmod +x scripts/upload-evidence.sh 2>/dev/null || true
           # Find the previous release tag to scan from. Fall back to last 50
@@ -479,7 +488,8 @@ jobs:
             exit 0
           fi
           bash scripts/submit-bundle-manifest.sh wgb "$VERSION" "$BUNDLED_MANIFEST"
-          # Upload as bundled_changes evidence against the REQ release.
+          # Upload as bundled_changes evidence against this release (REQ-tracked
+          # or bare-date housekeeping — devaudit-installer#622).
           bash scripts/upload-evidence.sh \
             wgb _compliance-docs bundled_changes "$BUNDLED_FILE" \
             --release "$VERSION" \
@@ -729,12 +739,25 @@ jobs:
           # The project-level TSR remains useful as Documents-tab baseline
           # describing the project's testing posture but no longer poses
           # as per-release test evidence. See DevAudit-Installer#101.
+          #
+          # devaudit-installer#621 — the comment above was aspirational,
+          # not actual: this call still attached --release/--environment,
+          # so the portal displayed this static, infrequently-updated file
+          # as if it were current per-release evidence on every release —
+          # most visibly on bare-date housekeeping releases, which have no
+          # REQ-scoped test-execution-summary.md to show instead, so this
+          # stale baseline was the only "test evidence" an auditor saw.
+          # Dropping --release/--create-release-if-missing/--environment/
+          # --sdlc-stage (all release-scoping flags — --environment
+          # requires --release server-side, so they come out together)
+          # makes this upload genuinely release-independent, matching the
+          # comment's stated intent: an orphaned Documents-tab artefact,
+          # not evidence attached to whichever release happens to be
+          # current when CI runs.
           if [ -f "compliance/test-summary-report.md" ]; then
             upload test-summary-report.md \
               wgb _compliance-docs compliance_document compliance/test-summary-report.md \
-              --category planning --git-sha ${{ github.sha }} --ci-run-id ${{ github.run_id }} --branch ${{ github.ref_name }} \
-              --release ${{ needs.register-release.outputs.version }} --create-release-if-missing \
-              --environment uat --sdlc-stage 2
+              --category planning --git-sha ${{ github.sha }} --ci-run-id ${{ github.run_id }} --branch ${{ github.ref_name }}
           fi
 
           # Per-REQ E2E JSON attachment only.

--- a/scripts/generate-bundled-changes.sh
+++ b/scripts/generate-bundled-changes.sh
@@ -134,67 +134,80 @@ derive_commit_range() {
   printf '%s\t%s' "$from" "$to"
 }
 
-CURRENT_TICKET="$(find_release_ticket "$VERSION" 2>/dev/null || true)"
-if [ -z "$CURRENT_TICKET" ] && [ -d "compliance/pending-releases" ]; then
-  echo "Error: release ticket for ${VERSION} not found; cannot build explicit bundle manifest." >&2
-  exit 1
-fi
-
-mapfile -t CANDIDATE_RELEASES < <(
-  if [ -d "compliance/pending-releases" ]; then
-    for ticket in compliance/pending-releases/RELEASE-TICKET-*.md; do
-      [ -f "$ticket" ] || continue
-      version="${ticket##*/RELEASE-TICKET-}"
-      version="${version%.md}"
-      [ "$version" = "$VERSION" ] && continue
-      printf '%s\n' "$version"
-    done
-  fi
-)
-
-mapfile -t EXPLICIT_PREDECESSORS < <(
-  if [ -n "$CURRENT_TICKET" ]; then
-    extract_explicit_predecessors "$CURRENT_TICKET"
-  fi
-)
-
-declare -A EXPLICIT_SET=()
-for version in "${EXPLICIT_PREDECESSORS[@]}"; do
-  if [ "$version" = "$VERSION" ]; then
-    echo "Error: bundle manifest cannot self-supersede ${VERSION}." >&2
-    exit 1
-  fi
-  if [ -n "${EXPLICIT_SET[$version]:-}" ]; then
-    echo "Error: duplicate explicit predecessor '${version}'." >&2
-    exit 1
-  fi
-  EXPLICIT_SET["$version"]=1
-  if [ -z "$(find_release_ticket "$version" 2>/dev/null || true)" ]; then
-    echo "Error: explicit predecessor '${version}' has no release ticket on disk." >&2
-    exit 1
-  fi
-done
-
-if [ "${#CANDIDATE_RELEASES[@]}" -gt 0 ] && [ "${#EXPLICIT_PREDECESSORS[@]}" -eq 0 ]; then
-  echo "Error: ambiguous predecessor ownership for ${VERSION}. Pending release tickets exist but the release ticket does not explicitly list absorbed predecessor releases." >&2
-  printf 'Candidates: %s\n' "${CANDIDATE_RELEASES[*]}" >&2
-  exit 1
-fi
-
-UNACCOUNTED=()
-for version in "${CANDIDATE_RELEASES[@]}"; do
-  if [ -z "${EXPLICIT_SET[$version]:-}" ]; then
-    UNACCOUNTED+=("$version")
-  fi
-done
-if [ "${#UNACCOUNTED[@]}" -gt 0 ]; then
-  echo "Error: ambiguous predecessor ownership for ${VERSION}. The following pending releases are not explicitly listed in the release ticket bundle section:" >&2
-  printf '  - %s\n' "${UNACCOUNTED[@]}" >&2
-  exit 1
-fi
-
+CURRENT_TICKET=""
+EXPLICIT_PREDECESSORS=()
 MEMBERS='[]'
 PREDECESSOR_LINES=()
+
+# devaudit-installer#622 — a bare-date housekeeping version has no release
+# ticket by design (SDLC framework only writes RELEASE-TICKET-*.md for
+# REQ-tracked releases), so none of the explicit-predecessor-ownership
+# machinery below applies to it: there is no ticket to declare absorbed
+# predecessors in, and no ambiguity to resolve against other pending
+# tickets. Skip straight to describing the version's own commit range via
+# the non-release work-item scan further down — that part of the script
+# already works for any version string and needs no release ticket.
+if ! [[ "$VERSION" =~ $DATE_VERSION_RE ]]; then
+  CURRENT_TICKET="$(find_release_ticket "$VERSION" 2>/dev/null || true)"
+  if [ -z "$CURRENT_TICKET" ] && [ -d "compliance/pending-releases" ]; then
+    echo "Error: release ticket for ${VERSION} not found; cannot build explicit bundle manifest." >&2
+    exit 1
+  fi
+
+  mapfile -t CANDIDATE_RELEASES < <(
+    if [ -d "compliance/pending-releases" ]; then
+      for ticket in compliance/pending-releases/RELEASE-TICKET-*.md; do
+        [ -f "$ticket" ] || continue
+        version="${ticket##*/RELEASE-TICKET-}"
+        version="${version%.md}"
+        [ "$version" = "$VERSION" ] && continue
+        printf '%s\n' "$version"
+      done
+    fi
+  )
+
+  mapfile -t EXPLICIT_PREDECESSORS < <(
+    if [ -n "$CURRENT_TICKET" ]; then
+      extract_explicit_predecessors "$CURRENT_TICKET"
+    fi
+  )
+
+  declare -A EXPLICIT_SET=()
+  for version in "${EXPLICIT_PREDECESSORS[@]}"; do
+    if [ "$version" = "$VERSION" ]; then
+      echo "Error: bundle manifest cannot self-supersede ${VERSION}." >&2
+      exit 1
+    fi
+    if [ -n "${EXPLICIT_SET[$version]:-}" ]; then
+      echo "Error: duplicate explicit predecessor '${version}'." >&2
+      exit 1
+    fi
+    EXPLICIT_SET["$version"]=1
+    if [ -z "$(find_release_ticket "$version" 2>/dev/null || true)" ]; then
+      echo "Error: explicit predecessor '${version}' has no release ticket on disk." >&2
+      exit 1
+    fi
+  done
+
+  if [ "${#CANDIDATE_RELEASES[@]}" -gt 0 ] && [ "${#EXPLICIT_PREDECESSORS[@]}" -eq 0 ]; then
+    echo "Error: ambiguous predecessor ownership for ${VERSION}. Pending release tickets exist but the release ticket does not explicitly list absorbed predecessor releases." >&2
+    printf 'Candidates: %s\n' "${CANDIDATE_RELEASES[*]}" >&2
+    exit 1
+  fi
+
+  UNACCOUNTED=()
+  for version in "${CANDIDATE_RELEASES[@]}"; do
+    if [ -z "${EXPLICIT_SET[$version]:-}" ]; then
+      UNACCOUNTED+=("$version")
+    fi
+  done
+  if [ "${#UNACCOUNTED[@]}" -gt 0 ]; then
+    echo "Error: ambiguous predecessor ownership for ${VERSION}. The following pending releases are not explicitly listed in the release ticket bundle section:" >&2
+    printf '  - %s\n' "${UNACCOUNTED[@]}" >&2
+    exit 1
+  fi
+fi
+
 for version in "${EXPLICIT_PREDECESSORS[@]}"; do
   ticket="$(find_release_ticket "$version")"
   title="$(extract_ticket_title "$ticket")"

--- a/scripts/submit-bundle-manifest.sh
+++ b/scripts/submit-bundle-manifest.sh
@@ -45,9 +45,18 @@ fi
 
 BASE_URL="${DEVAUDIT_BASE_URL%/}"
 
+# devaudit-installer#622 — generate-bundled-changes.sh has produced
+# schemaVersion 2 manifests (manifestHash + generator metadata) for a
+# while; the portal's contract (devaudit's
+# lib/api/release-lineage-contract.ts) already accepts both 1 and 2.
+# This check was never updated to match, so any manifest with actual
+# content (members or non-release work items — the only case that
+# reaches this script at all, per the empty-manifest skip below) has
+# been hard-failing this step ever since. Accept both versions the
+# portal accepts.
 SCHEMA_VERSION="$(jq -r '.schemaVersion // empty' "$MANIFEST_PATH")"
-if [ "$SCHEMA_VERSION" != "1" ]; then
-  echo "Error: manifest schemaVersion must be 1." >&2
+if [ "$SCHEMA_VERSION" != "1" ] && [ "$SCHEMA_VERSION" != "2" ]; then
+  echo "Error: manifest schemaVersion must be 1 or 2 (got: ${SCHEMA_VERSION:-<empty>})." >&2
   exit 1
 fi
 

--- a/scripts/upload-compliance-documents.sh
+++ b/scripts/upload-compliance-documents.sh
@@ -25,6 +25,14 @@ FLAGS="--git-sha ${DEVAUDIT_GIT_SHA} --ci-run-id ${DEVAUDIT_CI_RUN_ID} --branch 
 FLAGS="${FLAGS} --create-release-if-missing --environment uat --sdlc-stage 3"
 DERIVED_RELEASE="${DEVAUDIT_RELEASE_VERSION}"
 
+# devaudit-installer#621 — flags for documents that are genuinely
+# project-level and must NOT be attached to any one release (see
+# upload_project_level_doc below). --environment/--sdlc-stage require
+# --release server-side (evidence without a release is "orphaned" by
+# design for exactly these documents), so all three release-scoping
+# flags are simply omitted here rather than passed and then overridden.
+PROJECT_LEVEL_FLAGS="--git-sha ${DEVAUDIT_GIT_SHA} --ci-run-id ${DEVAUDIT_CI_RUN_ID} --branch ${DEVAUDIT_BRANCH}"
+
 # Derive change_type for the bare-date (housekeeping) DERIVED_RELEASE:
 # the prefix of the most recent commit's subject. No-op for tracked
 # releases — they get per-REQ derivation in the loop below.
@@ -43,6 +51,10 @@ DERIVED_META=()
 #   - RTM.md        → rtm         (ISO 29119 §3.3 traceability)
 #   - test-plan.md  → test_plan   (ISO 29119 §3.4 test plan)
 #   - test-cases.md → test_cases  (ISO 29119 §3.4 test cases)
+#
+# RTM.md is genuinely per-release evidence — it's kept current per REQ
+# by sdlc-implementer and the portal's release-completeness check reads
+# it per release — so it stays release-scoped via upload_project_doc.
 upload_project_doc() {
   local DOC="$1" EVTYPE="$2"
   if [ ! -f "$DOC" ]; then return 0; fi
@@ -53,9 +65,29 @@ upload_project_doc() {
     "${DERIVED_META[@]}" \
     || echo "Warning: Failed to upload $(basename "$DOC")"
 }
-upload_project_doc compliance/RTM.md         rtm
-upload_project_doc compliance/test-plan.md   test_plan
-upload_project_doc compliance/test-cases.md  test_cases
+upload_project_doc compliance/RTM.md rtm
+
+# devaudit-installer#621 — test-plan.md and test-cases.md, unlike
+# RTM.md above, are project-level test-strategy documents, not
+# per-release evidence: they were previously attached to
+# "${DERIVED_RELEASE}" via upload_project_doc just like RTM.md, so the
+# portal displayed whatever these files happened to say (often stale by
+# months) as if it were current evidence for every release — most
+# visibly on bare-date housekeeping releases, which have no REQ-scoped
+# test-scope.md/test-plan.md to show instead. upload_project_level_doc
+# omits --release (and the flags that require it) so these upload as
+# genuine Documents-tab artefacts, decoupled from any one release.
+upload_project_level_doc() {
+  local DOC="$1" EVTYPE="$2"
+  if [ ! -f "$DOC" ]; then return 0; fi
+  echo "Uploading: $(basename "$DOC") (${EVTYPE} — project-level, no release attachment)"
+  bash scripts/upload-evidence.sh \
+    ${DEVAUDIT_PROJECT_SLUG} _compliance-docs "$EVTYPE" "$DOC" \
+    --category planning ${PROJECT_LEVEL_FLAGS} \
+    || echo "Warning: Failed to upload $(basename "$DOC")"
+}
+upload_project_level_doc compliance/test-plan.md   test_plan
+upload_project_level_doc compliance/test-cases.md  test_cases
 
 # Project-level Test Summary Report — a hand-authored baseline
 # describing the project's testing posture. As of v0.1.32 this is
@@ -66,14 +98,13 @@ upload_project_doc compliance/test-cases.md  test_cases
 # project-level TSR continues to ship as a Documents-tab baseline
 # but no longer poses as per-release test evidence.
 # See DevAudit-Installer#101.
-if [ -f "compliance/test-summary-report.md" ]; then
-  echo "Uploading: test-summary-report.md (compliance_document — baseline)"
-  bash scripts/upload-evidence.sh \
-    ${DEVAUDIT_PROJECT_SLUG} _compliance-docs compliance_document compliance/test-summary-report.md \
-    --category planning ${FLAGS} --release "${DERIVED_RELEASE}" \
-    "${DERIVED_META[@]}" \
-    || echo "Warning: Failed to upload test-summary-report.md"
-fi
+#
+# devaudit-installer#621 — the comment above was aspirational, not
+# actual: this call still attached --release "${DERIVED_RELEASE}", so
+# every release displayed this static file as if it were current
+# per-release test evidence. Uses upload_project_level_doc now, same
+# fix as test-plan.md/test-cases.md above.
+upload_project_level_doc compliance/test-summary-report.md compliance_document
 
 # NOTE: test-summary-report.md stays as compliance_document because
 # it is a project-level evergreen baseline, NOT per-release test


### PR DESCRIPTION
## Summary
- Syncs the DevAudit SDLC framework (CI workflows, scripts) from the registry-published `@metasession.co/devaudit-cli@0.3.36` via `npx @metasession.co/devaudit-cli update`.
- **DevAudit-Installer#621** — `test-plan.md`, `test-cases.md`, and `test-summary-report.md` no longer attach to whatever release happens to be current when CI runs. Previously every release (especially bare-date housekeeping releases with no REQ-scoped test-scope.md/test-plan.md of their own) displayed these often-months-stale project-level documents as if they were current per-release test evidence. Only `RTM.md` remains release-scoped (genuinely per-release, kept current per REQ).
- **DevAudit-Installer#622** — bare-date housekeeping releases that bundle multiple merged PRs now get a bundled-changes manifest describing their own constituent commits, instead of the step being unconditionally skipped for every bare-date version. Also fixes an independent pre-existing bug: the bundle-manifest submission script only accepted `schemaVersion: 1` while the generator has produced `schemaVersion: 2` for a while.
- **DevAudit-Installer#613** — the Hotfix Back-Merge automation's PRs (installer-repo-side, not this repo's own CI) no longer get stuck at `action_required`.

No application code (`app/`, `lib/`, `components/`) touched — framework/tooling only.

Closes #632

## Test plan
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 1340 passed, 4 skipped, 0 failed
- [x] `npm audit` + `scripts/evaluate-npm-audit.sh` — 8 accepted (pre-existing #584 exception, unaffected — package.json/lock untouched), 0 unresolved
- [x] `bash -n` on all three modified scripts — clean
- [x] Manually reviewed full diff against the corresponding DevAudit-Installer fixes (#623) — matches exactly
- [ ] CI quality gates green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)