### PR TITLE
chore: sync DevAudit SDLC templates to 0.3.40

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,7 +1,7 @@
 name: Bug
 description: Defect in shipped behaviour. Full SDLC if it touches a high-risk surface; otherwise lighter.
-title: "[BUG] <one-line symptom>"
-labels: ["bug", "needs-triage"]
+title: '[BUG] <one-line symptom>'
+labels: ['bug', 'needs-triage']
 body:
   - type: markdown
     attributes:
@@ -46,13 +46,13 @@ body:
     id: surface_risk
     attributes:
       label: Affected surface — risk class
-      description: "Same scale as the Requirement template. Defects in HIGH/CRITICAL surfaces still need stage-1 risk classification and full evidence even if the fix is small."
+      description: 'Same scale as the Requirement template. Defects in HIGH/CRITICAL surfaces still need stage-1 risk classification and full evidence even if the fix is small.'
       options:
-        - "LOW — UI polish, low-traffic admin tooling, no security/data/payment surface"
-        - "MEDIUM — user-visible feature defect, no security/data risk"
-        - "HIGH — auth, payments, RBAC, evidence/audit storage, third-party data egress"
-        - "CRITICAL — regulated data, AI making decisions about people, production infra"
-        - "Unsure — defer to stage-1 plan to classify"
+        - 'LOW — UI polish, low-traffic admin tooling, no security/data/payment surface'
+        - 'MEDIUM — user-visible feature defect, no security/data risk'
+        - 'HIGH — auth, payments, RBAC, evidence/audit storage, third-party data egress'
+        - 'CRITICAL — regulated data, AI making decisions about people, production infra'
+        - 'Unsure — defer to stage-1 plan to classify'
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/requirement.yml
+++ b/.github/ISSUE_TEMPLATE/requirement.yml
@@ -1,7 +1,7 @@
 name: Requirement
 description: A new feature, enhancement, or significant change. Goes through full SDLC stages 1–5.
-title: "[REQ] <one-line summary>"
-labels: ["requirement", "needs-triage"]
+title: '[REQ] <one-line summary>'
+labels: ['requirement', 'needs-triage']
 body:
   - type: markdown
     attributes:
@@ -37,13 +37,13 @@ body:
     id: suspected_risk
     attributes:
       label: Suspected risk class
-      description: "Per Test_Policy.md §Risk-Based Testing. Final classification happens in stage 1; this is your first-cut signal."
+      description: 'Per Test_Policy.md §Risk-Based Testing. Final classification happens in stage 1; this is your first-cut signal.'
       options:
-        - "LOW — UI polish, low-traffic admin tooling, no security/data/payment surface"
-        - "MEDIUM — new feature, integration, refactor with user-visible effect"
-        - "HIGH — auth, payments, RBAC, evidence/audit storage, third-party data egress"
-        - "CRITICAL — regulated data, AI making decisions about people, production infra"
-        - "Unsure — defer to stage-1 plan to classify"
+        - 'LOW — UI polish, low-traffic admin tooling, no security/data/payment surface'
+        - 'MEDIUM — new feature, integration, refactor with user-visible effect'
+        - 'HIGH — auth, payments, RBAC, evidence/audit storage, third-party data egress'
+        - 'CRITICAL — regulated data, AI making decisions about people, production infra'
+        - 'Unsure — defer to stage-1 plan to classify'
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,7 +1,7 @@
 name: Task
 description: Chore, refactor, doc update, or dependency bump. Uses the trivial-change escape hatch — skips SDLC stages 1 + 3.
-title: "[TASK] <one-line summary>"
-labels: ["task", "chore"]
+title: '[TASK] <one-line summary>'
+labels: ['task', 'chore']
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Summary

- Ran `devaudit update 0.3.40 .` to sync SDLC templates/CI workflows/scripts from the latest published DevAudit release.
- Only diff: quoting-style normalization (double → single quotes, prettier) in the three GitHub issue-template YAML files (`bug.yml`, `requirement.yml`, `task.yml`). Everything else synced already matched the installed 0.3.39 content byte-for-byte.

Closes #659

## Test plan

- [x] `npm run lint` — 0 errors (pre-existing warnings unrelated to this diff)
- [x] `npx tsc --noEmit` — clean
- [x] Pre-push hook (skill-invocation sentinel, phase-progression, compliance artifact validation) passed
- No `REQ-XXX` — housekeeping/chore path per Phase 0 triage on #659, no RTM/evidence pack required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)