### PR TITLE
chore: patch js-yaml + nanoid to resolve high-severity advisories

### DIFF
--- a/compliance/security/accepted-vulnerabilities.json
+++ b/compliance/security/accepted-vulnerabilities.json
@@ -224,34 +224,6 @@
       "reason": "Same brace-expansion toolchain incompatibility as GHSA-mh99-v99m-4gvg (issue #584): development and CI tooling only, brace-expansion 5.0.8 is API-incompatible with the installed minimatch consumers, so the toolchain must be migrated as a reviewed change. GHSA-rgw5-rvv9-x895 bypasses the earlier CVE's mitigation via unbounded intermediate arrays, but the same compensating controls and remediation path apply.",
       "remediationIssue": "https://github.com/metasession-dev/wawagardenbar-app/issues/584",
       "compensatingControls": "Only trusted organization code and repository-controlled patterns execute these lint/test paths; CI jobs have bounded time and memory. Review issue #584 on every dependency update and remove this acceptance as soon as compatible consumers are available."
-    },
-    {
-      "advisoryId": "GHSA-5p4m-2wfm-xmqj",
-      "package": "js-yaml",
-      "vulnerableRange": ">=4.0.0 <4.3.1",
-      "vulnerableVersion": "4.3.0",
-      "dependencyPath": "node_modules/js-yaml",
-      "introducedBy": "direct",
-      "approvedAt": "2026-08-13",
-      "expiresAt": "2026-09-10",
-      "approvedBy": "william@ostendo.io",
-      "reason": "Development and CI tooling only (pulled in by cosmiconfig/@commitlint/load and @eslint/eslintrc, not the production bundle). Quadratic CPU consumption in !!omap resolution requires attacker-controlled YAML input, which this toolchain never parses from untrusted sources.",
-      "remediationIssue": "https://github.com/metasession-dev/wawagardenbar-app/issues/654",
-      "compensatingControls": "Only repository-controlled config files (commitlint/eslint config) are parsed as YAML by this dependency chain; no untrusted input reaches js-yaml. Review issue #654 on every dependency update and remove this acceptance once a patched js-yaml (>=4.3.1) resolves."
-    },
-    {
-      "advisoryId": "GHSA-2v37-7h3g-55p8",
-      "package": "nanoid",
-      "vulnerableRange": "<3.3.17",
-      "vulnerableVersion": "3.3.16",
-      "dependencyPath": "node_modules/nanoid",
-      "introducedBy": "direct",
-      "approvedAt": "2026-08-13",
-      "expiresAt": "2026-09-10",
-      "approvedBy": "william@ostendo.io",
-      "reason": "Development and CI tooling only (pulled in by postcss, not the production bundle). The infinite-loop condition requires calling the generator with size=0, which postcss's internal usage never does.",
-      "remediationIssue": "https://github.com/metasession-dev/wawagardenbar-app/issues/654",
-      "compensatingControls": "Only postcss's internal build-time usage calls this generator with fixed, non-zero size arguments; no user input reaches it. Review issue #654 on every dependency update and remove this acceptance once a patched nanoid (>=3.3.17) resolves."
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10206,9 +10206,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -11296,9 +11296,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
       "brace-expansion": "2.1.2"
     },
     "postcss": "$postcss",
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "fast-uri": "^4.1.1",
     "sharp": "^0.35.3"
   }


### PR DESCRIPTION
## Summary
- Bumps the `js-yaml` npm `overrides` pin from `4.3.0` → `4.3.1`, resolving **GHSA-5p4m-2wfm-xmqj** (quadratic CPU consumption in `!!omap` resolution). `4.3.0` was itself a prior security pin (`c97d942`, #~July 21); the new advisory affects that exact version, so the fix is bumping the pin forward, not adding a new one.
- `npm update nanoid` resolves postcss's transitive `nanoid` dependency `3.3.16` → `3.3.18`, resolving **GHSA-2v37-7h3g-55p8** (indefinite loop when `size=0`) — no override needed, postcss's `^3.3.16` range already permitted the newer patch.
- Removes both temporary risk-acceptance entries from `compliance/security/accepted-vulnerabilities.json` (added in #653) now that patched versions resolve cleanly.

Closes #654

## Test plan
- [x] `npm ls js-yaml nanoid` — confirms `js-yaml@4.3.1`, `nanoid@3.3.18` resolved
- [x] `npm audit` + `bash scripts/evaluate-npm-audit.sh` — 16 accepted (pre-existing #584 brace-expansion exceptions, unaffected), 0 unresolved
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 1378 passed, 4 skipped, 0 failed
- [x] Pre-push hooks (TypeScript check, sentinel check, compliance validation) — all passed
- [ ] CI quality gates green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)