### PR TITLE
compliance: refresh REQ-097/REQ-098 test-execution-summary for release PR

### DIFF
--- a/compliance/evidence/REQ-097/test-execution-summary.md
+++ b/compliance/evidence/REQ-097/test-execution-summary.md
@@ -29,11 +29,11 @@
 
 ## Test executions
 
-| Source  | SDLC stage       | Execution | Kind                         | Outcome                       | Workflow / run                                                           | Related evidence                                                                               | Date       |
-| ------- | ---------------- | --------- | ---------------------------- | ----------------------------- | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- | ---------- |
-| REQ-097 | 2 implement/test | #1        | unit                         | passed                        | Local Vitest — not yet a CI run                                          | 25 new tests across 3 files, full suite 1,340 passed                                           | 2026-07-30 |
-| REQ-097 | 2 implement/test | #2        | e2e (local)                  | passed                        | Local Playwright, `regression` project — not yet a CI run                | 2/2, `express-order-portion-pricing-req097.spec.ts`, AC1/AC2/AC3                               | 2026-07-30 |
-| REQ-097 | 2 implement/test | #3        | e2e (local, full regression) | passed (with unrelated noise) | Local Playwright, `regression` project, `--workers=1` — not yet a CI run | 519 passed / 13 failed (all pre-existing, verified unrelated via baseline re-run) / 15 skipped | 2026-07-30 |
+| Source  | SDLC stage       | Execution | Kind                         | Outcome                       | Workflow / run                                                    | Related evidence                                                                               | Date       |
+| ------- | ---------------- | --------- | ---------------------------- | ----------------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ---------- |
+| REQ-097 | 2 implement/test | #1        | unit                         | passed                        | Local Vitest, then CI Quality Gates on release PR #623            | 25 new tests across 3 files, full suite 1,340 passed                                           | 2026-07-30 |
+| REQ-097 | 2 implement/test | #2        | e2e (local)                  | passed                        | Local Playwright, `regression` project; CI E2E on release PR #623 | 2/2, `express-order-portion-pricing-req097.spec.ts`, AC1/AC2/AC3                               | 2026-07-30 |
+| REQ-097 | 2 implement/test | #3        | e2e (local, full regression) | passed (with unrelated noise) | Local Playwright, `regression` project, `--workers=1`             | 519 passed / 13 failed (all pre-existing, verified unrelated via baseline re-run) / 15 skipped | 2026-07-30 |
 
 ## Test plan coverage
 
@@ -50,8 +50,8 @@
 
 - Markdown evidence: `compliance/evidence/REQ-097/`
 - Screenshots: `compliance/evidence/REQ-097/screenshots/` (3 PNGs — AC1, AC2, AC3)
-- CI run: not yet available — this evidence pack is being compiled ahead of the integration PR being opened
+- CI run: release PR #623 (`develop` → `main`), production smoke run 30537370010 — see `compliance/approved-releases/RELEASE-TICKET-REQ-097.md`
 
 ## Final assessment
 
-Code and automated verification are complete and locally verified, including a full-regression run cross-checked against the unmodified baseline to positively confirm the 13 observed failures are pre-existing and unrelated to this REQ. Production promotion remains blocked on the same items every tracked REQ needs: CI Quality Gates on the integration PR, and the dual-actor UAT reviewer recording the feature-specific UAT execution.
+Code and automated verification are complete and locally verified, including a full-regression run cross-checked against the unmodified baseline to positively confirm the 13 observed failures are pre-existing and unrelated to this REQ. REQ-097 has since completed CI Quality Gates and UAT review and was released — see the close-out record at `compliance/approved-releases/RELEASE-TICKET-REQ-097.md`.

--- a/compliance/evidence/REQ-098/test-execution-summary.md
+++ b/compliance/evidence/REQ-098/test-execution-summary.md
@@ -31,10 +31,10 @@
 
 ## Test executions
 
