### PR TITLE
compliance: [REQ-098] regenerate bundled-changes with corrected scan scope

### DIFF
--- a/compliance/evidence/REQ-098/test-execution-summary.md
+++ b/compliance/evidence/REQ-098/test-execution-summary.md
@@ -65,3 +65,7 @@ No in-scope AC's coverage depends on the skipped sweep — AC1–AC7 each have t
 ## Final assessment
 
 Code and automated verification are complete for all 7 ACs, confirmed both locally and by CI Quality Gates + in-scope E2E on the integration PR (#636, merged to `develop`). The adjacent-area e2e regression sweep did not complete locally due to unrelated environment instability (documented above; accepted skip). This release PR (#637, `develop` → `main`) now awaits the dual-actor UAT reviewer's portal review and approval before Production promotion. The AC7 remediation script itself has not been run against production — that is a separate, explicit operator action after this release ships.
+
+## Addendum — bundled-changes scan scope correction
+
+`wawagardenbar-app#639` (merged 2026-08-04) fixed the release CI's bundled-changes scan window, which previously fell back to a fixed `HEAD~50` commit lookback (this repo has never tagged a release) instead of scanning since the actual last release to `main`. That over-scoped window caused this release's "bundled non-release work items" evidence to re-absorb commits already shipped in prior, already-approved releases. This commit is a trivial REQ-098-scoped push whose sole purpose is to re-derive `VERSION=REQ-098` on the next CI run, regenerating the bundled-changes manifest with the corrected `merge-base(main, HEAD)` scan window before UAT submission.


### PR DESCRIPTION
## Summary

Trivial, evidence-only follow-up so the next `Register Release` CI run on `develop` re-derives `VERSION=REQ-098` and regenerates REQ-098's bundled-changes manifest using the corrected `merge-base(main, HEAD)` scan window from #639, rather than the stale over-scoped list generated before that fix landed. The bundled-changes file itself isn't stored in git — it's a CI-run artifact uploaded straight to the portal — so this needs a REQ-098-scoped push to trigger regeneration.

Adds a short addendum note to `compliance/evidence/REQ-098/test-execution-summary.md` explaining why. No application code touched.

## Test plan

- [x] Pre-push compliance artifact validation passed
- [ ] After merge, confirm the triggered `Register Release` run resolves `VERSION=REQ-098` and logs a `SINCE_REF` that's a real commit (not `HEAD~50`)
- [ ] Confirm the portal's REQ-098 release page shows the corrected, smaller bundled-release list

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>