### PR TITLE
compliance: [REQ-100] add ai-use-note.md + ai-prompts.md

### DIFF
--- a/compliance/evidence/REQ-100/ai-prompts.md
+++ b/compliance/evidence/REQ-100/ai-prompts.md
@@ -1,0 +1,20 @@
+# REQ-100 — AI prompts log
+
+**Date:** 2026-08-27
+
+## Session prompts (user → AI)
+
+1. User investigation request against the UAT environment: "why is the kitchen showing total sales of 25,000 but the total kitchen category sales is actually 32,200 and all orders have been marked as paid" — this predates REQ-100 itself; the root cause was identified during that session and captured as GitHub issue #672, later split into standalone bugs #676 (this REQ) and #677.
+2. `invoke sdlc-implementer on #676` — with the pre-investigated root cause and fix approach supplied directly (see the issue body and the invocation args), since the debugging work had already happened in the prior session.
+
+## Internal AI prompts (orchestrator → sub-skills)
+
+- `requirements-aligner` — "Align SRS for REQ-100 ... Populate the SRS-ID column for each AC against docs/SRS.md, proposing a new REQ-AREA-NNN stub if nothing existing covers the by-main-category report's revenue/cost aggregation semantics." Returned a match against existing `REQ-MENUMGT-006` with drift (the item names this function as its source but never documented the multi-price behaviour) rather than a new stub.
+- `adr-author` — "Assess ADR-worthiness for REQ-100 ... Single file touched, no new dependency, no new database/cache/queue, no new external service, no pattern change spanning more than one file." Returned no-ADR verdict.
+- `risk-register-keeper` — "Draft risk-register entries (if any) for REQ-100 ... Read-only reporting function, no auth/RBAC change, no new write path, no new data exposure." Returned one entry: R-023, covering the unaudited-elsewhere gap rather than deferring outright.
+
+## Decision points
+
+- Kept `price`/`costPerUnit` on the output as quantity-weighted averages (derived from the now-correct summed total) rather than removing them from the type, so no consumer (the report UI) needed to change — only the number now displayed is correct.
+- Preferred each order line's own `subtotal` field over recomputing `price × quantity`, since `subtotal` is the schema's authoritative persisted charge — falls back to `price × quantity` only for the existing test fixtures, which predate `subtotal` being set on mocked items.
+- Opened risk R-023 rather than deferring, because the same accumulation bug pattern in sibling functions (`generateDailyReport`, `generateReportForDateRange`) is a genuinely unverified, specific, follow-up-able concern — not a speculative risk.

