### PR TITLE
ci: anchor bundled-changes scan to last release, not fixed HEAD~50

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,9 +459,21 @@ jobs:
           # is what actually describes "what's in this release").
           chmod +x scripts/generate-bundled-changes.sh 2>/dev/null || true
           chmod +x scripts/upload-evidence.sh 2>/dev/null || true
-          # Find the previous release tag to scan from. Fall back to last 50
-          # commits if no prior tag exists.
+          # Find the previous release tag to scan from. This repo has never
+          # tagged a release, so that lookup always comes back empty — fall
+          # back to the merge-base with main (the last point develop and
+          # main actually shared, i.e. the real "since the last release"
+          # boundary) instead of a fixed commit count, which silently
+          # re-absorbed already-released commits into every release's
+          # bundled-changes list. HEAD~50 remains a last-ditch fallback only
+          # if origin/main truly can't be resolved.
           SINCE_REF=$(git tag --sort=-creatordate | head -1 || true)
+          if [ -z "$SINCE_REF" ]; then
+            git fetch origin main --quiet 2>/dev/null || true
+            if git rev-parse --verify origin/main >/dev/null 2>&1; then
+              SINCE_REF=$(git merge-base origin/main HEAD 2>/dev/null || true)
+            fi
+          fi
           if [ -z "$SINCE_REF" ]; then
             SINCE_REF="HEAD~50"
           fi


### PR DESCRIPTION
## Summary

Found while investigating why REQ-098's release page showed a suspiciously long "bundled release" commit list. This repo has never created a git release tag, so `SINCE_REF=$(git tag --sort=-creatordate | head -1)` in `.github/workflows/ci.yml`'s "Generate and upload bundled changes" step always came back empty and fell back to a **fixed `HEAD~50`** window — regardless of when the last real release to `main` actually happened. Every release's bundled non-release-work list was re-absorbing commits already shipped in prior, already-approved releases.

## Fix

Fall back to `git merge-base origin/main HEAD` (the real last-shared point between `develop` and `main`, i.e. "since the last release") before falling back further to `HEAD~50` as a last resort if `origin/main` can't be resolved.

## Test plan

- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] TypeScript check passed (pre-push hook)
- [ ] After merge, confirm the next `Register Release` run on `develop` regenerates `BUNDLED-CHANGES-*.json` with a correctly-scoped commit count (only commits since the real last release to `main`, not a fixed 50)

Filed as CI-workflow housekeeping (no application code touched, no REQ scope).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>