### PR TITLE
chore: sync DevAudit SDLC templates to 1.2.0

### DIFF
--- a/.claude/skills/sdlc-implementer/SKILL.md
+++ b/.claude/skills/sdlc-implementer/SKILL.md
@@ -609,7 +609,7 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
      --branch "$(git rev-parse --abbrev-ref HEAD)"
    ```
    Evidence types: `screenshot`, `e2e_result`, `test_report`, `audit_log`, `compliance_document`, `manual_upload`, `srs_alignment` (from step 1), `architecture_decision` (from step 2), `risk_assessment` (from step 3).
-7. **Verify uploads landed.** `gh api` or `curl` against `https://devaudit.metasession.co/projects/<slug>/requirements/REQ-XXX/evidence` should show every artefact. Any artefact marked `UPLOAD_FAILED` in step 6 should be re-attempted here.
+7. **Verify uploads landed.** `gh api` or `curl` against `https://devaudit.ai/projects/<slug>/requirements/REQ-XXX/evidence` should show every artefact. Any artefact marked `UPLOAD_FAILED` in step 6 should be re-attempted here.
 8. **Update `compliance/RTM.md`** with portal links for each evidence row. Rows with `UPLOAD_FAILED` status remain marked as failed — do not mark them verified.
 9. **Update SDLC status sticky** before exiting Phase 3: `bash scripts/update-sdlc-status.sh "$ISSUE_NUM" "Phase 3 complete — evidence uploaded; SRS-alignment + ADR + risk-assessment artefacts attached" "Phase 4 — sdlc-implementer auto-continuing (open release PR)"`.
 
