### PR TITLE
ci: detect sdlc-implementer sentinel via git trailer for CI-uploaded evidence

### DIFF
--- a/scripts/upload-evidence.sh
+++ b/scripts/upload-evidence.sh
@@ -235,6 +235,29 @@ is_tracked_change_type() {
   esac
 }
 
+# devaudit#775 — a CI checkout never has the gitignored, local-only
+# `.sdlc-implementer-invoked` file, so evidence uploaded from a CI
+# workflow run could never carry sentinel provenance even when
+# sdlc-implementer genuinely drove the work — it read identically to a
+# real manual bypass. The skill now embeds the same phase-history JSON
+# as a `Sdlc-Implementer-Sentinel:` trailer on every commit it makes
+# during a tracked session. Scan the target commit and its recent
+# ancestors for that trailer when the local file is absent — this also
+# covers squash-merged PRs, since GitHub's default squash message
+# concatenates each original commit's message (trailer included) into
+# the merge commit body.
+detect_sentinel_git_trailer() {
+  local target="$1"
+  # `|| true` — under `set -o pipefail`, `grep -m1` finding no match (the
+  # common case: no trailer, genuinely untracked, or already covered by
+  # the local file) makes the whole pipeline exit non-zero, which would
+  # otherwise abort the entire upload script via `set -e`.
+  git log "$target" -n 50 --format='%B%x00' 2>/dev/null \
+    | tr '\0' '\n' \
+    | grep -m1 '^Sdlc-Implementer-Sentinel:' \
+    | sed -E 's/^Sdlc-Implementer-Sentinel:[[:space:]]*//' || true
+}
+
 resolve_sentinel_context() {
   if ! is_tracked_change_type "$CHANGE_TYPE"; then
     return 0
@@ -245,6 +268,9 @@ resolve_sentinel_context() {
   local git_target="HEAD"
   if [ -n "$GIT_SHA" ]; then
     git_target="$GIT_SHA"
+  fi
+  if [ -z "$SENTINEL_CONTENT" ]; then
+    SENTINEL_CONTENT=$(detect_sentinel_git_trailer "$git_target")
   fi
   COMMIT_TIMESTAMP=$(git show -s --format=%cI "$git_target" 2>/dev/null || true)
 }

--- a/scripts/upload-evidence.test.sh
+++ b/scripts/upload-evidence.test.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# upload-evidence.test.sh — Focused regression tests for sentinel propagation.
+#
+# Verifies tracked uploads automatically forward `.sdlc-implementer-invoked`
+# content and a commit timestamp to the portal-facing upload contract.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HELPER="$SCRIPT_DIR/upload-evidence.sh"
+[ -x "$HELPER" ] || chmod +x "$HELPER"
+
+PASS=0
+FAIL=0
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+assert_contains() {
+  local desc="$1" needle="$2" file="$3"
+  if grep -Fq "$needle" "$file"; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc"
+    echo "    missing: $needle"
+    echo "    file:"
+    sed 's/^/    /' "$file"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local desc="$1" needle="$2" file="$3"
+  if grep -Fq "$needle" "$file"; then
+    echo "  FAIL: $desc"
+    echo "    unexpectedly present: $needle"
+    echo "    file:"
+    sed 's/^/    /' "$file"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  fi
+}
+
+make_fixture() {
+  local dir="$1"
+  rm -rf "$dir"
+  mkdir -p "$dir/bin"
+  cd "$dir"
+  git init -q --initial-branch=main
+  git config user.email "test@example.com"
+  git config user.name "test"
+  echo "evidence" > evidence.txt
+  printf '%s\n' '[{"currentPhase":"3","initializedBy":"skill","status":"active"}]' > .sdlc-implementer-invoked
+  git add evidence.txt .sdlc-implementer-invoked
+  git commit -q -m "feat: tracked upload fixture"
+
+  cat > bin/curl <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+LOG_FILE="${UPLOAD_TEST_LOG:?}"
+URL=""
+OUT_FILE=""
+HDR_FILE=""
+WRITE_OUT=""
+ARGS=("$@")
+for ((i=0; i<${#ARGS[@]}; i++)); do
+  arg="${ARGS[$i]}"
+  case "$arg" in
+    -o) OUT_FILE="${ARGS[$((i+1))]}" ;;
+    -D) HDR_FILE="${ARGS[$((i+1))]}" ;;
+    -w) WRITE_OUT="${ARGS[$((i+1))]}" ;;
+    http://*|https://*) URL="$arg" ;;
+    -F)
+      echo "FORM:${ARGS[$((i+1))]}" >> "$LOG_FILE"
+      ;;
+  esac
+done
+echo "URL:${URL}" >> "$LOG_FILE"
+if [[ "$URL" == *"/api/health" ]]; then
+  printf '200 '
+  exit 0
+fi
+if [ -n "$OUT_FILE" ]; then
+  printf '{"ok":true}' > "$OUT_FILE"
+fi
+if [ -n "$HDR_FILE" ]; then
+  : > "$HDR_FILE"
+fi
+if [ -n "$WRITE_OUT" ]; then
+  printf '201'
+fi
+EOF
+  chmod +x bin/curl
+}
+
+echo "=== upload-evidence.sh tests ==="
+
+D1="$WORK/case1"
+make_fixture "$D1"
+LOG_FILE="$D1/upload.log"
+touch "$LOG_FILE"
+export PATH="$D1/bin:$PATH"
+export UPLOAD_TEST_LOG="$LOG_FILE"
+export DEVAUDIT_BASE_URL="https://devaudit.example.test"
+export DEVAUDIT_API_KEY="mc_test_dummy"
+
+bash "$HELPER" fixture-project REQ-091 test_report evidence.txt \
+  --release v2026.07.13 \
+  --environment uat \
+  --category test_report \
+  --change-type feat > "$D1/stdout.log" 2>&1
+
+assert_contains "tracked upload forwards sentinelContent" \
+  'FORM:sentinelContent=[{"currentPhase":"3","initializedBy":"skill","status":"active"}]' \
+  "$LOG_FILE"
+assert_contains "tracked upload forwards commitTimestamp field" \
+  'FORM:commitTimestamp=' \
+  "$LOG_FILE"
+assert_contains "tracked upload forwards changeType" \
+  'FORM:changeType=feat' \
+  "$LOG_FILE"
+assert_contains "tracked upload stamps commitTimestamp into metadata" \
+  'FORM:metadata={"commitTimestamp":"' \
+  "$LOG_FILE"
+
+# devaudit#775 — CI checkouts never have the gitignored local sentinel
+# file. Verify the git-trailer fallback picks up sdlc-implementer
+# provenance from the commit message instead, and that it stays silent
+# (no false sentinelContent) when neither the file nor the trailer exists.
+
+make_fixture_trailer_only() {
+  local dir="$1"
+  rm -rf "$dir"
+  mkdir -p "$dir/bin"
+  cd "$dir"
+  git init -q --initial-branch=main
+  git config user.email "test@example.com"
+  git config user.name "test"
+  echo "evidence" > evidence.txt
+  git add evidence.txt
+  git commit -q -F - <<'EOF'
+fix: ci-uploaded evidence fixture
+
+Ref: REQ-091
+Sdlc-Implementer-Sentinel: [{"currentPhase":"2","initializedBy":"skill","status":"active"}]
+EOF
+
+  cat > bin/curl <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+LOG_FILE="${UPLOAD_TEST_LOG:?}"
+URL=""
+OUT_FILE=""
+HDR_FILE=""
+WRITE_OUT=""
+ARGS=("$@")
+for ((i=0; i<${#ARGS[@]}; i++)); do
+  arg="${ARGS[$i]}"
+  case "$arg" in
+    -o) OUT_FILE="${ARGS[$((i+1))]}" ;;
+    -D) HDR_FILE="${ARGS[$((i+1))]}" ;;
+    -w) WRITE_OUT="${ARGS[$((i+1))]}" ;;
+    http://*|https://*) URL="$arg" ;;
+    -F)
+      echo "FORM:${ARGS[$((i+1))]}" >> "$LOG_FILE"
+      ;;
+  esac
+done
+echo "URL:${URL}" >> "$LOG_FILE"
+if [[ "$URL" == *"/api/health" ]]; then
+  printf '200 '
+  exit 0
+fi
+if [ -n "$OUT_FILE" ]; then
+  printf '{"ok":true}' > "$OUT_FILE"
+fi
+if [ -n "$HDR_FILE" ]; then
+  : > "$HDR_FILE"
+fi
+if [ -n "$WRITE_OUT" ]; then
+  printf '201'
+fi
+EOF
+  chmod +x bin/curl
+}
+
+D2="$WORK/case2-trailer-only"
+make_fixture_trailer_only "$D2"
+LOG_FILE="$D2/upload.log"
+touch "$LOG_FILE"
+export PATH="$D2/bin:$PATH"
+export UPLOAD_TEST_LOG="$LOG_FILE"
+
+bash "$HELPER" fixture-project REQ-091 test_report evidence.txt \
+  --release v2026.07.13 \
+  --environment uat \
+  --category test_report \
+  --change-type fix > "$D2/stdout.log" 2>&1
+
+assert_contains "CI checkout (no local sentinel file) forwards sentinelContent from the git trailer" \
+  'FORM:sentinelContent=[{"currentPhase":"2","initializedBy":"skill","status":"active"}]' \
+  "$LOG_FILE"
+
+D3="$WORK/case3-no-sentinel"
+rm -rf "$D3"
+mkdir -p "$D3/bin"
+cd "$D3"
+git init -q --initial-branch=main
+git config user.email "test@example.com"
+git config user.name "test"
+echo "evidence" > evidence.txt
+git add evidence.txt
+git commit -q -m "fix: genuinely untracked evidence fixture"
+cp "$D2/bin/curl" "$D3/bin/curl"
+LOG_FILE="$D3/upload.log"
+touch "$LOG_FILE"
+export PATH="$D3/bin:$PATH"
+export UPLOAD_TEST_LOG="$LOG_FILE"
+
+bash "$HELPER" fixture-project REQ-091 test_report evidence.txt \
+  --release v2026.07.13 \
+  --environment uat \
+  --category test_report \
+  --change-type fix > "$D3/stdout.log" 2>&1
+
+assert_not_contains "no local file and no trailer: sentinelContent stays unset (genuine bypass)" \
+  'FORM:sentinelContent=' \
+  "$LOG_FILE"
+
+echo ""
+echo "=== upload-evidence.test.sh: $PASS passed, $FAIL failed ==="
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Fixes the `wawagardenbar-app` side of `devaudit#775`.

