### PR TITLE
ci: dedent broken heredoc terminators in E2E triage step

### DIFF
--- a/.github/workflows/compliance-evidence.yml
+++ b/.github/workflows/compliance-evidence.yml
@@ -852,7 +852,7 @@ jobs:
               - [ ] \`EUAIA.Art-9 / Art-14 / Art-15\` — AI failure: <REPLACE — yes/no, which article(s)>
 
               Once closed, the \`incident-export.yml\` workflow exports this issue's body to \`compliance/governance/incident-report-<N>.md\`.
-              EOF
+          EOF
               )
               # Strip the 14-space heredoc indentation so the issue body is clean.
               ISSUE_BODY=$(echo "$ISSUE_BODY" | sed 's/^              //')
@@ -885,7 +885,7 @@ jobs:
               **Git SHA:** ${GIT_SHA}
 
               This failure appears to be a ${CLASSIFICATION} (not an application defect). A human should confirm and fix the ${CLASSIFICATION}, not the application. Filed with the \`test-bug\` label — this does NOT produce \`incident_report\` evidence.
-              EOF
+          EOF
               )
               ISSUE_BODY=$(echo "$ISSUE_BODY" | sed 's/^              //')
 


### PR DESCRIPTION
## Summary

Found while trying to approve UAT for REQ-098: the portal blocked approval with *"Test execution 7b1fd40c-f441-47e1-b2f5-7dac9a6a04b3 is failed without a documented incident or non-incident triage."* Traced that execution to E2E Regression run `30853905071` (an unrelated pre-existing flake in `daily-report-payments.spec.ts`, already confirmed unrelated to REQ-098). The workflow that's supposed to auto-classify and file an incident/test-bug issue for it — `compliance-evidence.yml`'s "Triage and file incidents on E2E Regression failure" step — actually crashed before it could do that:

```
/home/runner/work/_temp/....sh: line 277: syntax error: unexpected end of file
##[error]Process completed with exit code 2
```

Root cause: two issue-body heredocs use plain `<<EOF`, but their closing `EOF` line is indented 4 spaces deeper than the run block's base (matching the body content's indentation rather than sitting bare). Plain heredocs require an exact, unindented terminator, so bash never recognized it — it silently consumed everything after as heredoc text (including the real `fi`/`done` that should have closed the surrounding control flow) until hitting genuine EOF.

Reproduced locally by extracting the step's shell body and running `bash -n` — same "line 277: unexpected end of file" error. The two-line fix (dedent just the terminator lines, not the body content or its indentation-stripping `sed` logic) resolves it (`bash -n` exits 0).

## Impact

Any release whose E2E Regression run fails never gets its triage/incident issue filed, leaving that execution permanently blocking UAT approval with no way to satisfy the "documented incident or non-incident triage" gate through the normal automated path.

## Test plan

- [x] `bash -n` on the extracted step body: fails before fix (`line 277: unexpected end of file`), passes after
- [x] YAML still valid (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] TypeScript check passed (pre-push hook)
- [ ] After merge, re-run the crashed job (`gh run rerun --job 91822627740`) and confirm it completes and files the `[TEST-BUG]` issue this time

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>