@@ -631,7 +631,7 @@ Reached only on the **tracked** route from Phase 0 (the issue is already fetched
    - Closes #N
    - REQ-XXX
    - Risk: <class>
-   - Evidence: `https://devaudit.metasession.co/projects/<slug>/requirements/REQ-XXX`
+   - Evidence: `https://devaudit.ai/projects/<slug>/requirements/REQ-XXX`
    - For HIGH/CRITICAL: Four-eyes attestation: `@<reviewer-username>`
    - For HIGH/CRITICAL: Rollback plan: reference to `compliance/plans/REQ-XXX/implementation-plan.md` §Rollback
    - Test plan
@@ -695,7 +695,7 @@ Invoked separately by the user after UAT activity on the portal. Trigger: "resum
    - Check `git log` for the merge commit on `$RELEASE_BRANCH`.
    - If resuming after an environment detour (not a UAT approval), re-read `compliance/evidence/REQ-XXX/` to see which artefacts already exist and resume at the appropriate phase.
 
-1. **Read portal state.** `curl` `https://devaudit.metasession.co/api/projects/<slug>/releases/<version>` and inspect the approval status. Retry up to 3 times with exponential backoff (5s, 15s, 45s) on 5xx responses. If all retries fail, halt — "Portal unreachable at <URL>. Cannot determine UAT approval state. Operator action — verify portal availability + API key, then ping `resume REQ-XXX`." If the API returns 401/403, halt — "Portal API key rejected (HTTP 401/403). The `DEVAUDIT_API_KEY` secret may be expired or revoked. Operator action — rotate the API key, then ping `resume REQ-XXX`." Never guess the portal state.
+1. **Read portal state.** `curl` `https://devaudit.ai/api/projects/<slug>/releases/<version>` and inspect the approval status. Retry up to 3 times with exponential backoff (5s, 15s, 45s) on 5xx responses. If all retries fail, halt — "Portal unreachable at <URL>. Cannot determine UAT approval state. Operator action — verify portal availability + API key, then ping `resume REQ-XXX`." If the API returns 401/403, halt — "Portal API key rejected (HTTP 401/403). The `DEVAUDIT_API_KEY` secret may be expired or revoked. Operator action — rotate the API key, then ping `resume REQ-XXX`." Never guess the portal state.
 
 2. **Branch on state:**
    - **UAT approved** → run stage 5:
@@ -705,7 +705,7 @@ Invoked separately by the user after UAT activity on the portal. Trigger: "resum
      - **Gate topology:** when a host waits for CI before deploy, only pre-deploy eligibility belongs to the main-push suite. Post-deploy evidence and full regression trigger from a successful production `deployment_status`, not that same push. If the provider skipped the SHA due to CI gating, redeploy that exact SHA before running post-deploy verification.
      - Watch `post-deploy-prod.yml` via `gh run watch` — block until the workflow reaches a terminal state. Wrap in a timeout (30 minutes default, configurable via `sdlc-config.json:post_deploy.timeout_minutes`). If the timeout fires: halt — "post-deploy-prod.yml has not reached a terminal state in N minutes. The deployment may be stuck. Operator action — check hosting platform logs, decide whether to wait or rollback, then ping `resume REQ-XXX`."
      - Treat `post-deploy-prod.yml` success as necessary but not sufficient. The workflow must also confirm the hosting platform's GitHub deployment status for the merged SHA reached terminal `success`. If it reports `deployment_status_timeout`, `deployment_status_missing`, or terminal failure, remain blocked and preserve the deployment ID, SHA, environment, final observed state, target URL, elapsed time, and independent health-probe result. A successful health probe is corroboration only, never deployment-status proof. Halt — "The host deployment for <sha> is not terminal-successful after merge. Do not approve Production or mark Released. Operator action — inspect provider logs, fix forward or rollback, then rerun post-deploy verification once the production state is understood."
-     - Verify production smoke evidence uploaded (`--environment production`) at `https://devaudit.metasession.co/projects/<slug>/releases/<version>`.
+     - Verify production smoke evidence uploaded (`--environment production`) at `https://devaudit.ai/projects/<slug>/releases/<version>`.
      - **Read `production_review.terminal_status` from `sdlc-config.json`** (default: `prod_review`). Branch:
        - If `released` (Option B): PATCH directly to `released` — `PATCH /releases/<version>` with `{"status": "released"}`.
        - If `prod_review` (Option A, default): after `post-deploy-prod.yml` completes, the release is at `prod_review`. Update the sticky to "Phase 5 — production deployed; awaiting prod approval on portal" and halt. The operator clicks "Approve Production" (`prod_review` → `prod_approved`) then "Mark as Released" (`prod_approved` → `released`) in the portal. On next `resume REQ-XXX`, the skill reads the portal state — if `released`, finalise (close issue, update sticky to terminal). If `prod_approved`, prompt the operator to click "Mark as Released". If still `prod_review`, report "awaiting production approval" and stop.

--- a/.claude/skills/sdlc-implementer/references/change-request-loop.md
+++ b/.claude/skills/sdlc-implementer/references/change-request-loop.md
@@ -29,7 +29,7 @@ When the user runs `> Resume REQ-XXX` and the portal state is `uat_changes_reque
 Two sources to read:
 
 1. **PR comments** — `gh pr view <M> --comments --json comments,reviews --jq '.comments[].body, .reviews[].body'`. Includes line-level review comments and top-level discussion.
-2. **Portal release-page comments** — `curl https://devaudit.metasession.co/api/projects/<slug>/releases/<version>/comments`. Includes any comments the UAT reviewer left on the release card itself.
+2. **Portal release-page comments** — `curl https://devaudit.ai/api/projects/<slug>/releases/<version>/comments`. Includes any comments the UAT reviewer left on the release card itself.
 
 Both sources matter: PR comments are usually code-level; portal comments are usually about-the-release-as-a-whole.
 
@@ -133,7 +133,7 @@ The portal's release-approval state automatically resets to `uat_review` on the 
 
 Even though state has reset, the reviewer needs notification. Two actions:
 
-1. **Portal API**: `POST https://devaudit.metasession.co/api/projects/<slug>/releases/<version>/approval-requests` with `{"iteration": N, "summary": "Change-request iteration N addressed"}`. This notifies the reviewer on their portal dashboard.
+1. **Portal API**: `POST https://devaudit.ai/api/projects/<slug>/releases/<version>/approval-requests` with `{"iteration": N, "summary": "Change-request iteration N addressed"}`. This notifies the reviewer on their portal dashboard.
 2. **PR comment**: post a summary comment on the PR linking to the new commits and the iteration-N evidence on the portal:
 
 ```
@@ -143,7 +143,7 @@ Items addressed:
 - <bullet, link to original comment>
 - <bullet, link to original comment>
 
-Updated evidence: https://devaudit.metasession.co/projects/<slug>/requirements/REQ-XXX (filter by iteration N)
+Updated evidence: https://devaudit.ai/projects/<slug>/requirements/REQ-XXX (filter by iteration N)
 
 @<reviewer-username> — UAT re-review requested.
 ```

--- a/.github/workflows/check-release-approval.yml
+++ b/.github/workflows/check-release-approval.yml
@@ -61,8 +61,6 @@ jobs:
           # the gate can resolve the release and post a status check.
           ref: ${{ github.event.pull_request.head.sha || 'develop' }}
           fetch-depth: 0
-          # Shared self-hosted workspace — see DEVAUDIT-004.
-          clean: false
 
       - name: Detect declared standalone housekeeping promotion
         id: standalone

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,14 @@ jobs:
     if: ${{ always() && (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'chore/close-out-')) && (github.event_name == 'pull_request' || needs.register-release.result == 'success') }}
     runs-on: ${{ (inputs.runner_label || vars.CI_RUNNER_LABEL || 'github-ci') == 'github-ci' && 'ubuntu-latest' || (inputs.runner_label || vars.CI_RUNNER_LABEL || 'github-ci') }}
 