-| Source  | SDLC stage       | Execution | Kind        | Outcome | Workflow / run                                            | Related evidence                                                       | Date       |
-| ------- | ---------------- | --------- | ----------- | ------- | --------------------------------------------------------- | ---------------------------------------------------------------------- | ---------- |
-| REQ-098 | 2 implement/test | #1        | unit        | passed  | Local Vitest — not yet a CI run                           | 35 new tests across 6 files, full suite 1,375 passed                   | 2026-08-03 |
-| REQ-098 | 2 implement/test | #2        | e2e (local) | passed  | Local Playwright, `regression` project — not yet a CI run | 2/2, `write-off-tab.spec.ts` AC4, `dormant-tab-visibility.spec.ts` AC5 | 2026-08-03 |
+| Source  | SDLC stage       | Execution | Kind        | Outcome | Workflow / run                                                                                                                                                        | Related evidence                                                       | Date       |
+| ------- | ---------------- | --------- | ----------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ---------- |
+| REQ-098 | 2 implement/test | #1        | unit        | passed  | Local Vitest, then CI Pipeline on `develop` — [run 30853310138](https://github.com/metasession-dev/wawagardenbar-app/actions/runs/30853310138)                        | 35 new tests across 6 files, full suite 1,375 passed                   | 2026-08-03 |
+| REQ-098 | 2 implement/test | #2        | e2e (local) | passed  | Local Playwright, `regression` project; CI in-scope E2E on PR #636 — [run 30852776780](https://github.com/metasession-dev/wawagardenbar-app/actions/runs/30852776780) | 2/2, `write-off-tab.spec.ts` AC4, `dormant-tab-visibility.spec.ts` AC5 | 2026-08-03 |
 
 ## Test plan coverage
 
@@ -60,8 +60,8 @@ No in-scope AC's coverage depends on the skipped sweep — AC1–AC7 each have t
 
 - Markdown evidence: `compliance/evidence/REQ-098/`
 - Screenshots: `compliance/evidence/REQ-098/screenshots/` (2 canonical PNGs — AC4, AC5; feature-tier stage screenshots auto-suppressed on this local run since `E2E_NEW_SPECS` is CI-only)
-- CI run: not yet available — this evidence pack is being compiled ahead of the integration PR being opened
+- CI run: [Register Release + Quality Gates on `develop`, run 30853310138](https://github.com/metasession-dev/wawagardenbar-app/actions/runs/30853310138); [in-scope E2E on integration PR #636, run 30852776780](https://github.com/metasession-dev/wawagardenbar-app/actions/runs/30852776780)
 
 ## Final assessment
 
-Code and automated verification are complete and locally verified for all 7 ACs. The adjacent-area e2e regression sweep did not complete locally due to unrelated environment instability (documented above); CI's release-PR run provides the authoritative full-suite check. Production promotion remains blocked on the same items every tracked REQ needs: CI Quality Gates on the integration PR, and the dual-actor UAT reviewer recording the feature-specific UAT execution. The AC7 remediation script itself has not been run against production — that is a separate, explicit operator action after this release ships.
+Code and automated verification are complete for all 7 ACs, confirmed both locally and by CI Quality Gates + in-scope E2E on the integration PR (#636, merged to `develop`). The adjacent-area e2e regression sweep did not complete locally due to unrelated environment instability (documented above; accepted skip). This release PR (#637, `develop` → `main`) now awaits the dual-actor UAT reviewer's portal review and approval before Production promotion. The AC7 remediation script itself has not been run against production — that is a separate, explicit operator action after this release ships.


### PR DESCRIPTION
## Summary

`validate-test-summary.sh`'s release-PR-stage checks (devaudit-installer#607) correctly flagged Stage-3 draft placeholder language surviving into release PR #637 (`develop` → `main`, bundling REQ-098 and REQ-097):

- REQ-098's own `test-execution-summary.md` had "not yet a CI run" / "CI run: not yet available" placeholders — refreshed with the actual completed CI run links (develop CI Pipeline run 30853310138, PR #636's in-scope E2E run 30852776780) now that they've run, and the Final Assessment updated to reflect the current (not draft) state.
- REQ-097's `test-execution-summary.md` had the same stale placeholders, never refreshed after REQ-097's own actual release (PR #623, already RELEASED) — refreshed to reference that release.

No functional code change — evidence-pack documentation only.

## Test plan

- [x] `bash scripts/validate-test-summary.sh origin/main` — all checks pass
- [x] `bash scripts/validate-compliance-artifacts.sh origin/main` — all checks pass
- [x] `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)