Auditing REQ-098's production approval on the portal surfaced "Sentinel verification: UNVERIFIED / MANUAL BYPASS ATTEMPT — 10 with sentinel · 19 without." Traced the mechanism: `.sdlc-implementer-invoked` is gitignored and local-only, written by the sdlc-implementer skill in the developer's working directory. `resolve_sentinel_context()` in `upload-evidence.sh` only forwards `sentinelContent` if that file exists in the *current working tree* — which a fresh CI checkout never has. Every one of the ~19 "without sentinel" items was legitimately produced by CI (E2E results, gate outcomes, screenshots, compliance docs) during the same sdlc-implementer-driven work — just one step removed from the developer's shell.

## Fix

Companion fix in `DevAudit-Installer` (source of this template): the sdlc-implementer skill now embeds its sentinel's phase-history JSON as a `Sdlc-Implementer-Sentinel:` git trailer on every commit it makes during a tracked session. `resolve_sentinel_context()` here now falls back to scanning the target commit and its recent ancestors for that trailer when the local file is absent, forwarding it as `sentinelContent` exactly like the local-file path — so CI-uploaded evidence gets the same verification a local upload already gets. Also covers squash-merged PRs, since GitHub's default squash message concatenates each original commit's message (trailer included) into the merge commit body.

Ported directly from the `DevAudit-Installer` template fix, matching this session's established pattern for cross-repo CI-script bugs.

## Test plan

- [x] Added `scripts/upload-evidence.test.sh` (ported from the `DevAudit-Installer` template's regression suite) — 6/6 passed, including new cases for the git-trailer fallback and confirming a genuine bypass (no local file, no trailer) still forwards nothing.
- [x] `bash -n scripts/upload-evidence.sh` — syntax clean.
- [x] `npx tsc --noEmit` — clean (pre-push hook).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>