+    # `working-directory` lets monorepo / subdir Node projects (e.g. META-AGENT
+    # with mission-control/package.json) run gates from the right place without
+    # prefixing every command. Defaults to '.' (repo root) when
+    # sdlc-config.json doesn't set working_directory.
+    defaults:
+      run:
+        working-directory: .
+
     services:
       mongodb:
         image: mongo:7
@@ -71,33 +79,17 @@ jobs:
           # base — Playwright's evidenceShot helper reads that env var to
           # tag each captured screenshot as feature vs regression.
           fetch-depth: 0
-          # actions/checkout defaults to clean: true (git clean -ffdx before
-          # checkout), which wipes node_modules (gitignored) every run and
-          # silently defeats the lockfile-hash npm-ci skip below on a
-          # persistent self-hosted runner. npm ci still does a correct clean
-          # install whenever the lockfile hash changes, so this only lets the
-          # skip-path actually skip. See DEVAUDIT-004.
-          clean: false
-
-      - name: Remove stale .next build output
-        # clean: false above (DEVAUDIT-004) intentionally keeps node_modules
-        # and other gitignored state between runs — but .next is different:
-        # it's live scratch state a running dev server writes to, not a
-        # stable install-once cache, so a job whose dev server got killed
-        # mid-write (timeout, OOM, cancellation) can leave it torn/corrupted
-        # for every subsequent run's TypeScript Check and Build Check to trip
-        # over, on totally unrelated PRs. Regenerating it costs ~nothing in
-        # dev mode (lazy/incremental compilation), so there's no caching
-        # upside to keeping it — always start clean.
-        run: rm -rf .next
 
       - name: Validate self-hosted runner prerequisites
         env:
           DEVAUDIT_RUNNER_ENVIRONMENT: ${{ runner.environment }}
+        # scripts/ syncs to the repo root (#689), not this job's
+        # working-directory (a target's own subdirectory) — reference it via
+        # $GITHUB_WORKSPACE so this resolves correctly either way.
         run: |
-          if [ -f scripts/check-self-hosted-runner.sh ]; then
-            chmod +x scripts/check-self-hosted-runner.sh
-            bash scripts/check-self-hosted-runner.sh
+          if [ -f "$GITHUB_WORKSPACE/scripts/check-self-hosted-runner.sh" ]; then
+            chmod +x "$GITHUB_WORKSPACE/scripts/check-self-hosted-runner.sh"
+            bash "$GITHUB_WORKSPACE/scripts/check-self-hosted-runner.sh"
           else
             echo "::warning::scripts/check-self-hosted-runner.sh missing; run devaudit update to sync runner preflight."
           fi
@@ -106,15 +98,17 @@ jobs:
         if: github.event_name != 'pull_request' && github.ref_name == 'develop' && needs.register-release.outputs.version != 'skip'
         run: |
           BASE=""
-          if [ -f sdlc-config.json ]; then
-            BASE=$(jq -r '.devaudit.base_url // empty' sdlc-config.json 2>/dev/null || true)
+          # sdlc-config.json lives at the repo root (#689 follow-up), not this
+          # job's working-directory (a target's own subdirectory).
+          if [ -f "$GITHUB_WORKSPACE/sdlc-config.json" ]; then
+            BASE=$(jq -r '.devaudit.base_url // empty' "$GITHUB_WORKSPACE/sdlc-config.json" 2>/dev/null || true)
           fi
           [ -n "$BASE" ] || BASE="$DEVAUDIT_BASE_URL_VAR"
           [ -n "$BASE" ] || { echo "::warning::No DevAudit URL; test execution lifecycle disabled"; exit 0; }
           export DEVAUDIT_BASE_URL="${BASE%/}"
           echo "DEVAUDIT_BASE_URL=${DEVAUDIT_BASE_URL}" >> "$GITHUB_ENV"
-          chmod +x scripts/report-test-execution.sh scripts/report-release-check.sh 2>/dev/null || true
-          bash scripts/report-test-execution.sh start \
+          chmod +x "$GITHUB_WORKSPACE/scripts/report-test-execution.sh" "$GITHUB_WORKSPACE/scripts/report-release-check.sh" 2>/dev/null || true
+          bash "$GITHUB_WORKSPACE/scripts/report-test-execution.sh" start \
             --project-slug wgb \
             --release "${{ needs.register-release.outputs.version }}" \
             --sdlc-stage 2 --environment ci --suite-kind quality_gate \
@@ -154,12 +148,7 @@ jobs:
           echo "$VENV/bin" >> "$GITHUB_PATH"
 
       - name: Install Playwright (skip if already cached)
-        # --with-deps needs root to apt-get system libs (libnss3 etc.) and
-        # always fails on this non-root self-hosted runner — those libs are
-        # already provisioned on the host (see runner setup docs), so a
-        # plain `install chromium` is correct here: it's version-aware and
-        # skips the browser download itself when already cached.
-        run: npx playwright install chromium
+        run: npx playwright install --with-deps chromium 2>/dev/null || npx playwright install chromium
 
       # ── Gate 1: TypeScript ──
 
