### PR TITLE
ci: set DEVAUDIT_ALLOW_PENDING_TICKET_FALLBACK for release-approval gate

### DIFF
--- a/.github/workflows/check-release-approval.yml
+++ b/.github/workflows/check-release-approval.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           echo "standalone=false" >> "$GITHUB_OUTPUT"
           chmod +x scripts/derive-release-version.sh scripts/standalone-housekeeping-release.sh 2>/dev/null || true
-          VERSION=$(bash scripts/derive-release-version.sh)
+          VERSION=$(DEVAUDIT_ALLOW_PENDING_TICKET_FALLBACK=1 bash scripts/derive-release-version.sh)
           if ! [[ "$VERSION" =~ ^v[0-9]{4}\.[0-9]{2}\.[0-9]{2}([.][0-9]+)?$ ]]; then
             exit 0
           fi
@@ -204,7 +204,7 @@ jobs:
             # here makes the gate and the uploaders agree on release identity
             # (#81). The 8 scenarios are covered by derive-release-version.test.sh.
             chmod +x scripts/derive-release-version.sh 2>/dev/null || true
-            LOOKUP_PREFIX=$(bash scripts/derive-release-version.sh)
+            LOOKUP_PREFIX=$(DEVAUDIT_ALLOW_PENDING_TICKET_FALLBACK=1 bash scripts/derive-release-version.sh)
             echo "Derived release prefix from git history: ${LOOKUP_PREFIX}"
           fi
           echo "Resolving release for prefix: ${LOOKUP_PREFIX}"


### PR DESCRIPTION
## Summary

`check-release-approval.yml` called `scripts/derive-release-version.sh` without ever setting `DEVAUDIT_ALLOW_PENDING_TICKET_FALLBACK=1`, so the "exactly one pending release ticket → attribute this run to it" fallback (`derive-release-version.sh` lines 127-154) was always disabled here — unlike `scripts/check-release-pr-scope.sh`, which already sets it correctly.

This misattributes the gate to an unrelated bare-date release whenever a release PR's own head commit lacks an explicit `[REQ-XXX]` tag — the normal case for a `develop`→`main` release PR whose latest commits are housekeeping/CI fixes layered on top of the feature work.

## How this was found

REQ-098's release PR (#637) was already UAT- and production-approved in the DevAudit portal, but `DevAudit Release Approval` kept failing:

> Release v2026.08.04 is 'draft' — release approval required...

with the accompanying warning:

> Exactly one pending release ticket (REQ-098) exists but DEVAUDIT_ALLOW_PENDING_TICKET_FALLBACK is not set to 1 — falling through to the bare-date fallback instead of attributing this run to it.

`v2026.08.04` is a completely unrelated bare-date housekeeping release. REQ-098 was the correct, unambiguous, already-approved release.

## Fix

Set the flag inline on both `derive-release-version.sh` invocations (lines 74, 207), matching the existing precedent already used in `scripts/check-release-pr-scope.sh`.

Also filed upstream — this workflow is `devaudit install`/`devaudit update`-generated, and the source template has the identical bug: metasession-dev/DevAudit-Installer#637.

## Test plan

- [x] TypeScript check + pre-push hooks passed
- [ ] After merge, confirm PR #637's `DevAudit Release Approval` check resolves to REQ-098 and passes

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>