### PR TITLE
fix(reports): surface written-off orders' cost of goods sold

### DIFF
--- a/__tests__/services/financial-report-service.write-off-section.test.ts
+++ b/__tests__/services/financial-report-service.write-off-section.test.ts
@@ -78,8 +78,8 @@ describe('REQ-098 AC6: financial-report-service writtenOff section', () => {
       (query: { paymentStatus?: string }) => {
         if (query.paymentStatus === 'written-off') {
           return Promise.resolve([
-            { _id: 'wo1', total: 4000 },
-            { _id: 'wo2', total: 8000 },
+            { _id: 'wo1', total: 4000, items: [] },
+            { _id: 'wo2', total: 8000, items: [] },
           ]);
         }
         return Promise.resolve([
@@ -98,7 +98,11 @@ describe('REQ-098 AC6: financial-report-service writtenOff section', () => {
       new Date('2026-07-31T12:00:00Z')
     );
 
-    expect(report.writtenOff).toEqual({ count: 2, totalAmount: 12000 });
+    expect(report.writtenOff).toEqual({
+      count: 2,
+      totalAmount: 12000,
+      totalCost: 0,
+    });
     // Revenue is unaffected — driven entirely by the 'paid' query, which
     // never includes the written-off rows.
     expect(report.revenue.totalRevenue).toBe(5000);
@@ -117,14 +121,18 @@ describe('REQ-098 AC6: financial-report-service writtenOff section', () => {
       new Date('2026-07-31T12:00:00Z')
     );
 
-    expect(report.writtenOff).toEqual({ count: 0, totalAmount: 0 });
+    expect(report.writtenOff).toEqual({
+      count: 0,
+      totalAmount: 0,
+      totalCost: 0,
+    });
   });
 
   it('generateDateRangeReport — sums written-off orders across the range', async () => {
     mockOrderFindByStatus.mockImplementation(
       (query: { paymentStatus?: string }) => {
         if (query.paymentStatus === 'written-off') {
-          return Promise.resolve([{ _id: 'wo1', total: 12000 }]);
+          return Promise.resolve([{ _id: 'wo1', total: 12000, items: [] }]);
         }
         return Promise.resolve([]);
       }
@@ -135,6 +143,92 @@ describe('REQ-098 AC6: financial-report-service writtenOff section', () => {
       new Date('2026-07-31T23:59:59Z')
     );
 
-    expect(report.writtenOff).toEqual({ count: 1, totalAmount: 12000 });
+    expect(report.writtenOff).toEqual({
+      count: 1,
+      totalAmount: 12000,
+      totalCost: 0,
+    });
+  });
+
+  // wgb#644 — written-off orders' ingredient cost was already deducted from
+  // inventory at kitchen fulfillment; it must be summed and surfaced, using
+  // the same costPerUnit-snapshot-or-menuItem-fallback basis paid orders use.
+  it('generateDailySummary — sums written-off order items using their own costPerUnit snapshot', async () => {
+    mockOrderFindByStatus.mockImplementation(
+      (query: { paymentStatus?: string }) => {
+        if (query.paymentStatus === 'written-off') {
+          return Promise.resolve([
+            {
+              _id: 'wo1',
+              total: 4000,
+              items: [
+                { menuItemId: 'item-1', quantity: 2, costPerUnit: 300 },
+                { menuItemId: 'item-2', quantity: 1, costPerUnit: 150 },
+              ],
+            },
+          ]);
+        }
+        return Promise.resolve([]);
+      }
+    );
+
+    const report = await FinancialReportService.generateDailySummary(
+      new Date('2026-07-31T12:00:00Z')
+    );
+
+    // (2 * 300) + (1 * 150) = 750
+    expect(report.writtenOff.totalCost).toBe(750);
+    expect(menuItemFindByIdMock).not.toHaveBeenCalled();
+  });
+
+  it('generateDailySummary — falls back to the current menu item cost when an order item has no costPerUnit snapshot', async () => {
+    mockOrderFindByStatus.mockImplementation(
+      (query: { paymentStatus?: string }) => {
+        if (query.paymentStatus === 'written-off') {
+          return Promise.resolve([
+            {
+              _id: 'wo1',
+              total: 4000,
+              items: [{ menuItemId: 'item-legacy', quantity: 3 }],
+            },
+          ]);
+        }
+        return Promise.resolve([]);
+      }
+    );
+    menuItemFindByIdMock.mockResolvedValue({ costPerUnit: 200 });
+
+    const report = await FinancialReportService.generateDailySummary(
+      new Date('2026-07-31T12:00:00Z')
+    );
+
+    expect(report.writtenOff.totalCost).toBe(600); // 3 * 200
+    expect(menuItemFindByIdMock).toHaveBeenCalledWith('item-legacy');
+  });
+
+  it('generateDailySummary — nets written-off COGS against netProfit', async () => {
+    mockOrderFindByStatus.mockImplementation(
+      (query: { paymentStatus?: string }) => {
+        if (query.paymentStatus === 'written-off') {
+          return Promise.resolve([
+            {
+              _id: 'wo1',
+              total: 4000,
+              items: [{ menuItemId: 'item-1', quantity: 1, costPerUnit: 500 }],
+            },
+          ]);
+        }
+        return Promise.resolve([]);
+      }
+    );
+
+    const report = await FinancialReportService.generateDailySummary(
+      new Date('2026-07-31T12:00:00Z')
+    );
+
+    expect(report.writtenOff.totalCost).toBe(500);
+    // grossProfit.total is 0 (no paid orders) and operatingExpenses are 0,
+    // so netProfit should be entirely the written-off cost, negated.
+    expect(report.netProfit).toBe(-500);
   });
 });

--- a/components/features/reports/written-off-section.tsx
+++ b/components/features/reports/written-off-section.tsx
@@ -14,6 +14,15 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 export type WrittenOffSummary = {
   count: number;
   totalAmount: number;
+  /**
+   * @requirement wgb#644 — ingredient/COGS cost of these orders' line
+   * items. The kitchen already fulfilled them (inventory deducted in
+   * full) before the tab was written off, so this cost was genuinely
+   * incurred — it's netted against Net Profit as a real expense, distinct
+   * from both `totalAmount` (bad-debt revenue, already excluded above)
+   * and regular Direct Costs/Purchases (paid-order COGS).
+   */
+  totalCost: number;
 };
 
 type Props = {
@@ -24,6 +33,7 @@ type Props = {
 export function WrittenOffSection({ writtenOff, formatCurrency }: Props) {
   const count = writtenOff?.count ?? 0;
   const totalAmount = writtenOff?.totalAmount ?? 0;
+  const totalCost = writtenOff?.totalCost ?? 0;
 
   return (
     <div className="space-y-3" data-testid="written-off-section">
@@ -51,6 +61,19 @@ export function WrittenOffSection({ writtenOff, formatCurrency }: Props) {
             {count} order{count === 1 ? '' : 's'} reclassified as uncollectible
             bad debt — already excluded from revenue above.
           </p>
+          <div className="mt-3 border-t pt-3">
+            <div
+              className="text-lg font-semibold text-destructive"
+              data-testid="written-off-total-cost"
+            >
+              {formatCurrency(totalCost)}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Written-off cost of goods — ingredient cost already consumed by
+              the kitchen on these orders, netted against Net Profit below as a
+              controllable loss (not double-counted in Direct Costs).
+            </p>
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/lib/report-export.ts
+++ b/lib/report-export.ts
@@ -267,10 +267,19 @@ export function exportReportAsPDF(
 
   const writtenOffCount = report.writtenOff?.count ?? 0;
   const writtenOffTotal = report.writtenOff?.totalAmount ?? 0;
+  // wgb#644 — ingredient/COGS cost of written-off orders' line items,
+  // netted against Net Profit; distinct from the bad-debt amount above.
+  const writtenOffCost = report.writtenOff?.totalCost ?? 0;
   autoTable(doc, {
     startY: yPos,
-    head: [['Orders written off', 'Total amount']],
-    body: [[String(writtenOffCount), formatCurrency(writtenOffTotal)]],
+    head: [['Orders written off', 'Total amount', 'Cost of goods']],
+    body: [
+      [
+        String(writtenOffCount),
+        formatCurrency(writtenOffTotal),
+        formatCurrency(writtenOffCost),
+      ],
+    ],
     theme: 'grid',
     headStyles: { fillColor: [107, 114, 128] },
     styles: { fontSize: 9 },
@@ -438,8 +447,12 @@ export function exportReportAsExcel(
   // never silently missing from the exported report.
   const writtenOffData: Array<Array<string | number>> = [
     ['Written Off (Bad Debt)'],
-    ['Orders written off', 'Total amount'],
-    [report.writtenOff?.count ?? 0, report.writtenOff?.totalAmount ?? 0],
+    ['Orders written off', 'Total amount', 'Cost of goods'],
+    [
+      report.writtenOff?.count ?? 0,
+      report.writtenOff?.totalAmount ?? 0,
+      report.writtenOff?.totalCost ?? 0,
+    ],
   ];
   const writtenOffSheet = XLSX.utils.aoa_to_sheet(writtenOffData);
   XLSX.utils.book_append_sheet(workbook, writtenOffSheet, 'Written Off');
@@ -552,9 +565,9 @@ export function exportReportAsCSV(
   // silently missing from the exported report.
   csvRows.push('');
   csvRows.push('Written Off (Bad Debt)');
-  csvRows.push('Orders written off,Total amount');
+  csvRows.push('Orders written off,Total amount,Cost of goods');
   csvRows.push(
-    `${report.writtenOff?.count ?? 0},${report.writtenOff?.totalAmount ?? 0}`
+    `${report.writtenOff?.count ?? 0},${report.writtenOff?.totalAmount ?? 0},${report.writtenOff?.totalCost ?? 0}`
   );
 
   // Create and download CSV

--- a/services/financial-report-service.ts
+++ b/services/financial-report-service.ts
@@ -154,10 +154,21 @@ export interface DailySummaryReport {
    * `revenue.totalRevenue`/`metrics.orderCount` (both queries above filter
    * strictly on `paymentStatus: 'paid'`) — this section exists so that
    * exclusion is visible and explained on the report, not a silent drop.
+   *
+   * @requirement wgb#644 — `totalCost` is the ingredient/COGS cost of
+   * these same orders' line items, computed with the same per-line-item
+   * cost basis paid orders use for `grossProfit` (`OrderService.completeOrder`
+   * deducts inventory at kitchen fulfillment regardless of payment
+   * outcome, so a written-off order's cost was already incurred — it
+   * just never appears in `grossProfit` because that's driven entirely
+   * by paid orders). Netted against `netProfit` as a real expense, since
+   * industry practice (comps/walkouts/bad debt) treats this as a
+   * controllable-loss cost, not an untracked one.
    */
   writtenOff: {
     count: number;
     totalAmount: number;
+    totalCost: number;
   };
 }
 
@@ -208,13 +219,21 @@ export class FinancialReportService {
    * that field mirrors the tab-level aggregate write-off amount onto
    * every linked order for per-order audit display, so summing it across
    * sibling orders on the same tab would double-count).
+   *
+   * @requirement wgb#644 — also sums `totalCost`, the ingredient cost of
+   * these orders' line items, using the same `costPerUnit || menuItem
+   * fallback || 0` basis the paid-order item loop uses for `grossProfit`
+   * (below). A written-off order's inventory was deducted in full at
+   * kitchen fulfillment regardless of payment outcome, so this cost was
+   * genuinely incurred — it just never appears in `grossProfit`, which is
+   * computed only from paid orders' items.
    */
   private static async computeWrittenOffSummary(
     startDate: Date,
     endDate: Date,
     legacyStart: Date,
     legacyEnd: Date
-  ): Promise<{ count: number; totalAmount: number }> {
+  ): Promise<{ count: number; totalAmount: number; totalCost: number }> {
     const writtenOffOrders = await OrderModel.find({
       paymentStatus: 'written-off',
       $or: [
@@ -225,14 +244,42 @@ export class FinancialReportService {
         },
         { businessDate: null, paidAt: { $gte: legacyStart, $lte: legacyEnd } },
       ],
-    }).lean<Array<{ total: number }>>();
+    }).lean<
+      Array<{
+        total: number;
+        items?: Array<{
+          menuItemId?: { toString(): string } | string;
+          quantity: number;
+          costPerUnit?: number;
+        }>;
+      }>
+    >();
 
     const totalAmount = writtenOffOrders.reduce(
       (sum, order) => sum + (order.total ?? 0),
       0
     );
 
-    return { count: writtenOffOrders.length, totalAmount };
+    const costPerUnitCache = new Map<string, number>();
+    let totalCost = 0;
+    for (const order of writtenOffOrders) {
+      for (const item of order.items ?? []) {
+        let costPerUnit = item.costPerUnit || 0;
+        if (!costPerUnit && item.menuItemId) {
+          const itemId = item.menuItemId.toString();
+          if (!costPerUnitCache.has(itemId)) {
+            const menuItem = await MenuItemModel.findById(itemId).lean<{
+              costPerUnit?: number;
+            } | null>();
+            costPerUnitCache.set(itemId, menuItem?.costPerUnit ?? 0);
+          }
+          costPerUnit = costPerUnitCache.get(itemId) ?? 0;
+        }
+        totalCost += costPerUnit * (item.quantity ?? 0);
+      }
+    }
+
+    return { count: writtenOffOrders.length, totalAmount, totalCost };
   }
 
   private static async createCategoryBreakdowns(): Promise<
@@ -704,11 +751,15 @@ export class FinancialReportService {
       report.operatingExpenses.totalOperatingExpenses;
 
     // Calculate net profit
-    // Net Profit = Gross Profit - Operating Expenses (Overhead)
-    // We exclude Direct Costs (Purchases) because COGS is already subtracted from Revenue to get Gross Profit
+    // Net Profit = Gross Profit - Operating Expenses (Overhead) - Written-off COGS
+    // We exclude Direct Costs (Purchases) because COGS is already subtracted from Revenue to get Gross Profit.
+    // Written-off COGS (wgb#644) is netted separately: it's inventory genuinely
+    // consumed with no offsetting revenue, so unlike Direct Costs it isn't already
+    // reflected anywhere in Gross Profit.
     report.netProfit =
       report.grossProfit.total -
-      report.operatingExpenses.totalOperatingExpenses;
+      report.operatingExpenses.totalOperatingExpenses -
+      report.writtenOff.totalCost;
 
     // Calculate metrics (margins based on item revenue, not payment total)
     const itemRevenue = report.categories.reduce(
@@ -1006,9 +1057,11 @@ export class FinancialReportService {
       report.operatingExpenses.totalDirectCosts +
       report.operatingExpenses.totalOperatingExpenses;
 
+    // Written-off COGS (wgb#644) netted the same way as generateDailySummary above.
     report.netProfit =
       report.grossProfit.total -
-      report.operatingExpenses.totalOperatingExpenses;
+      report.operatingExpenses.totalOperatingExpenses -
+      report.writtenOff.totalCost;
 
     const rangeItemRevenue = report.categories.reduce(
       (total, category) => total + category.revenue.totalRevenue,


### PR DESCRIPTION
## Summary

Closes #644.

Written-off tabs correctly exclude revenue (`paymentStatus` queries only match `'paid'`), but the ingredient cost of those same orders never appeared anywhere in the financial reports. `OrderService.completeOrder` deducts inventory at kitchen fulfillment independent of payment outcome, so a written-off order's COGS was a real, physical inventory loss — Gross Profit and Prime Cost both looked artificially better than reality for any period containing write-offs, with no figure anywhere saying "this is what dormant-tab write-offs actually cost us in ingredients."

## Fix

Per the issue's own proposed fix, using the industry-standard treatment it documents (comps/walkouts/bad debt as a visible controllable-loss cost, not folded into COGS or left untracked):

1. `computeWrittenOffSummary` now also sums each written-off order's line-item cost, using the exact same `costPerUnit` snapshot (falling back to the current menu item's cost) that paid orders use for `grossProfit`.
2. Surfaced as a new `writtenOff.totalCost` field, shown as a distinct "Written-off cost of goods" line in `WrittenOffSection` and added to all three report exports (PDF/Excel/CSV) alongside the existing "Written Off (Bad Debt)" amount — clearly labeled so it isn't conflated with either bad-debt revenue or regular Direct Costs.
3. Netted against `netProfit` as a real expense (the issue's recommended default, given the Prime Cost / theft-detection visibility argument it makes).

## Test plan

- [x] Extended `__tests__/services/financial-report-service.write-off-section.test.ts` — existing fixtures updated for the new `totalCost` field; added 3 new cases: cost computed from an order's own `costPerUnit` snapshot, fallback to the current menu item's cost when the snapshot is missing (legacy orders), and confirming `netProfit` is netted correctly.
- [x] `npx vitest run` — 1378/1382 passed (4 pre-existing skips, unrelated)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors in touched files (982 pre-existing unrelated `no-console` warnings elsewhere in the repo)

**Not verified**: this repo's `vitest.config.ts` only runs `*.test.ts` (no `.tsx`, no `@testing-library`) — UI-facing coverage here goes through Playwright E2E, not vitest component tests, so I did not add a component-level test and did not verify the new report-card line by running the app in a browser. The underlying money computation (the part with real correctness risk) is covered by the service-level unit tests above; the UI change itself is a straightforward additive stat line using the same `Card`/`formatCurrency` patterns already in the component.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>