@@ -204,8 +193,8 @@ jobs:
           # against the installed package-lock path and writes an auditable
           # decision record. It is intentionally fail-closed: malformed audit
           # output or a malformed/expired exception fails this gate.
-          chmod +x scripts/evaluate-npm-audit.sh 2>/dev/null || true
-          bash scripts/evaluate-npm-audit.sh
+          chmod +x "$GITHUB_WORKSPACE/scripts/evaluate-npm-audit.sh" 2>/dev/null || true
+          bash "$GITHUB_WORKSPACE/scripts/evaluate-npm-audit.sh"
 
       # ── Gate 4: E2E Tests (Playwright) ──
 
@@ -343,6 +332,10 @@ jobs:
 
       # ── Upload artifacts ──
 
+      # actions/upload-artifact@v7 doesn't honour the job's `working-directory`;
+      # paths are workspace-relative. Prefix with WORKING_DIR_PREFIX so artifacts
+      # uploaded from a subdir project (e.g. mission-control/) include the
+      # subdir in their stored path, matching where the gate steps wrote them.
       - uses: actions/upload-artifact@v7
         if: always()
         continue-on-error: true
@@ -380,9 +373,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          # See clean: false note on the quality-gates checkout above — same
-          # shared self-hosted workspace, same reasoning (DEVAUDIT-004).
-          clean: false
 
       - name: Resolve DevAudit base URL
         run: |
