### PR TITLE
test: [REQ-098] comment-only touch to trigger bundled-changes regen

### DIFF
--- a/__tests__/services/tab-service.write-off.test.ts
+++ b/__tests__/services/tab-service.write-off.test.ts
@@ -7,6 +7,11 @@
  * call shape. Mirrors the mocking style of
  * `__tests__/services/tab-service.business-date.test.ts` /
  * `__tests__/services/tab-service.delete-payment-revert.test.ts`.
+ *
+ * (2026-08-04: no behavior change — retriggers a REQ-098-scoped CI push
+ * so the release's bundled-changes evidence regenerates under #639's
+ * corrected scan window; ci.yml's paths-ignore excludes compliance/**
+ * doc-only pushes from firing the job that does that.)
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 


### PR DESCRIPTION
## Summary

Follow-up to #640, which didn't actually work: it only touched `compliance/evidence/`, and `ci.yml`'s `push` trigger has `paths-ignore: ['compliance/**', ...]` specifically to stop doc-only pushes from re-running full CI — so the `register-release` job (which generates the bundled-changes manifest) never fired for that push. Only `compliance-evidence.yml` fired, which re-uploads per-file evidence docs but has nothing to do with bundled-changes.

This instead touches a REQ-098 test file's docstring — no behavior change, 6/6 tests in that file still pass — specifically to land outside every `paths-ignore` entry and actually trigger `ci.yml`'s push pipeline, re-deriving `VERSION=REQ-098` and regenerating the bundled-changes manifest with #639's corrected `merge-base(main, HEAD)` scan window.

## Test plan

- [x] `npx vitest run __tests__/services/tab-service.write-off.test.ts` — 6/6 passed, unchanged
- [x] Pre-push TypeScript + compliance artifact validation passed
- [ ] After merge, confirm `ci.yml`'s `Register Release` job actually runs (not `paths-ignore`'d) and logs `Scanning bundled changes since <real-sha>` for `VERSION=REQ-098`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>