### PR TITLE
ci: enable portal-driven CI runner selection (issue #666)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,7 +1,7 @@
 name: Bug
 description: Defect in shipped behaviour. Full SDLC if it touches a high-risk surface; otherwise lighter.
-title: '[BUG] <one-line symptom>'
-labels: ['bug', 'needs-triage']
+title: "[BUG] <one-line symptom>"
+labels: ["bug", "needs-triage"]
 body:
   - type: markdown
     attributes:
@@ -46,13 +46,13 @@ body:
     id: surface_risk
     attributes:
       label: Affected surface — risk class
-      description: 'Same scale as the Requirement template. Defects in HIGH/CRITICAL surfaces still need stage-1 risk classification and full evidence even if the fix is small.'
+      description: "Same scale as the Requirement template. Defects in HIGH/CRITICAL surfaces still need stage-1 risk classification and full evidence even if the fix is small."
       options:
-        - 'LOW — UI polish, low-traffic admin tooling, no security/data/payment surface'
-        - 'MEDIUM — user-visible feature defect, no security/data risk'
-        - 'HIGH — auth, payments, RBAC, evidence/audit storage, third-party data egress'
-        - 'CRITICAL — regulated data, AI making decisions about people, production infra'
-        - 'Unsure — defer to stage-1 plan to classify'
+        - "LOW — UI polish, low-traffic admin tooling, no security/data/payment surface"
+        - "MEDIUM — user-visible feature defect, no security/data risk"
+        - "HIGH — auth, payments, RBAC, evidence/audit storage, third-party data egress"
+        - "CRITICAL — regulated data, AI making decisions about people, production infra"
+        - "Unsure — defer to stage-1 plan to classify"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/requirement.yml
+++ b/.github/ISSUE_TEMPLATE/requirement.yml
@@ -1,7 +1,7 @@
 name: Requirement
 description: A new feature, enhancement, or significant change. Goes through full SDLC stages 1–5.
-title: '[REQ] <one-line summary>'
-labels: ['requirement', 'needs-triage']
+title: "[REQ] <one-line summary>"
+labels: ["requirement", "needs-triage"]
 body:
   - type: markdown
     attributes:
@@ -37,13 +37,13 @@ body:
     id: suspected_risk
     attributes:
       label: Suspected risk class
-      description: 'Per Test_Policy.md §Risk-Based Testing. Final classification happens in stage 1; this is your first-cut signal.'
+      description: "Per Test_Policy.md §Risk-Based Testing. Final classification happens in stage 1; this is your first-cut signal."
       options:
-        - 'LOW — UI polish, low-traffic admin tooling, no security/data/payment surface'
-        - 'MEDIUM — new feature, integration, refactor with user-visible effect'
-        - 'HIGH — auth, payments, RBAC, evidence/audit storage, third-party data egress'
-        - 'CRITICAL — regulated data, AI making decisions about people, production infra'
-        - 'Unsure — defer to stage-1 plan to classify'
+        - "LOW — UI polish, low-traffic admin tooling, no security/data/payment surface"
+        - "MEDIUM — new feature, integration, refactor with user-visible effect"
+        - "HIGH — auth, payments, RBAC, evidence/audit storage, third-party data egress"
+        - "CRITICAL — regulated data, AI making decisions about people, production infra"
+        - "Unsure — defer to stage-1 plan to classify"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/srs-bootstrap.yml
+++ b/.github/ISSUE_TEMPLATE/srs-bootstrap.yml
@@ -1,7 +1,7 @@
 name: SRS Bootstrap
 description: Author this project's first Software Requirements Specification (docs/SRS.md). One-time — use Requirement for everything after.
-title: '[SRS] Bootstrap the Software Requirements Specification'
-labels: ['srs-bootstrap', 'documentation']
+title: "[SRS] Bootstrap the Software Requirements Specification"
+labels: ["srs-bootstrap", "documentation"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,7 +1,7 @@
 name: Task
 description: Chore, refactor, doc update, or dependency bump. Uses the trivial-change escape hatch — skips SDLC stages 1 + 3.
-title: '[TASK] <one-line summary>'
-labels: ['task', 'chore']
+title: "[TASK] <one-line summary>"
+labels: ["task", "chore"]
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/check-release-approval.yml
+++ b/.github/workflows/check-release-approval.yml
@@ -38,7 +38,7 @@ permissions:
 jobs:
   check-approval:
     name: DevAudit Release Approval
-    runs-on: ubuntu-latest
+    runs-on: ${{ (inputs.runner_label || vars.CI_RUNNER_LABEL || 'github-ci') == 'github-ci' && 'ubuntu-latest' || (inputs.runner_label || vars.CI_RUNNER_LABEL || 'github-ci') }}
     env:
       DEVAUDIT_BASE_URL_VAR: ${{ vars.DEVAUDIT_BASE_URL }}
       DEVAUDIT_API_KEY: ${{ secrets.DEVAUDIT_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     name: Quality Gates
     needs: [register-release]
     if: ${{ always() && (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'chore/close-out-')) && (github.event_name == 'pull_request' || needs.register-release.result == 'success') }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ (inputs.runner_label || vars.CI_RUNNER_LABEL || 'github-ci') == 'github-ci' && 'ubuntu-latest' || (inputs.runner_label || vars.CI_RUNNER_LABEL || 'github-ci') }}
 
     services:
       mongodb:
@@ -342,7 +342,7 @@ jobs:
   # ──────────────────────────────────────────────
   register-release:
     name: Register Release
-    runs-on: ubuntu-latest
+    runs-on: ${{ (inputs.runner_label || vars.CI_RUNNER_LABEL || 'github-ci') == 'github-ci' && 'ubuntu-latest' || (inputs.runner_label || vars.CI_RUNNER_LABEL || 'github-ci') }}
     # PRs to develop should report Quality Gates without mutating DevAudit
     # releases or evidence. Release registration remains a develop-push /
     # manual-dispatch side effect.
@@ -562,7 +562,7 @@ jobs:
   # ──────────────────────────────────────────────
   upload-evidence:
     name: Upload Evidence
-    runs-on: ubuntu-latest
+    runs-on: ${{ (inputs.runner_label || vars.CI_RUNNER_LABEL || 'github-ci') == 'github-ci' && 'ubuntu-latest' || (inputs.runner_label || vars.CI_RUNNER_LABEL || 'github-ci') }}
     needs: [quality-gates, register-release]
     # `!cancelled()` preserves failed-gate evidence on eligible integration
     # pushes, while a pull request remains an intentionally inapplicable,

--- a/.github/workflows/close-out-completion.yml
+++ b/.github/workflows/close-out-completion.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   report-completion:
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'chore/close-out-')
-    runs-on: ubuntu-latest
+    runs-on: ${{ (inputs.runner_label || vars.CI_RUNNER_LABEL || 'github-ci') == 'github-ci' && 'ubuntu-latest' || (inputs.runner_label || vars.CI_RUNNER_LABEL || 'github-ci') }}
     env:
       DEVAUDIT_API_KEY: ${{ secrets.DEVAUDIT_API_KEY }}
       PROJECT_SLUG: wgb

--- a/.github/workflows/close-out-release.yml
+++ b/.github/workflows/close-out-release.yml
@@ -41,7 +41,7 @@ permissions:
 jobs:
   close-out:
     name: Close out release
-    runs-on: ubuntu-latest
+    runs-on: ${{ (inputs.runner_label || vars.CI_RUNNER_LABEL || 'github-ci') == 'github-ci' && 'ubuntu-latest' || (inputs.runner_label || vars.CI_RUNNER_LABEL || 'github-ci') }}
     env:
       # devaudit-installer#613 — PRs opened with the default GITHUB_TOKEN
       # (actor github-actions[bot]) get their own pull_request-triggered

--- a/.github/workflows/compliance-evidence.yml
+++ b/.github/workflows/compliance-evidence.yml
@@ -52,7 +52,7 @@ jobs:
     # sibling job below; running both on a workflow_run event would
     # double-upload every compliance doc.
     if: github.event_name != 'workflow_run'
-    runs-on: ubuntu-latest
+    runs-on: ${{ (inputs.runner_label || vars.CI_RUNNER_LABEL || 'github-ci') == 'github-ci' && 'ubuntu-latest' || (inputs.runner_label || vars.CI_RUNNER_LABEL || 'github-ci') }}
     # #409: this workflow only uploads evidence. Normal housekeeping is
     # integration history, so it must not create PRs, dispatch gates, or
     # receive write-scoped GitHub credentials.
@@ -286,7 +286,7 @@ jobs:
   upload-e2e-regression-evidence:
     name: Upload E2E Regression Evidence
     if: github.event_name == 'workflow_run'
-    runs-on: ubuntu-latest
+    runs-on: ${{ (inputs.runner_label || vars.CI_RUNNER_LABEL || 'github-ci') == 'github-ci' && 'ubuntu-latest' || (inputs.runner_label || vars.CI_RUNNER_LABEL || 'github-ci') }}
     # actions: read is required so `actions/download-artifact@v8` with
     # `run-id` can read another workflow's artifacts. Without it the
     # download step fails with a 404 even when the artifact exists.

--- a/.github/workflows/compliance-validation.yml
+++ b/.github/workflows/compliance-validation.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   compliance-validation:
     name: Compliance Validation
-    runs-on: ubuntu-latest
+    runs-on: ${{ (inputs.runner_label || vars.CI_RUNNER_LABEL || 'github-ci') == 'github-ci' && 'ubuntu-latest' || (inputs.runner_label || vars.CI_RUNNER_LABEL || 'github-ci') }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/feature-e2e.yml
+++ b/.github/workflows/feature-e2e.yml
@@ -16,7 +16,7 @@ jobs:
   detect-req:
     name: Detect REQ from branch
     if: ${{ !startsWith(github.head_ref, 'chore/close-out-') }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ (inputs.runner_label || vars.CI_RUNNER_LABEL || 'github-ci') == 'github-ci' && 'ubuntu-latest' || (inputs.runner_label || vars.CI_RUNNER_LABEL || 'github-ci') }}
     outputs:
       req_id: ${{ steps.detect.outputs.req_id }}
       has_tests: ${{ steps.detect.outputs.has_tests }}
@@ -83,7 +83,7 @@ jobs:
     name: Run in-scope E2E
     needs: detect-req
     if: needs.detect-req.outputs.has_tests == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ (inputs.runner_label || vars.CI_RUNNER_LABEL || 'github-ci') == 'github-ci' && 'ubuntu-latest' || (inputs.runner_label || vars.CI_RUNNER_LABEL || 'github-ci') }}
 
     services:
       mongodb:

--- a/.github/workflows/post-deploy-prod.yml
+++ b/.github/workflows/post-deploy-prod.yml
@@ -45,7 +45,7 @@ jobs:
         github.event.deployment.environment == 'prod' ||
         endsWith(github.event.deployment.environment, '/ production') ||
         endsWith(github.event.deployment.environment, '/production')))
-    runs-on: ubuntu-latest
+    runs-on: ${{ (inputs.runner_label || vars.CI_RUNNER_LABEL || 'github-ci') == 'github-ci' && 'ubuntu-latest' || (inputs.runner_label || vars.CI_RUNNER_LABEL || 'github-ci') }}
     permissions:
       contents: read
       deployments: read
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0 # full history so merged commits' REQ tags are readable
+          fetch-depth: 0   # full history so merged commits' REQ tags are readable
 
       - name: Resolve DevAudit base URL and post-deploy terminal status
         run: |

--- a/.github/workflows/reconcile-deployment.yml
+++ b/.github/workflows/reconcile-deployment.yml
@@ -31,7 +31,7 @@ on:
 jobs:
   reconcile:
     name: Verify and reconcile deployment
-    runs-on: ubuntu-latest
+    runs-on: ${{ (inputs.runner_label || vars.CI_RUNNER_LABEL || 'github-ci') == 'github-ci' && 'ubuntu-latest' || (inputs.runner_label || vars.CI_RUNNER_LABEL || 'github-ci') }}
     permissions:
       contents: read
       deployments: write