@@ -601,10 +591,6 @@ jobs:
       DEVAUDIT_API_KEY: ${{ secrets.DEVAUDIT_API_KEY }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          # See clean: false note on the quality-gates checkout above — same
-          # shared self-hosted workspace, same reasoning (DEVAUDIT-004).
-          clean: false
 
       - name: Resolve DevAudit base URL
         run: |

--- a/.github/workflows/close-out-completion.yml
+++ b/.github/workflows/close-out-completion.yml
@@ -20,8 +20,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
-          # Shared self-hosted workspace — see DEVAUDIT-004.
-          clean: false
 
       - name: Report tracked close-out completion
         run: |

--- a/.github/workflows/close-out-release.yml
+++ b/.github/workflows/close-out-release.yml
@@ -62,8 +62,6 @@ jobs:
           ref: develop
           fetch-depth: 0
           token: ${{ secrets.INSTALLER_DISPATCH_TOKEN || github.token }}
-          # Shared self-hosted workspace — see DEVAUDIT-004.
-          clean: false
 
       - name: Resolve inputs
         id: in

--- a/.github/workflows/compliance-evidence.yml
+++ b/.github/workflows/compliance-evidence.yml
@@ -69,8 +69,6 @@ jobs:
           # carries the REQ tag in a feature → develop PR flow, so without this
           # the change_type derivation is null nearly everywhere — #77).
           fetch-depth: 0
-          # Shared self-hosted workspace — see DEVAUDIT-004.
-          clean: false
 
       - name: Resolve DevAudit base URL
         id: resolve
@@ -308,8 +306,6 @@ jobs:
           # default branch currently points to.
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
-          # Shared self-hosted workspace — see DEVAUDIT-004.
-          clean: false
 
       - name: Resolve DevAudit base URL
         id: resolve

--- a/.github/workflows/compliance-validation.yml
+++ b/.github/workflows/compliance-validation.yml
@@ -26,8 +26,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          # Shared self-hosted workspace — see DEVAUDIT-004.
-          clean: false
 
       - name: Validate compliance artifacts
         run: bash scripts/validate-compliance-artifacts.sh origin/main

--- a/.github/workflows/feature-e2e.yml
+++ b/.github/workflows/feature-e2e.yml
@@ -24,10 +24,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          # Shared self-hosted workspace with ci.yml's quality-gates job —
-          # default clean:true wipes node_modules between jobs on the single
-          # runner, defeating its npm-ci cache (DEVAUDIT-004).
-          clean: false
       - name: Parse REQ from branch name
         id: detect
         run: |
@@ -89,6 +85,14 @@ jobs:
     if: needs.detect-req.outputs.has_tests == 'true'
     runs-on: ${{ (inputs.runner_label || vars.CI_RUNNER_LABEL || 'github-ci') == 'github-ci' && 'ubuntu-latest' || (inputs.runner_label || vars.CI_RUNNER_LABEL || 'github-ci') }}
 
+    # See ci.yml.template's quality-gates job for why this exists (#689
+    # polyglot-monorepo subdir targets, e.g. META-AGENT's mission-control/).
+    # scripts/ stays repo-root-relative below (via $GITHUB_WORKSPACE) since
+    # register-release-style tooling lives there regardless of target.
+    defaults:
+      run:
+        working-directory: .
+
     services:
       mongodb:
         image: mongo:7
@@ -107,16 +111,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          # Shared self-hosted workspace with ci.yml's quality-gates job —
-          # default clean:true wipes node_modules between jobs on the single
-          # runner, defeating its npm-ci cache (DEVAUDIT-004).
-          clean: false
-      - name: Remove stale .next build output
-        # .next is live dev-server scratch state, not a stable cache — a
-        # killed/timed-out dev server on any run (this job or ci.yml's) can
-        # leave it torn/corrupted for the next run to trip over. Cheap to
-        # regenerate, no reason to keep it. See ci.yml's matching step.
-        run: rm -rf .next
       - uses: actions/setup-node@v6
         with:
           node-version: 20
@@ -130,12 +124,7 @@ jobs:
             echo "$LOCK_HASH" > node_modules/.lock-hash
           fi
       - name: Install Playwright (skip if already cached)
-        # --with-deps needs root to apt-get system libs (libnss3 etc.) and
-        # always fails on this non-root self-hosted runner — those libs are
-        # already provisioned on the host (see runner setup docs), so a
-        # plain `install chromium` is correct here: it's version-aware and
-        # skips the browser download itself when already cached.
-        run: npx playwright install chromium
+        run: npx playwright install --with-deps chromium 2>/dev/null || npx playwright install chromium
 
       - name: Set database URI from dynamic port
         run: |
@@ -215,8 +204,10 @@ jobs:
           REQ_ID="${{ needs.detect-req.outputs.req_id }}"
           : > "$GITHUB_OUTPUT"
           CONFIG_URL=""
-          if [ -f sdlc-config.json ]; then
-            CONFIG_URL=$(jq -r '.devaudit.base_url // empty' sdlc-config.json 2>/dev/null || true)
+          # sdlc-config.json lives at the repo root (#689 follow-up), not this
+          # job's working-directory (a target's own subdirectory).
+          if [ -f "$GITHUB_WORKSPACE/sdlc-config.json" ]; then
+            CONFIG_URL=$(jq -r '.devaudit.base_url // empty' "$GITHUB_WORKSPACE/sdlc-config.json" 2>/dev/null || true)
           fi
           BASE="${CONFIG_URL:-$DEVAUDIT_BASE_URL_VAR}"
           if [ -z "$BASE" ] || [ -z "$DEVAUDIT_API_KEY" ]; then
@@ -225,14 +216,14 @@ jobs:
             exit 0
           fi
           export DEVAUDIT_BASE_URL="${BASE%/}"
-          chmod +x scripts/upload-evidence.sh scripts/report-test-execution.sh 2>/dev/null || true
-          bash scripts/upload-evidence.sh \
+          chmod +x $GITHUB_WORKSPACE/scripts/upload-evidence.sh $GITHUB_WORKSPACE/scripts/report-test-execution.sh 2>/dev/null || true
+          bash $GITHUB_WORKSPACE/scripts/upload-evidence.sh \
             wgb _compliance-docs release_registration README.md \
             --release "$REQ_ID" --create-release-if-missing \
             --environment uat --category planning \
             --git-sha "${{ github.event.pull_request.head.sha }}" \
             --branch "${{ github.head_ref }}" || true
-          bash scripts/report-test-execution.sh start \
+          bash $GITHUB_WORKSPACE/scripts/report-test-execution.sh start \
             --project-slug wgb \
             --release "$REQ_ID" \
             --sdlc-stage 2 \
@@ -272,8 +263,10 @@ jobs:
         run: |
           REQ_ID="${{ needs.detect-req.outputs.req_id }}"
           CONFIG_URL=""
-          if [ -f sdlc-config.json ]; then
-            CONFIG_URL=$(jq -r '.devaudit.base_url // empty' sdlc-config.json 2>/dev/null || true)
+          # sdlc-config.json lives at the repo root (#689 follow-up), not this
+          # job's working-directory (a target's own subdirectory).
+          if [ -f "$GITHUB_WORKSPACE/sdlc-config.json" ]; then
+            CONFIG_URL=$(jq -r '.devaudit.base_url // empty' "$GITHUB_WORKSPACE/sdlc-config.json" 2>/dev/null || true)
           fi
           BASE="${CONFIG_URL:-$DEVAUDIT_BASE_URL_VAR}"
           if [ -z "$BASE" ] || [ -z "$DEVAUDIT_API_KEY" ]; then
@@ -294,7 +287,7 @@ jobs:
             echo "::error::Feature E2E produced no e2e-results.json"
             exit 1
           fi
-          bash scripts/upload-evidence.sh \
+          bash $GITHUB_WORKSPACE/scripts/upload-evidence.sh \
             wgb "$REQ_ID" e2e_result e2e-results.json \
             --category e2e_result --release "$REQ_ID" --create-release-if-missing \
             --environment uat --sdlc-stage 2 \
@@ -313,7 +306,7 @@ jobs:
             exit 1
           fi
           for shot in "${SHOTS[@]}"; do
-            bash scripts/upload-evidence.sh \
+            bash $GITHUB_WORKSPACE/scripts/upload-evidence.sh \
               wgb "$REQ_ID" screenshot "$shot" \
               --category screenshot --release "$REQ_ID" --create-release-if-missing \
               --environment uat --sdlc-stage 2 \
@@ -325,7 +318,7 @@ jobs:
           done
 
           if [ -f playwright-report.zip ]; then
-            bash scripts/upload-evidence.sh \
+            bash $GITHUB_WORKSPACE/scripts/upload-evidence.sh \
               wgb "$REQ_ID" feature_e2e_report playwright-report.zip \
               --category e2e_report --release "$REQ_ID" --create-release-if-missing \
               --environment uat --sdlc-stage 2 \
@@ -347,8 +340,10 @@ jobs:
             exit 0
           fi
           CONFIG_URL=""
-          if [ -f sdlc-config.json ]; then
-            CONFIG_URL=$(jq -r '.devaudit.base_url // empty' sdlc-config.json 2>/dev/null || true)
+          # sdlc-config.json lives at the repo root (#689 follow-up), not this
+          # job's working-directory (a target's own subdirectory).
+          if [ -f "$GITHUB_WORKSPACE/sdlc-config.json" ]; then
+            CONFIG_URL=$(jq -r '.devaudit.base_url // empty' "$GITHUB_WORKSPACE/sdlc-config.json" 2>/dev/null || true)
           fi
           BASE="${CONFIG_URL:-$DEVAUDIT_BASE_URL_VAR}"
           if [ -z "$BASE" ] || [ -z "$DEVAUDIT_API_KEY" ]; then
@@ -360,8 +355,8 @@ jobs:
             *)         OUTCOME=failed ;;
           esac
           export DEVAUDIT_BASE_URL="${BASE%/}"
