### PR TITLE
ci: wipe .next before every run to prevent cross-run build corruption

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,18 @@ jobs:
           # skip-path actually skip. See DEVAUDIT-004.
           clean: false
 
+      - name: Remove stale .next build output
+        # clean: false above (DEVAUDIT-004) intentionally keeps node_modules
+        # and other gitignored state between runs — but .next is different:
+        # it's live scratch state a running dev server writes to, not a
+        # stable install-once cache, so a job whose dev server got killed
+        # mid-write (timeout, OOM, cancellation) can leave it torn/corrupted
+        # for every subsequent run's TypeScript Check and Build Check to trip
+        # over, on totally unrelated PRs. Regenerating it costs ~nothing in
+        # dev mode (lazy/incremental compilation), so there's no caching
+        # upside to keeping it — always start clean.
+        run: rm -rf .next
+
       - name: Validate self-hosted runner prerequisites
         env:
           DEVAUDIT_RUNNER_ENVIRONMENT: ${{ runner.environment }}

--- a/.github/workflows/feature-e2e.yml
+++ b/.github/workflows/feature-e2e.yml
@@ -111,6 +111,12 @@ jobs:
           # default clean:true wipes node_modules between jobs on the single
           # runner, defeating its npm-ci cache (DEVAUDIT-004).
           clean: false
+      - name: Remove stale .next build output
+        # .next is live dev-server scratch state, not a stable cache — a
+        # killed/timed-out dev server on any run (this job or ci.yml's) can
+        # leave it torn/corrupted for the next run to trip over. Cheap to
+        # regenerate, no reason to keep it. See ci.yml's matching step.
+        run: rm -rf .next
       - uses: actions/setup-node@v6
         with:
           node-version: 20

--- a/docs/operations/CI-DESIGN-AND-IMPLEMENTATION-PLAN.md
+++ b/docs/operations/CI-DESIGN-AND-IMPLEMENTATION-PLAN.md
@@ -155,3 +155,21 @@ interrupts an in-flight run — it just retries the next night. This bounds
 finding (1) to a ≤24h staleness window instead of indefinite persistence.
 Host-local infra, not a repo file — not part of PR #668, no upstream
 template implications, doesn't affect other devaudit-installer consumers.
+
+**[DONE — 2026-08-21] Incident: `.next` corruption actually happened, within
+hours.** Not a hypothetical — PR #670 (an unrelated doc-only change) failed
+Quality Gates' TypeScript Check with syntax errors in
+`.next/dev/types/validator.ts`, a Next.js-generated file neither PR touched.
+Root cause: a dev server killed mid-write by the transient "Wait for dev
+server" timeout hit during PR #669's first CI attempt left a torn/truncated
+file in `.next` (gitignored, so previously wiped every run by `clean: true`;
+now persists per finding (1)'s fix). Every subsequent PR's TypeScript Check
+read the same corrupted file regardless of what that PR actually changed.
+**Fix:** added an explicit `rm -rf .next` as the first step after checkout in
+`ci.yml` and `feature-e2e.yml`, before any gate runs. Unlike `node_modules`/
+Playwright/Semgrep, `.next` is live dev-server scratch state, not a
+stable install-once cache — regenerating it costs ~nothing in dev mode
+(lazy/incremental compilation), so there's no caching upside to weigh against
+the corruption risk; it should never have been allowed to persist in the
+first place. Also added to the nightly cache-wipe script as a backstop.
+Confirms the code review's finding (1) was not theoretical.


### PR DESCRIPTION
## Summary

Live incident, not hypothetical. PR #670 (an unrelated doc-only change) failed Quality Gates' TypeScript Check with syntax errors in `.next/dev/types/validator.ts` — a Next.js-generated file neither PR touched:

```
.next/dev/types/validator.ts(495,1): error TS1128: Declaration or statement expected.
.next/dev/types/validator.ts(1085,5): error TS1003: Identifier expected.
```

## Root cause

A dev server killed mid-write by the transient "Wait for dev server" timeout on PR #669's first CI attempt left a torn/truncated file in `.next`. `.next` is gitignored, so previously it was wiped every run by `actions/checkout`'s default `clean: true`. Since #668 set `clean: false` to fix the npm-cache skip, `.next` now persists across runs too — so every subsequent PR's TypeScript Check read the same corrupted file, regardless of what that PR actually changed.

This confirms a finding from the code review on #668: `clean: false` removes the only cross-run isolation, with no bound on staleness for anything the lockfile-hash check doesn't cover. That finding wasn't theoretical — it broke CI within hours.

## Fix

Added `rm -rf .next` as the first step after checkout in `ci.yml` and `feature-e2e.yml`, before any gate runs. Unlike `node_modules`/Playwright/Semgrep, `.next` is live dev-server scratch state, not a stable install-once cache — regenerating it costs ~nothing in dev mode (lazy/incremental compilation), so there's no caching upside to weigh against the corruption risk. It should never have been allowed to persist.

Also added `.next` to the nightly cache-wipe script as a backstop (already deployed to `ostendo-server` as part of unblocking this incident).

## Verification

The corrupted `.next` was manually removed from the runner to unblock PR #670 immediately; this PR is the durable fix so it can't happen again.