--- a/sdlc-config.json
+++ b/sdlc-config.json
@@ -1,5 +1,5 @@
 {
-  "runner": "ubuntu-latest",
+  "runner": "self-hosted",
   "sast_baseline": 0,
   "accepted_dep_risks": "",
   "database_service": "mongodb",


### PR DESCRIPTION
## Summary
- Flips `sdlc-config.json`'s `runner` sentinel from a static `"ubuntu-latest"` override to `"self-hosted"`, so `devaudit-installer`'s `resolveRunner()` emits the dynamic `CI_RUNNER_LABEL`-driven `runs-on:` expression instead of hardcoding GitHub-hosted infra.
- Regenerated via `devaudit update` (already-installed v0.3.40, no CLI upgrade needed) — synced all workflow files, so every job now resolves its runner from `vars.CI_RUNNER_LABEL` (falling back to `ubuntu-latest` via the `github-ci` default) instead of just `ci.yml`.
- `CI_RUNNER_LABEL=ostendo-workhorse-ci` is already set as a repo variable (confirmed via `gh variable list`), matching the portal's runner-policy setting for this project.

## Classification
Housekeeping (CI maintenance), LOW risk, Lightweight path per `sdlc-implementer` Phase 0 — no runtime app/lib code touched, so no REQ-XXX/RTM/evidence pack.

## Gates
- Lint/tsc/vitest skipped — zero application source files changed (only `.github/workflows/*.yml` + `sdlc-config.json`), `node_modules` not installed locally, and installing solely to lint unrelated code isn't a meaningful gate for this diff.
- **Verify-via-dispatch pending** — will dispatch `ci.yml` against this branch before merge to confirm the run actually lands on the registered self-hosted runner (`ostendo-server`) rather than hanging on an unmatched label.

Closes #666

🤖 Generated with [Claude Code](https://claude.com/claude-code)