-          chmod +x scripts/report-test-execution.sh 2>/dev/null || true
-          bash scripts/report-test-execution.sh complete \
+          chmod +x $GITHUB_WORKSPACE/scripts/report-test-execution.sh 2>/dev/null || true
+          bash $GITHUB_WORKSPACE/scripts/report-test-execution.sh complete \
             --project-slug wgb \
             --release "${{ needs.detect-req.outputs.req_id }}" \
             --sdlc-stage 2 \

--- a/.github/workflows/post-deploy-prod.yml
+++ b/.github/workflows/post-deploy-prod.yml
@@ -62,8 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0   # full history so merged commits' REQ tags are readable
-          clean: false     # shared self-hosted workspace — see DEVAUDIT-004
+          fetch-depth: 0 # full history so merged commits' REQ tags are readable
 
       - name: Resolve DevAudit base URL and post-deploy terminal status
         run: |

--- a/.github/workflows/quality-gates-provenance.yml
+++ b/.github/workflows/quality-gates-provenance.yml
@@ -26,6 +26,17 @@ on:
   pull_request:
     branches: [main]
 
+# A repo with tightened default GITHUB_TOKEN permissions (GitHub's
+# increasingly common secure-by-default setting) grants only `contents:
+# read` unless a workflow asks for more — this job's "Verify prior Quality
+# Gates success" step reads check-runs (`checks: read`) and the hotfix path
+# dispatches + watches a run (`actions: write`), so both must be requested
+# explicitly or the same-SHA provenance check 403s outright on such a repo.
+permissions:
+  contents: read
+  checks: read
+  actions: write
+
 jobs:
   release-scope-integrity:
     name: Release Scope Integrity

--- a/.github/workflows/reconcile-deployment.yml
+++ b/.github/workflows/reconcile-deployment.yml
@@ -42,8 +42,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.expected_sha }}
-          # Shared self-hosted workspace — see DEVAUDIT-004.
-          clean: false
       - name: Verify provider deployment before reconciliation
         env:
           GH_TOKEN: ${{ github.token }}

--- a/SDLC/Implementation_Plan_TEMPLATE.md
+++ b/SDLC/Implementation_Plan_TEMPLATE.md
@@ -191,4 +191,4 @@ How the team will know the REQ is correct in production:
 
 This file lives at `compliance/plans/REQ-XXX/implementation-plan.md` and is uploaded automatically on the next push to `develop` via `compliance-evidence.yml`. The portal's framework-coverage matrix flips ISO 29119 §3.4, ISO 27001 A.8.25, GDPR Art. 25, and EU AI Act Art. 11 to COVERED for this REQ once the upload lands.
 
-Verify the upload at `https://devaudit.metasession.co/projects/<slug>/releases/REQ-XXX` — the "Evidence by requirement" list should show this plan tagged with `category=planning`.
+Verify the upload at `https://devaudit.ai/projects/<slug>/releases/REQ-XXX` — the "Evidence by requirement" list should show this plan tagged with `category=planning`.

