### PR TITLE
ci: set DEVAUDIT_ALLOW_PENDING_TICKET_FALLBACK at remaining call sites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,7 +394,7 @@ jobs:
           # compliance-evidence.yml call the same helper so a single
           # feature converges on one release record. See DevAudit #310.
           chmod +x scripts/derive-release-version.sh 2>/dev/null || true
-          VERSION=$(./scripts/derive-release-version.sh)
+          VERSION=$(DEVAUDIT_ALLOW_PENDING_TICKET_FALLBACK=1 ./scripts/derive-release-version.sh)
           if [ -z "$VERSION" ]; then
             echo "version=skip" >> "$GITHUB_OUTPUT"
             echo "Release registration skipped: close-out reconciliation detected."

--- a/.github/workflows/compliance-evidence.yml
+++ b/.github/workflows/compliance-evidence.yml
@@ -121,7 +121,7 @@ jobs:
           # one release record regardless of whether the push touched
           # code or docs. See DevAudit #310.
           chmod +x scripts/derive-release-version.sh 2>/dev/null || true
-          VERSION=$(./scripts/derive-release-version.sh)
+          VERSION=$(DEVAUDIT_ALLOW_PENDING_TICKET_FALLBACK=1 ./scripts/derive-release-version.sh)
           if [ -z "$VERSION" ]; then
             echo "version=skip" >> "$GITHUB_OUTPUT"
             echo "Compliance evidence upload skipped: close-out reconciliation detected."
@@ -346,7 +346,7 @@ jobs:
         id: version
         run: |
           chmod +x scripts/derive-release-version.sh 2>/dev/null || true
-          VERSION=$(./scripts/derive-release-version.sh)
+          VERSION=$(DEVAUDIT_ALLOW_PENDING_TICKET_FALLBACK=1 ./scripts/derive-release-version.sh)
           if [ -z "$VERSION" ]; then
             echo "version=skip" >> "$GITHUB_OUTPUT"
             echo "E2E evidence upload skipped: close-out reconciliation detected."

--- a/scripts/prepare-release-pr.sh
+++ b/scripts/prepare-release-pr.sh
@@ -30,7 +30,7 @@ RELEASE_BRANCH=$(jq -r '.release_branch // "main"' sdlc-config.json 2>/dev/null 
 if [ ! -x scripts/derive-release-version.sh ]; then
   chmod +x scripts/derive-release-version.sh 2>/dev/null || true
 fi
-CURRENT_RELEASE=$(./scripts/derive-release-version.sh)
+CURRENT_RELEASE=$(DEVAUDIT_ALLOW_PENDING_TICKET_FALLBACK=1 ./scripts/derive-release-version.sh)
 if [ -z "$CURRENT_RELEASE" ]; then
   echo "No active release version derived; close-out reconciliation appears in progress." >&2
   exit 1


### PR DESCRIPTION
## Summary

Closes #646. Follow-up sweep after #645: found `DEVAUDIT_ALLOW_PENDING_TICKET_FALLBACK` missing at three more `derive-release-version.sh` call sites (`ci.yml:397`, `compliance-evidence.yml:124,349`, `scripts/prepare-release-pr.sh:33`), same root cause as #645. Full details in #646.

Also ported to `DevAudit-Installer`'s source templates so it doesn't regress on the next `devaudit update`.

## Test plan

- [x] `bash scripts/tests/derive-release-version.test.sh` — passes
- [x] TypeScript check + pre-push hooks passed
- [x] `bash -n scripts/prepare-release-pr.sh` — syntax OK

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>