### PR TITLE
ci: authenticate close-out-release.yml as INSTALLER_DISPATCH_TOKEN when configured

### DIFF
--- a/.github/workflows/close-out-release.yml
+++ b/.github/workflows/close-out-release.yml
@@ -43,13 +43,24 @@ jobs:
     name: Close out release
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ github.token }}
+      # devaudit-installer#613 — PRs opened with the default GITHUB_TOKEN
+      # (actor github-actions[bot]) get their own pull_request-triggered
+      # required checks (including Quality Gates) stuck at `action_required`
+      # instead of running, blocking auto-merge until a maintainer manually
+      # approves each pending workflow run — this is what stalled REQ-098's
+      # close-out PR (wgb#650, devaudit#795). INSTALLER_DISPATCH_TOKEN, if
+      # set, authenticates the checkout/push/PR-create as a real,
+      # already-trusted account instead — PRs opened that way aren't
+      # subject to this gate. Falls back to the default GITHUB_TOKEN
+      # (today's unchanged, still-gated behavior) when unset.
+      GH_TOKEN: ${{ secrets.INSTALLER_DISPATCH_TOKEN || github.token }}
       DEVAUDIT_API_KEY: ${{ secrets.DEVAUDIT_API_KEY }}
     steps:
       - uses: actions/checkout@v6
         with:
           ref: develop
           fetch-depth: 0
+          token: ${{ secrets.INSTALLER_DISPATCH_TOKEN || github.token }}
 
       - name: Resolve inputs
         id: in


### PR DESCRIPTION
## Summary

Ports `DevAudit-Installer#644` to this repo's own copy — same fix applied to the template source.

A close-out PR authored by the default `GITHUB_TOKEN` (actor `github-actions[bot]`) has its own `pull_request`-triggered required checks stuck at GitHub's `action_required` state until a maintainer manually approves the pending run. This is exactly what stalled REQ-098's close-out PR (#650) — it sat `mergeStateStatus: BLOCKED` until manually approved via the API.

## Fix

`close-out-release.yml`'s checkout and every `gh` call now authenticate as `${{ secrets.INSTALLER_DISPATCH_TOKEN || github.token }}` — falls back to the unchanged default when the secret isn't configured, so this ships safely regardless of whether the secret exists yet.

**Follow-up needed**: add an `INSTALLER_DISPATCH_TOKEN` repo secret (PAT with contents+pull-requests write) to actually activate the bypass. Until then, behavior is unchanged — one manual "Approve and run" click per close-out PR, same as before this fix.

## Test plan

- [x] `npx tsc --noEmit` — clean (pre-push hook)
- Behavioral verification: same pattern already confirmed working in `DevAudit-Installer`'s own `hotfix-backmerge.yml`, and the template source's new unit test (`DevAudit-Installer` PR #644).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>