--- a/SDLC/README_TEMPLATE.md
+++ b/SDLC/README_TEMPLATE.md
@@ -429,7 +429,7 @@ Add these to your GitHub repository (Settings → Secrets and variables → Acti
 
 | Setting | Tab | Value | Source |
 | -------- | ----- | ------- | -------- |
-| `DEVAUDIT_BASE_URL` | Variables | The deployed DevAudit URL, e.g. `https://devaudit.metasession.co` | The hosting team |
+| `DEVAUDIT_BASE_URL` | Variables | The deployed DevAudit URL, e.g. `https://devaudit.ai` | The hosting team |
 | `DEVAUDIT_API_KEY` | Secrets | Project-scoped API key (`mc_…`) with `uploader` role | DevAudit → Project Settings → API Keys → New key |
 
 ### Project Registration

--- a/SDLC/blueprints/implementing-an-sdlc-issue.raw.md
+++ b/SDLC/blueprints/implementing-an-sdlc-issue.raw.md
@@ -175,7 +175,7 @@ Goal: every test result + report + screenshot lands on the portal under REQ-XXX 
      --git-sha "$(git rev-parse HEAD)" --branch "$(git rev-parse --abbrev-ref HEAD)"
    ```
    Repeat per evidence type (`screenshot`, `test_report`, `audit_log`, `compliance_document`, `manual_upload`).
-4. **Verify uploads** at `https://devaudit.metasession.co/projects/<slug>/requirements/REQ-XXX`. Every entry should render.
+4. **Verify uploads** at `https://devaudit.ai/projects/<slug>/requirements/REQ-XXX`. Every entry should render.
 5. **Update `compliance/RTM.md`** with the portal links for each evidence row.
 
 CI also uploads evidence automatically on `develop` push (via the `ci.yml.template` workflow synced from DevAudit-Installer). Manual stage 3 uploads from your laptop are a belt-and-braces complement, mostly useful when you want to attach evidence the automated workflow doesn't produce (manual sign-off PDFs, threat models, etc.).
@@ -193,7 +193,7 @@ Goal: PR open against `main` with all gates green and the UAT approval requested
    - Four-eyes attestation (HIGH/CRITICAL only)
    - Rollback plan (HIGH/CRITICAL only)
 3. **Add labels** — `awaiting-uat-review` is the canonical "ready for human review" signal. Add `risk:HIGH` or `risk:CRITICAL` where applicable so reviewers can prioritise.
-4. **Wait for UAT approval on the portal.** Reviewer opens `https://devaudit.metasession.co/projects/<slug>/releases/<version>` and clicks Approve (or Request Changes). The `DevAudit Release Approval` check unblocks once approval is granted.
+4. **Wait for UAT approval on the portal.** Reviewer opens `https://devaudit.ai/projects/<slug>/releases/<version>` and clicks Approve (or Request Changes). The `DevAudit Release Approval` check unblocks once approval is granted.
 
 If a reviewer asks for changes:
 
@@ -207,7 +207,7 @@ Goal: PR merged → production deploys → smoke evidence captured → release m
 
 1. **Merge** the PR via `gh pr merge --merge` (preserves audit trail per the SDLC merge-commit convention). Branch protection blocks `--squash` and `--rebase` on SDLC repos.
 2. **Watch the deploy** — `gh run watch` against the `post-deploy-prod.yml` workflow. ~3–5 minutes typically.
-3. **Verify production smoke evidence uploaded.** The post-deploy workflow runs production smoke tests and pushes evidence with `--environment production`. Confirm at `https://devaudit.metasession.co/projects/<slug>/releases/<version>`.
+3. **Verify production smoke evidence uploaded.** The post-deploy workflow runs production smoke tests and pushes evidence with `--environment production`. Confirm at `https://devaudit.ai/projects/<slug>/releases/<version>`.
 4. **Mark the release as Released** on the portal once production smoke is green.
 
 If production smoke fails:
@@ -291,7 +291,7 @@ Compile evidence for REQ-{REQ_ID} per SDLC stage 3 (compile-evidence):
    evidence-type is one of: screenshot, e2e_result, test_report, audit_log,
    compliance_document, manual_upload.
 4. Verify uploads landed at
-   https://devaudit.metasession.co/projects/{PROJECT_SLUG}/requirements/REQ-{REQ_ID}
+   https://devaudit.ai/projects/{PROJECT_SLUG}/requirements/REQ-{REQ_ID}
 5. Update compliance/RTM.md with portal links per evidence row.
 ```
 
@@ -306,7 +306,7 @@ Open the PR for REQ-{REQ_ID} per SDLC stage 4 (submit-for-review):
      - "Closes #{ISSUE_NUMBER}"
      - "REQ: REQ-{REQ_ID}"
      - "Risk: {RISK_CLASS}"
-     - "Evidence: https://devaudit.metasession.co/projects/{PROJECT_SLUG}/requirements/REQ-{REQ_ID}"
+     - "Evidence: https://devaudit.ai/projects/{PROJECT_SLUG}/requirements/REQ-{REQ_ID}"
      - For HIGH/CRITICAL: "Four-eyes attestation: <reviewer-username>" and
        "Rollback plan: <ref to plan §rollback>"
 3. Add labels: `awaiting-uat-review`, `risk:{RISK_CLASS}`.
@@ -328,7 +328,7 @@ Merge REQ-{REQ_ID} per SDLC stage 5 (deploy-main), then track to production:
    never --rebase).
 3. Watch `gh run watch` against the post-deploy-prod.yml workflow.
 4. Verify production smoke evidence uploaded (environment=production) at
-   https://devaudit.metasession.co/projects/{PROJECT_SLUG}/releases/{VERSION}
+   https://devaudit.ai/projects/{PROJECT_SLUG}/releases/{VERSION}
 5. Mark the release as `Released` on the portal.
 
 If production smoke FAILS:
@@ -416,7 +416,7 @@ The sample prompts in this doc are a stopgap that lets us run the SDLC manually 
 | ---------------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `devaudit push` returns 401                          | Token expired or wrong account                   | `devaudit auth status` → `devaudit auth login` if needed                                                                                                   |
 | `devaudit push` returns 403                          | Project key missing or wrong                     | Verify `DEVAUDIT_API_KEY` is set; re-issue from the portal `/settings/api-keys` if rotated                                                                 |
-| `gh pr checks` shows `DevAudit Release Approval` red | UAT review not granted or release not registered | Visit `https://devaudit.metasession.co/projects/<slug>/releases/<version>` → request approval; if release missing, `ci.yml` registers it on `develop` push |
+| `gh pr checks` shows `DevAudit Release Approval` red | UAT review not granted or release not registered | Visit `https://devaudit.ai/projects/<slug>/releases/<version>` → request approval; if release missing, `ci.yml` registers it on `develop` push |
 | Production smoke flaky on the same test repeatedly   | Test flake, not a real defect                    | File the flake as a separate issue tagged `flaky-test`; do NOT mark the release failed                                                                     |
 | Forgot to add `Ref: REQ-XXX` to commits              | RTM traceability gap                             | Amend the commit (if local) or add a follow-up commit with the trailer; CI's compliance-validation workflow will flag it on PR                             |
 | Stage 1 plan deviates significantly mid-stage-2      | Implementation discovered a gap in the plan      | Update the plan IN PLACE; note the deviation in a new `## Plan deviation` section. The plan is the source of truth, not a one-shot artefact                |

--- a/SDLC/joining-an-existing-project.md
+++ b/SDLC/joining-an-existing-project.md
@@ -8,7 +8,7 @@ You're the second (or nth) developer joining a project that's already been DevAu
 
 ```bash
 npm install -g @metasession.co/devaudit-cli            # one-time, all projects
-# Issue a personal PAT at https://devaudit.metasession.co/settings/tokens
+# Issue a personal PAT at https://devaudit.ai/settings/tokens
 devaudit auth login                                    # paste mctok_…
 gh auth login                                          # if not already
 devaudit doctor                                        # node ≥22, git, gh, jq, curl
@@ -81,7 +81,7 @@ The `npx @metasession.co/devaudit-cli@latest` invocation always pulls the latest
 
 ### 2. Issue + paste a personal access token
 
-Visit `https://devaudit.metasession.co/settings/tokens`, create a token (it starts with `mctok_`), then:
+Visit `https://devaudit.ai/settings/tokens`, create a token (it starts with `mctok_`), then:
 
 ```bash
 devaudit auth login
@@ -93,7 +93,7 @@ Verify:
 ```bash
 devaudit auth status
 #   token source: ~/.config/devaudit/auth.json
-#   portal:       https://devaudit.metasession.co
+#   portal:       https://devaudit.ai
 #   accessible projects: <slug>, <slug>, …
 ```
 


### PR DESCRIPTION
## Summary
- Runs `npx @metasession.co/devaudit-cli update` to sync CI workflows, SDLC blueprints/templates, and skills from 0.3.40 to 1.2.0.
- Housekeeping only — no application code (`app/`, `lib/`, `services/`) touched. 16 files changed, all under `.github/workflows/`, `SDLC/`, and `.claude/skills/`.

Closes #673

## Test plan
- [x] `npm run lint` — 0 errors (984 pre-existing warnings, unrelated)
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 1381 passed, 4 skipped
- [x] E2E gate skipped — no UI-facing files in this change
- [x] `npm audit --audit-level=high` — 2 pre-existing vulnerabilities (brace-expansion, dompurify), unrelated to this sync
- [ ] semgrep — not available in this environment; change touches no application code so risk is low

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01917hDiGzcaCVfqMpem2zBG