--- a/compliance/evidence/REQ-100/ai-use-note.md
+++ b/compliance/evidence/REQ-100/ai-use-note.md
@@ -1,0 +1,30 @@
+# REQ-100 — AI use note
+
+**Date:** 2026-08-27
+**Tool:** Claude Code (Sonnet 5) via `sdlc-implementer` orchestration.
+
+## What the AI did
+
+- Investigated the root cause during a prior UAT debugging session against live `wawagardenbar_uat` data (not part of this REQ's own scope): found `FinancialReportService.generateMainCategoryReport()` accumulated `quantity` per `menuItemId` but froze `price`/`costPerUnit` at whichever order line was seen first, under/over-counting any item sold at more than one price within a reporting window.
+- Ran Phase 0 triage on issue [#676](https://github.com/metasession-dev/wawagardenbar-app/issues/676) (a bug report split from #672), classified it as tracked/fix/MEDIUM per the issue's own declared risk class.
+- Authored the implementation plan, then invoked `requirements-aligner` (traced all 3 ACs to an existing SRS item, `REQ-MENUMGT-006` — a "match + drift" case: the item already named this exact function as its source but never documented the multi-price summation semantics, which is why the bug shipped undocumented; added a canonical Given/When/Then line rather than a stub), `adr-author` (no ADR needed — single-file arithmetic fix, no new dependency/db/service/pattern change), and `risk-register-keeper` (opened R-023 — the identical accumulation pattern is unaudited in `generateDailyReport`/`generateReportForDateRange`) as sub-skills — none authored inline.
+- MEDIUM risk auto-continued through the Phase 1 plan-approval checkpoint (no HIGH/CRITICAL pause).
+- Implemented the fix: the per-`menuItemId` map entry now accumulates `revenue`/`cost` fields per order line (preferring each line's own `subtotal`) instead of a single stored `price`/`costPerUnit` recomputed against total quantity at the end. Output `price`/`costPerUnit` become quantity-weighted averages for display only — `total` is always the authoritative summed figure, matching the existing output type contract exactly (no consumer/UI change needed).
+- Added one new unit test to the existing `financial-report-service.main-category.test.ts` file reproducing the exact live-UAT scenario (an item sold as both a half-portion and full-portion line); did not author any browser-driven test — no UI-facing files are touched by this REQ, so the `e2e-test-engineer` sub-skill was not invoked.
+- Discovered mid-Phase-2 that the pre-push compliance validator requires the full Stage-3 evidence pack (test-execution-summary.md, release ticket, implementation-plan.md copy) before a feature branch can even push — earlier than the generic skill instructions describe — and produced all three locally before the first successful push, rather than bypassing the hook.
+
+## Honest framing of limitations
+
+**Only `generateMainCategoryReport()` was audited and fixed.** Other per-item aggregation functions in the same file (`generateDailyReport`, `generateReportForDateRange`) were not checked for the identical pattern — this is the explicit, named gap recorded as risk-register entry R-023, not silently left undocumented.
+
+**No production/UAT re-verification was performed as part of this REQ's own automated evidence** — the plan's manual-smoke step (re-check the UAT figures that originally surfaced the bug) is called out as a post-deploy operator action, not something the AI executed here.
+
+## What the operator validated
+
+- Will validate at PR review (#678, merged) and during portal UAT review (#679, pending).
+
+## Reproducibility
+
+```bash
+npx vitest run __tests__/services/financial-report-service.main-category.test.ts
+```

--- a/compliance/evidence/REQ-100/security-summary.md
+++ b/compliance/evidence/REQ-100/security-summary.md
@@ -1,0 +1,21 @@
+# Security Evidence Summary — REQ-100
+
+**Date:** 2026-08-27
+
+| Control                                       | Result | Evidence                                                                                                                                                                                                                                                                            |
+| --------------------------------------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| SAST                                          | PASS   | `npx tsc --noEmit` — 0 errors; `npx eslint services/financial-report-service.ts __tests__/services/financial-report-service.main-category.test.ts` — 0 errors; CI Quality Gates on PR #678 also ran semgrep, passed                                                                 |
+| Dependency audit                              | PASS   | No new dependencies introduced by this REQ; `npm audit --audit-level=high` shows only pre-existing accepted exceptions (`compliance/security/accepted-vulnerabilities.json`, renewed 2026-08-26 to 2026-09-25)                                                                      |
+| RBAC — no change to authorization surface     | PASS   | `generateMainCategoryReport()` is a read-only reporting function; this REQ changes only its internal aggregation arithmetic, not the caller's existing admin/staff `mainCategoryReportAccess` permission gate (`lib/permissions.ts:getAllowedMainCategoriesForReports`, unmodified) |
+| Query construction — no injection surface     | PASS   | No query shape changed — the fix is purely in-memory `Map` accumulation logic over already-fetched order documents; no new user-controlled input reaches any database query                                                                                                         |
+| No new secrets, credentials, or external deps | PASS   | None — single-file arithmetic fix                                                                                                                                                                                                                                                   |
+
+## Data handling
+
+No new personal-data field, category, or purpose is introduced (see implementation plan §5). The fields involved (`price`, `quantity`, `subtotal`, `costPerUnit`) are order/menu financial figures, not personal data. No data subject-identifying field is read, stored, or transmitted differently by this REQ.
+
+## Post-deploy controls
+
+- No migration required — no schema change, no new field written or read that wasn't already read before.
+- Reversible via `git revert` — no data-write path is touched by this REQ, so rollback has no data implications.
+- No new secrets, credentials, or external dependencies.


### PR DESCRIPTION
## Summary
- Adds `ai-use-note.md` and `ai-prompts.md` to REQ-100's evidence pack, closing the portal's "AI Contributors" nudge (non-blocking — the compliance validator does not require these files, but this repo's convention includes them for AI-authored REQs).

Ref: REQ-100

## Test plan
- N/A — documentation only, no code change.